### PR TITLE
feat(layout): makes PF3 forms vertical

### DIFF
--- a/packages/pf3-component-mapper/src/form-fields/form-fields.js
+++ b/packages/pf3-component-mapper/src/form-fields/form-fields.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormControl, HelpBlock, Checkbox, Radio as PfRadio, Col, FormGroup } from 'patternfly-react';
+import { FormControl, HelpBlock, Checkbox, Radio as PfRadio, FormGroup, ControlLabel } from 'patternfly-react';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
 import { validationError } from './helpers';
 import MultipleChoiceList from './multiple-choice-list';
@@ -33,7 +33,7 @@ const selectComponent = ({
     <FormControl { ...input } placeholder={ placeholder } disabled={ isDisabled } readOnly={ isReadOnly } { ...rest } />,
   [componentTypes.TEXTAREA_FIELD]: () =>
     <FormControl { ...input } disabled={ isDisabled } readOnly={ isReadOnly } { ...rest } componentClass="textarea" placeholder={ placeholder }/>,
-  [componentTypes.CHECKBOX]: () => <Checkbox { ...input } disabled={ isDisabled || isReadOnly }>{ !noCheckboxLabel && label }</Checkbox>,
+  [componentTypes.CHECKBOX]: () => <Checkbox { ...input } disabled={ isDisabled || isReadOnly }>{ label }</Checkbox>,
   [componentTypes.RADIO]: () => options.map(option => (
     <FieldProvider
       key={ `${input.name}-${option.value}` }
@@ -80,20 +80,19 @@ const FinalFormField = ({
   description,
   hideLabel,
   isVisible,
+  noCheckboxLabel,
   ...rest
 }) => {
   const invalid = validationError(meta, validateOnMount);
   return (
     <FormGroup validationState={ invalid ? 'error' : null }>
-      { label &&
-          <Col md={ hideLabel ? 0 : 2 } componentClass="label" className="control-label">
-            { !hideLabel && (rest.isRequired ? <RequiredLabel label={ label } /> : label) }
-          </Col> }
-      <Col md={ !label ? 12 : 10 }>
-        { selectComponent({ ...rest, invalid, label })() }
-        { description && <HelpBlock style={{ color: '#767676' }}>{ description }</HelpBlock> }
-        { renderHelperText(invalid && meta.error, helperText) }
-      </Col>
+      { label && !hideLabel && !noCheckboxLabel &&
+          <ControlLabel>
+            { rest.isRequired ? <RequiredLabel label={ label } /> : label }
+          </ControlLabel> }
+      { selectComponent({ ...rest, invalid, label })() }
+      { description && <HelpBlock style={{ color: '#767676' }}>{ description }</HelpBlock> }
+      { renderHelperText(invalid && meta.error, helperText) }
     </FormGroup>
   );
 };

--- a/packages/pf3-component-mapper/src/form-fields/layout-components.js
+++ b/packages/pf3-component-mapper/src/form-fields/layout-components.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { layoutComponents } from '@data-driven-forms/react-form-renderer';
-import { Col, FormGroup, ButtonGroup, Icon, HelpBlock, Form } from 'patternfly-react';
+import { FormGroup, ButtonGroup, Icon, HelpBlock, Form } from 'patternfly-react';
 import Button from './button';
 
 const ArrayFieldWrapper = ({ children }) => (
@@ -13,16 +13,16 @@ const ArrayFieldWrapper = ({ children }) => (
 );
 
 const layoutMapper = {
-  [layoutComponents.FORM_WRAPPER]: ({ children, ...props }) => <Form { ...props } horizontal>{ children }</Form>,
+  [layoutComponents.FORM_WRAPPER]: ({ children, ...props }) => <Form { ...props } >{ children }</Form>,
   [layoutComponents.BUTTON]: ({ label, variant, children, ...props }) => <Button bsStyle={ variant } { ...props }>{ label || children }</Button>,
-  [layoutComponents.COL]: ({ children, xs, ...rest }) => <Col xs={ xs || 12 } key={ rest.key || rest.name }>{ children }</Col>,
+  [layoutComponents.COL]: ({ children, xs, ...rest }) => <div key={ rest.key || rest.name }>{ children }</div>,
   [layoutComponents.FORM_GROUP]: FormGroup,
   [layoutComponents.BUTTON_GROUP]: ({ children, ...props }) => <ButtonGroup className="pull-right" { ...props }>{ children }</ButtonGroup>,
   [layoutComponents.ICON]: props => <Icon { ...props } />,
   [layoutComponents.ARRAY_FIELD_WRAPPER]: ArrayFieldWrapper,
   [layoutComponents.HELP_BLOCK]: HelpBlock,
-  [layoutComponents.TITLE]: ({children}) => <h3>{children}</h3>,
-  [layoutComponents.DESCRIPTION]: ({children}) => <p>{children}</p>,
+  [layoutComponents.TITLE]: ({ children }) => <h3>{ children }</h3>,
+  [layoutComponents.DESCRIPTION]: ({ children }) => <p>{ children }</p>,
 };
 
 export default layoutMapper;

--- a/packages/pf3-component-mapper/src/form-fields/multiple-choice-list.js
+++ b/packages/pf3-component-mapper/src/form-fields/multiple-choice-list.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import RequiredLabel from './required-label';
-import { Checkbox, Col, FormGroup } from 'patternfly-react';
+import { Checkbox, Col, FormGroup, ControlLabel } from 'patternfly-react';
 import { composeValidators } from '@data-driven-forms/react-form-renderer';
 
 const MultipleChoiceList = ({ validate, FieldProvider, ...props }) => (
@@ -20,13 +20,13 @@ const MultipleChoiceList = ({ validate, FieldProvider, ...props }) => (
       const groupValues = rest.input.value;
       return (
         <FormGroup validationState={ showError ? 'error' : null }>
-          <Col md={ 2 } componentClass="label" className="control-label">
+          <ControlLabel>
             { (isRequired ? <RequiredLabel label={ label } /> : label) }
-          </Col>
-          <Col md={ 10 }>
+          </ControlLabel>
+          <div>
             { options.map(option =>
               (<FieldProvider
-                formOptions={rest.formOptions}
+                formOptions={ rest.formOptions }
                 id={ `${rest.id}-${option.value}` }
                 key={ option.value }
                 { ...option }
@@ -49,7 +49,7 @@ const MultipleChoiceList = ({ validate, FieldProvider, ...props }) => (
                   );
                 } }
               />)) }
-          </Col>
+          </div>
         </FormGroup>
       );
     } }

--- a/packages/pf3-component-mapper/src/form-fields/switch-field.js
+++ b/packages/pf3-component-mapper/src/form-fields/switch-field.js
@@ -49,33 +49,35 @@ class Switch extends React.Component {
   render() {
     const { onText, offText, disabled, isReadOnly, bsSize, ...props } = this.props;
     return (
-      <label
-        className={ `pf3-switch${disabled || isReadOnly ? ' disabled' : ''}${bsSize === 'mini' || bsSize === 'mn' ? ' mini' : ''}` }
-        style={{ width: this.state.labelWidth + DIVIDER_SIZE + COMBINED_MARGIN }}
-      >
-        <input type="checkbox" { ...props } disabled={ disabled || isReadOnly } />
-        <span className={ `pf3-switch-slider${props.checked ? ' checked' : ''}` }>
-          <span
-            className="on-text"
-            style={{
-              ...createLabelStyles(this.state.labelWidth),
-              ...createTransform(this.state.labelWidth, props.checked),
-            }}
-          >
-            { onText }
+      <div>
+        <label
+          className={ `pf3-switch${disabled || isReadOnly ? ' disabled' : ''}${bsSize === 'mini' || bsSize === 'mn' ? ' mini' : ''}` }
+          style={{ width: this.state.labelWidth + DIVIDER_SIZE + COMBINED_MARGIN }}
+        >
+          <input type="checkbox" { ...props } disabled={ disabled || isReadOnly } />
+          <span className={ `pf3-switch-slider${props.checked ? ' checked' : ''}` }>
+            <span
+              className="on-text"
+              style={{
+                ...createLabelStyles(this.state.labelWidth),
+                ...createTransform(this.state.labelWidth, props.checked),
+              }}
+            >
+              { onText }
+            </span>
+            <span className="divider" style={ createTransform(this.state.labelWidth, props.checked) }/>
+            <span
+              className="off-text"
+              style={{
+                ...createLabelStyles(this.state.labelWidth, false),
+                ...createTransform(this.state.labelWidth, props.checked, true),
+              }}
+            >
+              { offText }
+            </span>
           </span>
-          <span className="divider" style={ createTransform(this.state.labelWidth, props.checked) }/>
-          <span
-            className="off-text"
-            style={{
-              ...createLabelStyles(this.state.labelWidth, false),
-              ...createTransform(this.state.labelWidth, props.checked, true),
-            }}
-          >
-            { offText }
-          </span>
-        </span>
-      </label>
+        </label>
+      </div>
     );
   }
 }

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
@@ -41,37 +41,27 @@ exports[`FormFields <CheckboxGroup /> should render single checkbox variant 1`] 
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Checkbox
+            bsClass="checkbox"
+            disabled={false}
+            inline={false}
+            name="single-check-box"
+            title=""
           >
             <div
-              className="col-md-12"
+              className="checkbox"
             >
-              <Checkbox
-                bsClass="checkbox"
-                disabled={false}
-                inline={false}
-                name="single-check-box"
+              <label
                 title=""
               >
-                <div
-                  className="checkbox"
-                >
-                  <label
-                    title=""
-                  >
-                    <input
-                      disabled={false}
-                      name="single-check-box"
-                      type="checkbox"
-                    />
-                  </label>
-                </div>
-              </Checkbox>
+                <input
+                  disabled={false}
+                  name="single-check-box"
+                  type="checkbox"
+                />
+              </label>
             </div>
-          </Col>
+          </Checkbox>
         </div>
       </FormGroup>
     </FinalFormField>
@@ -131,76 +121,66 @@ exports[`FormFields <Radio /> should render correctly 1`] = `
       <div
         className="form-group"
       >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          md={12}
+        <MockFieldProvider
+          key="radio-1"
+          name="radio"
+          render={[Function]}
+          type="radio"
+          value={1}
         >
-          <div
-            className="col-md-12"
+          <Radio
+            bsClass="radio"
+            disabled={false}
+            inline={false}
+            onChange={[Function]}
+            title=""
           >
-            <MockFieldProvider
-              key="radio-1"
-              name="radio"
-              render={[Function]}
-              type="radio"
-              value={1}
+            <div
+              className="radio"
             >
-              <Radio
-                bsClass="radio"
-                disabled={false}
-                inline={false}
-                onChange={[Function]}
+              <label
                 title=""
               >
-                <div
-                  className="radio"
-                >
-                  <label
-                    title=""
-                  >
-                    <input
-                      disabled={false}
-                      onChange={[Function]}
-                      type="radio"
-                    />
-                    option 1
-                  </label>
-                </div>
-              </Radio>
-            </MockFieldProvider>
-            <MockFieldProvider
-              key="radio-2"
-              name="radio"
-              render={[Function]}
-              type="radio"
-              value={2}
+                <input
+                  disabled={false}
+                  onChange={[Function]}
+                  type="radio"
+                />
+                option 1
+              </label>
+            </div>
+          </Radio>
+        </MockFieldProvider>
+        <MockFieldProvider
+          key="radio-2"
+          name="radio"
+          render={[Function]}
+          type="radio"
+          value={2}
+        >
+          <Radio
+            bsClass="radio"
+            disabled={false}
+            inline={false}
+            onChange={[Function]}
+            title=""
+          >
+            <div
+              className="radio"
             >
-              <Radio
-                bsClass="radio"
-                disabled={false}
-                inline={false}
-                onChange={[Function]}
+              <label
                 title=""
               >
-                <div
-                  className="radio"
-                >
-                  <label
-                    title=""
-                  >
-                    <input
-                      disabled={false}
-                      onChange={[Function]}
-                      type="radio"
-                    />
-                    option 2
-                  </label>
-                </div>
-              </Radio>
-            </MockFieldProvider>
-          </div>
-        </Col>
+                <input
+                  disabled={false}
+                  onChange={[Function]}
+                  type="radio"
+                />
+                option 2
+              </label>
+            </div>
+          </Radio>
+        </MockFieldProvider>
       </div>
     </FormGroup>
   </FieldInterface>
@@ -268,73 +248,65 @@ exports[`FormFields <SwitchField /> should render Switch correctly 1`] = `
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            checked=""
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                checked=""
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -406,85 +378,75 @@ exports[`FormFields <SwitchField /> should render Switch with label correctly 1`
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            className="control-label"
-            componentClass="label"
-            md={2}
+          <ControlLabel
+            bsClass="control-label"
+            srOnly={false}
           >
             <label
-              className="control-label col-md-2"
+              className="control-label"
             >
               Label
             </label>
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={10}
+          </ControlLabel>
+          <Switch
+            checked=""
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-10"
-            >
-              <Switch
-                checked=""
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -556,73 +518,65 @@ exports[`FormFields <SwitchField /> should render Switch with onText (custom pro
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            checked=""
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="OnText"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                checked=""
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="OnText"
-                value=""
-              >
-                <label
-                  className="pf3-switch"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    OnText
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OnText
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -694,73 +648,65 @@ exports[`FormFields <SwitchField /> should render Switch with placeholder correc
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            checked=""
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                checked=""
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -832,75 +778,67 @@ exports[`FormFields <SwitchField /> should render disabled Switch correctly 1`] 
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            checked=""
+            disabled={true}
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                checked=""
-                disabled={true}
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch disabled"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch disabled"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  disabled={true}
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    disabled={true}
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -972,74 +910,66 @@ exports[`FormFields <SwitchField /> should render mini Switch correctly 1`] = `
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            bsSize="mini"
+            checked=""
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                bsSize="mini"
-                checked=""
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch mini"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch mini"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -1111,75 +1041,67 @@ exports[`FormFields <SwitchField /> should render readOnly Switch correctly 1`] 
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            checked=""
+            id="someIdKey"
+            isReadOnly={true}
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                checked=""
-                id="someIdKey"
-                isReadOnly={true}
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch disabled"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch disabled"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  disabled={true}
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    disabled={true}
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -1251,74 +1173,66 @@ exports[`FormFields <SwitchField /> should render sm Switch correctly 1`] = `
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={12}
+          <Switch
+            bsSize="mn"
+            checked=""
+            id="someIdKey"
+            name="Name of the field"
+            offText="OFF"
+            onChange={[Function]}
+            onText="ON"
+            value=""
           >
-            <div
-              className="col-md-12"
-            >
-              <Switch
-                bsSize="mn"
-                checked=""
-                id="someIdKey"
-                name="Name of the field"
-                offText="OFF"
-                onChange={[Function]}
-                onText="ON"
-                value=""
-              >
-                <label
-                  className="pf3-switch mini"
-                  style={
-                    Object {
-                      "width": 80,
-                    }
+            <div>
+              <label
+                className="pf3-switch mini"
+                style={
+                  Object {
+                    "width": 80,
                   }
+                }
+              >
+                <input
+                  checked=""
+                  id="someIdKey"
+                  name="Name of the field"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  className="pf3-switch-slider"
                 >
-                  <input
-                    checked=""
-                    id="someIdKey"
-                    name="Name of the field"
-                    onChange={[Function]}
-                    type="checkbox"
-                    value=""
+                  <span
+                    className="on-text"
+                    style={
+                      Object {
+                        "left": -46,
+                        "width": 46,
+                      }
+                    }
+                  >
+                    ON
+                  </span>
+                  <span
+                    className="divider"
+                    style={Object {}}
                   />
                   <span
-                    className="pf3-switch-slider"
+                    className="off-text"
+                    style={
+                      Object {
+                        "left": 34,
+                        "width": 46,
+                      }
+                    }
                   >
-                    <span
-                      className="on-text"
-                      style={
-                        Object {
-                          "left": -46,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      ON
-                    </span>
-                    <span
-                      className="divider"
-                      style={Object {}}
-                    />
-                    <span
-                      className="off-text"
-                      style={
-                        Object {
-                          "left": 34,
-                          "width": 46,
-                        }
-                      }
-                    >
-                      OFF
-                    </span>
+                    OFF
                   </span>
-                </label>
-              </Switch>
+                </span>
+              </label>
             </div>
-          </Col>
+          </Switch>
         </div>
       </FormGroup>
     </FieldInterface>
@@ -1352,28 +1266,18 @@ exports[`FormFields <TextField /> should render correctly 1`] = `
       <div
         className="form-group"
       >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          md={12}
+        <FormControl
+          bsClass="form-control"
+          componentClass="input"
+          id="text-field"
+          name="text-field"
         >
-          <div
-            className="col-md-12"
-          >
-            <FormControl
-              bsClass="form-control"
-              componentClass="input"
-              id="text-field"
-              name="text-field"
-            >
-              <input
-                className="form-control"
-                id="text-field"
-                name="text-field"
-              />
-            </FormControl>
-          </div>
-        </Col>
+          <input
+            className="form-control"
+            id="text-field"
+            name="text-field"
+          />
+        </FormControl>
       </div>
     </FormGroup>
   </FieldInterface>
@@ -1408,30 +1312,20 @@ exports[`FormFields <TextField /> should render correctly with placeholder 1`] =
       <div
         className="form-group"
       >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          md={12}
+        <FormControl
+          bsClass="form-control"
+          componentClass="input"
+          id="text-field"
+          name="text-field"
+          placeholder="placeholder"
         >
-          <div
-            className="col-md-12"
-          >
-            <FormControl
-              bsClass="form-control"
-              componentClass="input"
-              id="text-field"
-              name="text-field"
-              placeholder="placeholder"
-            >
-              <input
-                className="form-control"
-                id="text-field"
-                name="text-field"
-                placeholder="placeholder"
-              />
-            </FormControl>
-          </div>
-        </Col>
+          <input
+            className="form-control"
+            id="text-field"
+            name="text-field"
+            placeholder="placeholder"
+          />
+        </FormControl>
       </div>
     </FormGroup>
   </FieldInterface>
@@ -1464,28 +1358,18 @@ exports[`FormFields <TextareaField /> should render correctly 1`] = `
       <div
         className="form-group"
       >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          md={12}
+        <FormControl
+          bsClass="form-control"
+          componentClass="textarea"
+          id="textarea-field"
+          name="textarea-field"
         >
-          <div
-            className="col-md-12"
-          >
-            <FormControl
-              bsClass="form-control"
-              componentClass="textarea"
-              id="textarea-field"
-              name="textarea-field"
-            >
-              <textarea
-                className="form-control"
-                id="textarea-field"
-                name="textarea-field"
-              />
-            </FormControl>
-          </div>
-        </Col>
+          <textarea
+            className="form-control"
+            id="textarea-field"
+            name="textarea-field"
+          />
+        </FormControl>
       </div>
     </FormGroup>
   </FieldInterface>
@@ -1520,30 +1404,20 @@ exports[`FormFields <TextareaField /> should render correctly with placeholder 1
       <div
         className="form-group"
       >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          md={12}
+        <FormControl
+          bsClass="form-control"
+          componentClass="textarea"
+          id="textarea-field"
+          name="textarea-field"
+          placeholder="placeholder"
         >
-          <div
-            className="col-md-12"
-          >
-            <FormControl
-              bsClass="form-control"
-              componentClass="textarea"
-              id="textarea-field"
-              name="textarea-field"
-              placeholder="placeholder"
-            >
-              <textarea
-                className="form-control"
-                id="textarea-field"
-                name="textarea-field"
-                placeholder="placeholder"
-              />
-            </FormControl>
-          </div>
-        </Col>
+          <textarea
+            className="form-control"
+            id="textarea-field"
+            name="textarea-field"
+            placeholder="placeholder"
+          />
+        </FormControl>
       </div>
     </FormGroup>
   </FieldInterface>

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/multiple-choice-list.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/multiple-choice-list.test.js.snap
@@ -59,134 +59,124 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
         <div
           className="form-group"
         >
-          <Col
-            bsClass="col"
-            className="control-label"
-            componentClass="label"
-            md={2}
+          <ControlLabel
+            bsClass="control-label"
+            srOnly={false}
           >
             <label
-              className="control-label col-md-2"
+              className="control-label"
             />
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={10}
-          >
-            <div
-              className="col-md-10"
+          </ControlLabel>
+          <div>
+            <FieldProvider
+              id="undefined-0"
+              key="0"
+              label="Foo"
+              render={[Function]}
+              type="checkbox"
+              value={0}
             >
-              <FieldProvider
+              <MockFieldProvider
                 id="undefined-0"
-                key="0"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 label="Foo"
                 render={[Function]}
                 type="checkbox"
                 value={0}
               >
-                <MockFieldProvider
+                <Checkbox
+                  aria-label="Foo"
+                  bsClass="checkbox"
+                  disabled={false}
                   id="undefined-0"
-                  input={
-                    Object {
-                      "onChange": [MockFunction],
-                      "value": Array [],
-                    }
-                  }
+                  inline={false}
                   label="Foo"
-                  render={[Function]}
+                  onChange={[Function]}
+                  title=""
                   type="checkbox"
                   value={0}
                 >
-                  <Checkbox
-                    aria-label="Foo"
-                    bsClass="checkbox"
-                    disabled={false}
-                    id="undefined-0"
-                    inline={false}
-                    label="Foo"
-                    onChange={[Function]}
-                    title=""
-                    type="checkbox"
-                    value={0}
+                  <div
+                    className="checkbox"
                   >
-                    <div
-                      className="checkbox"
+                    <label
+                      title=""
                     >
-                      <label
-                        title=""
-                      >
-                        <input
-                          aria-label="Foo"
-                          disabled={false}
-                          id="undefined-0"
-                          label="Foo"
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={0}
-                        />
-                        Foo
-                      </label>
-                    </div>
-                  </Checkbox>
-                </MockFieldProvider>
-              </FieldProvider>
-              <FieldProvider
+                      <input
+                        aria-label="Foo"
+                        disabled={false}
+                        id="undefined-0"
+                        label="Foo"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={0}
+                      />
+                      Foo
+                    </label>
+                  </div>
+                </Checkbox>
+              </MockFieldProvider>
+            </FieldProvider>
+            <FieldProvider
+              id="undefined-1"
+              key="1"
+              label="Bar"
+              render={[Function]}
+              type="checkbox"
+              value={1}
+            >
+              <MockFieldProvider
                 id="undefined-1"
-                key="1"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": 1,
+                  }
+                }
                 label="Bar"
                 render={[Function]}
                 type="checkbox"
                 value={1}
               >
-                <MockFieldProvider
+                <Checkbox
+                  aria-label="Bar"
+                  bsClass="checkbox"
+                  disabled={false}
                   id="undefined-1"
-                  input={
-                    Object {
-                      "onChange": [MockFunction],
-                      "value": 1,
-                    }
-                  }
+                  inline={false}
                   label="Bar"
-                  render={[Function]}
+                  onChange={[Function]}
+                  title=""
                   type="checkbox"
                   value={1}
                 >
-                  <Checkbox
-                    aria-label="Bar"
-                    bsClass="checkbox"
-                    disabled={false}
-                    id="undefined-1"
-                    inline={false}
-                    label="Bar"
-                    onChange={[Function]}
-                    title=""
-                    type="checkbox"
-                    value={1}
+                  <div
+                    className="checkbox"
                   >
-                    <div
-                      className="checkbox"
+                    <label
+                      title=""
                     >
-                      <label
-                        title=""
-                      >
-                        <input
-                          aria-label="Bar"
-                          disabled={false}
-                          id="undefined-1"
-                          label="Bar"
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={1}
-                        />
-                        Bar
-                      </label>
-                    </div>
-                  </Checkbox>
-                </MockFieldProvider>
-              </FieldProvider>
-            </div>
-          </Col>
+                      <input
+                        aria-label="Bar"
+                        disabled={false}
+                        id="undefined-1"
+                        label="Bar"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={1}
+                      />
+                      Bar
+                    </label>
+                  </div>
+                </Checkbox>
+              </MockFieldProvider>
+            </FieldProvider>
+          </div>
         </div>
       </FormGroup>
     </MockFieldProvider>
@@ -259,146 +249,136 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
         <div
           className="form-group has-error"
         >
-          <Col
-            bsClass="col"
-            className="control-label"
-            componentClass="label"
-            md={2}
+          <ControlLabel
+            bsClass="control-label"
+            srOnly={false}
           >
             <label
-              className="control-label col-md-2"
+              className="control-label"
             />
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={10}
-          >
-            <div
-              className="col-md-10"
+          </ControlLabel>
+          <div>
+            <FieldProvider
+              id="undefined-0"
+              key="0"
+              label="Foo"
+              render={[Function]}
+              type="checkbox"
+              value={0}
             >
-              <FieldProvider
+              <MockFieldProvider
                 id="undefined-0"
-                key="0"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 label="Foo"
+                meta={
+                  Object {
+                    "error": "Error message",
+                    "touched": true,
+                  }
+                }
                 render={[Function]}
                 type="checkbox"
                 value={0}
               >
-                <MockFieldProvider
+                <Checkbox
+                  aria-label="Foo"
+                  bsClass="checkbox"
+                  disabled={false}
                   id="undefined-0"
-                  input={
-                    Object {
-                      "onChange": [MockFunction],
-                      "value": Array [],
-                    }
-                  }
+                  inline={false}
                   label="Foo"
-                  meta={
-                    Object {
-                      "error": "Error message",
-                      "touched": true,
-                    }
-                  }
-                  render={[Function]}
+                  onChange={[Function]}
+                  title=""
                   type="checkbox"
                   value={0}
                 >
-                  <Checkbox
-                    aria-label="Foo"
-                    bsClass="checkbox"
-                    disabled={false}
-                    id="undefined-0"
-                    inline={false}
-                    label="Foo"
-                    onChange={[Function]}
-                    title=""
-                    type="checkbox"
-                    value={0}
+                  <div
+                    className="checkbox"
                   >
-                    <div
-                      className="checkbox"
+                    <label
+                      title=""
                     >
-                      <label
-                        title=""
-                      >
-                        <input
-                          aria-label="Foo"
-                          disabled={false}
-                          id="undefined-0"
-                          label="Foo"
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={0}
-                        />
-                        Foo
-                      </label>
-                    </div>
-                  </Checkbox>
-                </MockFieldProvider>
-              </FieldProvider>
-              <FieldProvider
+                      <input
+                        aria-label="Foo"
+                        disabled={false}
+                        id="undefined-0"
+                        label="Foo"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={0}
+                      />
+                      Foo
+                    </label>
+                  </div>
+                </Checkbox>
+              </MockFieldProvider>
+            </FieldProvider>
+            <FieldProvider
+              id="undefined-1"
+              key="1"
+              label="Bar"
+              render={[Function]}
+              type="checkbox"
+              value={1}
+            >
+              <MockFieldProvider
                 id="undefined-1"
-                key="1"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 label="Bar"
+                meta={
+                  Object {
+                    "error": "Error message",
+                    "touched": true,
+                  }
+                }
                 render={[Function]}
                 type="checkbox"
                 value={1}
               >
-                <MockFieldProvider
+                <Checkbox
+                  aria-label="Bar"
+                  bsClass="checkbox"
+                  disabled={false}
                   id="undefined-1"
-                  input={
-                    Object {
-                      "onChange": [MockFunction],
-                      "value": Array [],
-                    }
-                  }
+                  inline={false}
                   label="Bar"
-                  meta={
-                    Object {
-                      "error": "Error message",
-                      "touched": true,
-                    }
-                  }
-                  render={[Function]}
+                  onChange={[Function]}
+                  title=""
                   type="checkbox"
                   value={1}
                 >
-                  <Checkbox
-                    aria-label="Bar"
-                    bsClass="checkbox"
-                    disabled={false}
-                    id="undefined-1"
-                    inline={false}
-                    label="Bar"
-                    onChange={[Function]}
-                    title=""
-                    type="checkbox"
-                    value={1}
+                  <div
+                    className="checkbox"
                   >
-                    <div
-                      className="checkbox"
+                    <label
+                      title=""
                     >
-                      <label
-                        title=""
-                      >
-                        <input
-                          aria-label="Bar"
-                          disabled={false}
-                          id="undefined-1"
-                          label="Bar"
-                          onChange={[Function]}
-                          type="checkbox"
-                          value={1}
-                        />
-                        Bar
-                      </label>
-                    </div>
-                  </Checkbox>
-                </MockFieldProvider>
-              </FieldProvider>
-            </div>
-          </Col>
+                      <input
+                        aria-label="Bar"
+                        disabled={false}
+                        id="undefined-1"
+                        label="Bar"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value={1}
+                      />
+                      Bar
+                    </label>
+                  </div>
+                </Checkbox>
+              </MockFieldProvider>
+            </FieldProvider>
+          </div>
         </div>
       </FormGroup>
     </MockFieldProvider>

--- a/packages/pf3-component-mapper/src/tests/form-fields/__snapshots__/select.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/form-fields/__snapshots__/select.test.js.snap
@@ -78,67 +78,188 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
       <div
         className="form-group"
       >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          md={12}
+        <Select
+          input={
+            Object {
+              "name": "select-input",
+              "onChange": [MockFunction],
+            }
+          }
+          loadOptions={
+            [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": Promise {},
+                },
+              ],
+            }
+          }
+          loadingMessage="Loading..."
+          options={
+            Array [
+              Object {
+                "label": "option 1",
+                "value": 1,
+              },
+              Object {
+                "label": "option 2",
+                "value": 2,
+              },
+            ]
+          }
+          rest={
+            Object {
+              "id": "select-input",
+              "name": "select-input",
+            }
+          }
         >
-          <div
-            className="col-md-12"
+          <StateManager
+            className="final-form-select "
+            closeMenuOnSelect={true}
+            defaultInputValue=""
+            defaultMenuIsOpen={false}
+            defaultValue={null}
+            hideSelectedOptions={false}
+            id="select-input"
+            isClearable={false}
+            isSearchable={false}
+            name="select-input"
+            noOptionsMessage={[Function]}
+            onChange={[Function]}
+            options={
+              Array [
+                Object {
+                  "label": "label",
+                },
+              ]
+            }
+            placeholder="Please choose"
+            styles={
+              Object {
+                "clearIndicator": [Function],
+                "container": [Function],
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "indicatorSeparator": [Function],
+                "indicatorsContainer": [Function],
+                "input": [Function],
+                "menu": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+                "multiValueRemove": [Function],
+                "option": [Function],
+                "placeholder": [Function],
+                "singleValue": [Function],
+              }
+            }
+            value={
+              Array [
+                Object {
+                  "label": "label",
+                },
+              ]
+            }
           >
             <Select
-              input={
-                Object {
-                  "name": "select-input",
-                  "onChange": [MockFunction],
-                }
-              }
-              loadOptions={
-                [MockFunction] {
-                  "calls": Array [
-                    Array [],
-                  ],
-                  "results": Array [
-                    Object {
-                      "isThrow": false,
-                      "value": Promise {},
-                    },
-                  ],
-                }
-              }
-              loadingMessage="Loading..."
+              backspaceRemovesValue={true}
+              blurInputOnSelect={true}
+              captureMenuScroll={false}
+              className="final-form-select "
+              closeMenuOnScroll={false}
+              closeMenuOnSelect={true}
+              components={Object {}}
+              controlShouldRenderValue={true}
+              escapeClearsValue={false}
+              filterOption={[Function]}
+              formatGroupLabel={[Function]}
+              getOptionLabel={[Function]}
+              getOptionValue={[Function]}
+              hideSelectedOptions={false}
+              id="select-input"
+              inputValue=""
+              isClearable={false}
+              isDisabled={false}
+              isLoading={false}
+              isMulti={false}
+              isOptionDisabled={[Function]}
+              isRtl={false}
+              isSearchable={false}
+              loadingMessage={[Function]}
+              maxMenuHeight={300}
+              menuIsOpen={false}
+              menuPlacement="bottom"
+              menuPosition="absolute"
+              menuShouldBlockScroll={false}
+              menuShouldScrollIntoView={true}
+              minMenuHeight={140}
+              name="select-input"
+              noOptionsMessage={[Function]}
+              onChange={[Function]}
+              onInputChange={[Function]}
+              onMenuClose={[Function]}
+              onMenuOpen={[Function]}
+              openMenuOnClick={true}
+              openMenuOnFocus={false}
               options={
                 Array [
                   Object {
-                    "label": "option 1",
-                    "value": 1,
-                  },
-                  Object {
-                    "label": "option 2",
-                    "value": 2,
+                    "label": "label",
                   },
                 ]
               }
-              rest={
+              pageSize={5}
+              placeholder="Please choose"
+              screenReaderStatus={[Function]}
+              styles={
                 Object {
-                  "id": "select-input",
-                  "name": "select-input",
+                  "clearIndicator": [Function],
+                  "container": [Function],
+                  "control": [Function],
+                  "dropdownIndicator": [Function],
+                  "indicatorSeparator": [Function],
+                  "indicatorsContainer": [Function],
+                  "input": [Function],
+                  "menu": [Function],
+                  "multiValue": [Function],
+                  "multiValueLabel": [Function],
+                  "multiValueRemove": [Function],
+                  "option": [Function],
+                  "placeholder": [Function],
+                  "singleValue": [Function],
                 }
               }
+              tabIndex="0"
+              tabSelectsValue={true}
+              value={
+                Array [
+                  Object {
+                    "label": "label",
+                  },
+                ]
+              }
             >
-              <StateManager
+              <SelectContainer
                 className="final-form-select "
-                closeMenuOnSelect={true}
-                defaultInputValue=""
-                defaultMenuIsOpen={false}
-                defaultValue={null}
-                hideSelectedOptions={false}
-                id="select-input"
-                isClearable={false}
-                isSearchable={false}
-                name="select-input"
-                noOptionsMessage={[Function]}
-                onChange={[Function]}
+                clearValue={[Function]}
+                cx={[Function]}
+                getStyles={[Function]}
+                getValue={[Function]}
+                hasValue={true}
+                innerProps={
+                  Object {
+                    "id": "select-input",
+                    "onKeyDown": [Function],
+                  }
+                }
+                isDisabled={false}
+                isFocused={false}
+                isMulti={false}
+                isRtl={false}
                 options={
                   Array [
                     Object {
@@ -146,85 +267,57 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
                     },
                   ]
                 }
-                placeholder="Please choose"
-                styles={
+                selectOption={[Function]}
+                selectProps={
                   Object {
-                    "clearIndicator": [Function],
-                    "container": [Function],
-                    "control": [Function],
-                    "dropdownIndicator": [Function],
-                    "indicatorSeparator": [Function],
-                    "indicatorsContainer": [Function],
-                    "input": [Function],
-                    "menu": [Function],
-                    "multiValue": [Function],
-                    "multiValueLabel": [Function],
-                    "multiValueRemove": [Function],
-                    "option": [Function],
-                    "placeholder": [Function],
-                    "singleValue": [Function],
-                  }
-                }
-                value={
-                  Array [
-                    Object {
-                      "label": "label",
-                    },
-                  ]
-                }
-              >
-                <Select
-                  backspaceRemovesValue={true}
-                  blurInputOnSelect={true}
-                  captureMenuScroll={false}
-                  className="final-form-select "
-                  closeMenuOnScroll={false}
-                  closeMenuOnSelect={true}
-                  components={Object {}}
-                  controlShouldRenderValue={true}
-                  escapeClearsValue={false}
-                  filterOption={[Function]}
-                  formatGroupLabel={[Function]}
-                  getOptionLabel={[Function]}
-                  getOptionValue={[Function]}
-                  hideSelectedOptions={false}
-                  id="select-input"
-                  inputValue=""
-                  isClearable={false}
-                  isDisabled={false}
-                  isLoading={false}
-                  isMulti={false}
-                  isOptionDisabled={[Function]}
-                  isRtl={false}
-                  isSearchable={false}
-                  loadingMessage={[Function]}
-                  maxMenuHeight={300}
-                  menuIsOpen={false}
-                  menuPlacement="bottom"
-                  menuPosition="absolute"
-                  menuShouldBlockScroll={false}
-                  menuShouldScrollIntoView={true}
-                  minMenuHeight={140}
-                  name="select-input"
-                  noOptionsMessage={[Function]}
-                  onChange={[Function]}
-                  onInputChange={[Function]}
-                  onMenuClose={[Function]}
-                  onMenuOpen={[Function]}
-                  openMenuOnClick={true}
-                  openMenuOnFocus={false}
-                  options={
-                    Array [
+                    "backspaceRemovesValue": true,
+                    "blurInputOnSelect": true,
+                    "captureMenuScroll": false,
+                    "className": "final-form-select ",
+                    "closeMenuOnScroll": false,
+                    "closeMenuOnSelect": true,
+                    "components": Object {},
+                    "controlShouldRenderValue": true,
+                    "escapeClearsValue": false,
+                    "filterOption": [Function],
+                    "formatGroupLabel": [Function],
+                    "getOptionLabel": [Function],
+                    "getOptionValue": [Function],
+                    "hideSelectedOptions": false,
+                    "id": "select-input",
+                    "inputValue": "",
+                    "isClearable": false,
+                    "isDisabled": false,
+                    "isLoading": false,
+                    "isMulti": false,
+                    "isOptionDisabled": [Function],
+                    "isRtl": false,
+                    "isSearchable": false,
+                    "loadingMessage": [Function],
+                    "maxMenuHeight": 300,
+                    "menuIsOpen": false,
+                    "menuPlacement": "bottom",
+                    "menuPosition": "absolute",
+                    "menuShouldBlockScroll": false,
+                    "menuShouldScrollIntoView": true,
+                    "minMenuHeight": 140,
+                    "name": "select-input",
+                    "noOptionsMessage": [Function],
+                    "onChange": [Function],
+                    "onInputChange": [Function],
+                    "onMenuClose": [Function],
+                    "onMenuOpen": [Function],
+                    "openMenuOnClick": true,
+                    "openMenuOnFocus": false,
+                    "options": Array [
                       Object {
                         "label": "label",
                       },
-                    ]
-                  }
-                  pageSize={5}
-                  placeholder="Please choose"
-                  screenReaderStatus={[Function]}
-                  styles={
-                    Object {
+                    ],
+                    "pageSize": 5,
+                    "placeholder": "Please choose",
+                    "screenReaderStatus": [Function],
+                    "styles": Object {
                       "clearIndicator": [Function],
                       "container": [Function],
                       "control": [Function],
@@ -239,20 +332,53 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
                       "option": [Function],
                       "placeholder": [Function],
                       "singleValue": [Function],
-                    }
-                  }
-                  tabIndex="0"
-                  tabSelectsValue={true}
-                  value={
-                    Array [
+                    },
+                    "tabIndex": "0",
+                    "tabSelectsValue": true,
+                    "value": Array [
                       Object {
                         "label": "label",
                       },
-                    ]
+                    ],
                   }
+                }
+                setValue={[Function]}
+                theme={
+                  Object {
+                    "borderRadius": 4,
+                    "colors": Object {
+                      "danger": "#DE350B",
+                      "dangerLight": "#FFBDAD",
+                      "neutral0": "hsl(0, 0%, 100%)",
+                      "neutral10": "hsl(0, 0%, 90%)",
+                      "neutral20": "hsl(0, 0%, 80%)",
+                      "neutral30": "hsl(0, 0%, 70%)",
+                      "neutral40": "hsl(0, 0%, 60%)",
+                      "neutral5": "hsl(0, 0%, 95%)",
+                      "neutral50": "hsl(0, 0%, 50%)",
+                      "neutral60": "hsl(0, 0%, 40%)",
+                      "neutral70": "hsl(0, 0%, 30%)",
+                      "neutral80": "hsl(0, 0%, 20%)",
+                      "neutral90": "hsl(0, 0%, 10%)",
+                      "primary": "#2684FF",
+                      "primary25": "#DEEBFF",
+                      "primary50": "#B2D4FF",
+                      "primary75": "#4C9AFF",
+                    },
+                    "spacing": Object {
+                      "baseUnit": 4,
+                      "controlHeight": 38,
+                      "menuGutter": 8,
+                    },
+                  }
+                }
+              >
+                <div
+                  className="css-ftyz56-container final-form-select"
+                  id="select-input"
+                  onKeyDown={[Function]}
                 >
-                  <SelectContainer
-                    className="final-form-select "
+                  <Control
                     clearValue={[Function]}
                     cx={[Function]}
                     getStyles={[Function]}
@@ -260,14 +386,16 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
                     hasValue={true}
                     innerProps={
                       Object {
-                        "id": "select-input",
-                        "onKeyDown": [Function],
+                        "onMouseDown": [Function],
+                        "onTouchEnd": [Function],
                       }
                     }
+                    innerRef={[Function]}
                     isDisabled={false}
                     isFocused={false}
                     isMulti={false}
                     isRtl={false}
+                    menuIsOpen={false}
                     options={
                       Array [
                         Object {
@@ -382,28 +510,19 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
                     }
                   >
                     <div
-                      className="css-196sad2 final-form-select"
-                      id="select-input"
-                      onKeyDown={[Function]}
+                      className="css-10nhwt3-control"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
-                      <Control
+                      <ValueContainer
                         clearValue={[Function]}
                         cx={[Function]}
                         getStyles={[Function]}
                         getValue={[Function]}
                         hasValue={true}
-                        innerProps={
-                          Object {
-                            "onMouseDown": [Function],
-                            "onTouchEnd": [Function],
-                          }
-                        }
-                        innerRef={[Function]}
                         isDisabled={false}
-                        isFocused={false}
                         isMulti={false}
                         isRtl={false}
-                        menuIsOpen={false}
                         options={
                           Array [
                             Object {
@@ -518,13 +637,16 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
                         }
                       >
                         <div
-                          className="css-19z4khe"
-                          onMouseDown={[Function]}
-                          onTouchEnd={[Function]}
+                          className="css-1hwfws3"
                         >
-                          <ValueContainer
+                          <SingleValue
                             clearValue={[Function]}
                             cx={[Function]}
+                            data={
+                              Object {
+                                "label": "label",
+                              }
+                            }
                             getStyles={[Function]}
                             getValue={[Function]}
                             hasValue={true}
@@ -645,589 +767,457 @@ exports[`<SelectField /> should mount Async correctly 1`] = `
                             }
                           >
                             <div
-                              className="css-1hwfws3"
+                              className="css-z11soc-singleValue"
                             >
-                              <SingleValue
-                                clearValue={[Function]}
-                                cx={[Function]}
-                                data={
-                                  Object {
-                                    "label": "label",
-                                  }
-                                }
-                                getStyles={[Function]}
-                                getValue={[Function]}
-                                hasValue={true}
-                                isDisabled={false}
-                                isMulti={false}
-                                isRtl={false}
-                                options={
-                                  Array [
-                                    Object {
-                                      "label": "label",
-                                    },
-                                  ]
-                                }
-                                selectOption={[Function]}
-                                selectProps={
-                                  Object {
-                                    "backspaceRemovesValue": true,
-                                    "blurInputOnSelect": true,
-                                    "captureMenuScroll": false,
-                                    "className": "final-form-select ",
-                                    "closeMenuOnScroll": false,
-                                    "closeMenuOnSelect": true,
-                                    "components": Object {},
-                                    "controlShouldRenderValue": true,
-                                    "escapeClearsValue": false,
-                                    "filterOption": [Function],
-                                    "formatGroupLabel": [Function],
-                                    "getOptionLabel": [Function],
-                                    "getOptionValue": [Function],
-                                    "hideSelectedOptions": false,
-                                    "id": "select-input",
-                                    "inputValue": "",
-                                    "isClearable": false,
-                                    "isDisabled": false,
-                                    "isLoading": false,
-                                    "isMulti": false,
-                                    "isOptionDisabled": [Function],
-                                    "isRtl": false,
-                                    "isSearchable": false,
-                                    "loadingMessage": [Function],
-                                    "maxMenuHeight": 300,
-                                    "menuIsOpen": false,
-                                    "menuPlacement": "bottom",
-                                    "menuPosition": "absolute",
-                                    "menuShouldBlockScroll": false,
-                                    "menuShouldScrollIntoView": true,
-                                    "minMenuHeight": 140,
-                                    "name": "select-input",
-                                    "noOptionsMessage": [Function],
-                                    "onChange": [Function],
-                                    "onInputChange": [Function],
-                                    "onMenuClose": [Function],
-                                    "onMenuOpen": [Function],
-                                    "openMenuOnClick": true,
-                                    "openMenuOnFocus": false,
-                                    "options": Array [
-                                      Object {
-                                        "label": "label",
-                                      },
-                                    ],
-                                    "pageSize": 5,
-                                    "placeholder": "Please choose",
-                                    "screenReaderStatus": [Function],
-                                    "styles": Object {
-                                      "clearIndicator": [Function],
-                                      "container": [Function],
-                                      "control": [Function],
-                                      "dropdownIndicator": [Function],
-                                      "indicatorSeparator": [Function],
-                                      "indicatorsContainer": [Function],
-                                      "input": [Function],
-                                      "menu": [Function],
-                                      "multiValue": [Function],
-                                      "multiValueLabel": [Function],
-                                      "multiValueRemove": [Function],
-                                      "option": [Function],
-                                      "placeholder": [Function],
-                                      "singleValue": [Function],
-                                    },
-                                    "tabIndex": "0",
-                                    "tabSelectsValue": true,
-                                    "value": Array [
-                                      Object {
-                                        "label": "label",
-                                      },
-                                    ],
-                                  }
-                                }
-                                setValue={[Function]}
-                                theme={
-                                  Object {
-                                    "borderRadius": 4,
-                                    "colors": Object {
-                                      "danger": "#DE350B",
-                                      "dangerLight": "#FFBDAD",
-                                      "neutral0": "hsl(0, 0%, 100%)",
-                                      "neutral10": "hsl(0, 0%, 90%)",
-                                      "neutral20": "hsl(0, 0%, 80%)",
-                                      "neutral30": "hsl(0, 0%, 70%)",
-                                      "neutral40": "hsl(0, 0%, 60%)",
-                                      "neutral5": "hsl(0, 0%, 95%)",
-                                      "neutral50": "hsl(0, 0%, 50%)",
-                                      "neutral60": "hsl(0, 0%, 40%)",
-                                      "neutral70": "hsl(0, 0%, 30%)",
-                                      "neutral80": "hsl(0, 0%, 20%)",
-                                      "neutral90": "hsl(0, 0%, 10%)",
-                                      "primary": "#2684FF",
-                                      "primary25": "#DEEBFF",
-                                      "primary50": "#B2D4FF",
-                                      "primary75": "#4C9AFF",
-                                    },
-                                    "spacing": Object {
-                                      "baseUnit": 4,
-                                      "controlHeight": 38,
-                                      "menuGutter": 8,
-                                    },
-                                  }
-                                }
-                              >
-                                <div
-                                  className="css-1rg84oi"
-                                >
-                                  label
-                                </div>
-                              </SingleValue>
-                              <DummyInput
-                                disabled={false}
-                                id="react-select-3-input"
-                                innerRef={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                readOnly={true}
-                                tabIndex="0"
-                                value=""
-                              >
-                                <input
-                                  className="css-14uuagi"
-                                  disabled={false}
-                                  id="react-select-3-input"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  readOnly={true}
-                                  tabIndex="0"
-                                  value=""
-                                />
-                              </DummyInput>
+                              label
                             </div>
-                          </ValueContainer>
-                          <IndicatorsContainer
-                            clearValue={[Function]}
-                            cx={[Function]}
-                            getStyles={[Function]}
-                            getValue={[Function]}
-                            hasValue={true}
-                            isDisabled={false}
-                            isMulti={false}
-                            isRtl={false}
-                            options={
-                              Array [
-                                Object {
-                                  "label": "label",
-                                },
-                              ]
-                            }
-                            selectOption={[Function]}
-                            selectProps={
-                              Object {
-                                "backspaceRemovesValue": true,
-                                "blurInputOnSelect": true,
-                                "captureMenuScroll": false,
-                                "className": "final-form-select ",
-                                "closeMenuOnScroll": false,
-                                "closeMenuOnSelect": true,
-                                "components": Object {},
-                                "controlShouldRenderValue": true,
-                                "escapeClearsValue": false,
-                                "filterOption": [Function],
-                                "formatGroupLabel": [Function],
-                                "getOptionLabel": [Function],
-                                "getOptionValue": [Function],
-                                "hideSelectedOptions": false,
-                                "id": "select-input",
-                                "inputValue": "",
-                                "isClearable": false,
-                                "isDisabled": false,
-                                "isLoading": false,
-                                "isMulti": false,
-                                "isOptionDisabled": [Function],
-                                "isRtl": false,
-                                "isSearchable": false,
-                                "loadingMessage": [Function],
-                                "maxMenuHeight": 300,
-                                "menuIsOpen": false,
-                                "menuPlacement": "bottom",
-                                "menuPosition": "absolute",
-                                "menuShouldBlockScroll": false,
-                                "menuShouldScrollIntoView": true,
-                                "minMenuHeight": 140,
-                                "name": "select-input",
-                                "noOptionsMessage": [Function],
-                                "onChange": [Function],
-                                "onInputChange": [Function],
-                                "onMenuClose": [Function],
-                                "onMenuOpen": [Function],
-                                "openMenuOnClick": true,
-                                "openMenuOnFocus": false,
-                                "options": Array [
-                                  Object {
-                                    "label": "label",
-                                  },
-                                ],
-                                "pageSize": 5,
-                                "placeholder": "Please choose",
-                                "screenReaderStatus": [Function],
-                                "styles": Object {
-                                  "clearIndicator": [Function],
-                                  "container": [Function],
-                                  "control": [Function],
-                                  "dropdownIndicator": [Function],
-                                  "indicatorSeparator": [Function],
-                                  "indicatorsContainer": [Function],
-                                  "input": [Function],
-                                  "menu": [Function],
-                                  "multiValue": [Function],
-                                  "multiValueLabel": [Function],
-                                  "multiValueRemove": [Function],
-                                  "option": [Function],
-                                  "placeholder": [Function],
-                                  "singleValue": [Function],
-                                },
-                                "tabIndex": "0",
-                                "tabSelectsValue": true,
-                                "value": Array [
-                                  Object {
-                                    "label": "label",
-                                  },
-                                ],
-                              }
-                            }
-                            setValue={[Function]}
-                            theme={
-                              Object {
-                                "borderRadius": 4,
-                                "colors": Object {
-                                  "danger": "#DE350B",
-                                  "dangerLight": "#FFBDAD",
-                                  "neutral0": "hsl(0, 0%, 100%)",
-                                  "neutral10": "hsl(0, 0%, 90%)",
-                                  "neutral20": "hsl(0, 0%, 80%)",
-                                  "neutral30": "hsl(0, 0%, 70%)",
-                                  "neutral40": "hsl(0, 0%, 60%)",
-                                  "neutral5": "hsl(0, 0%, 95%)",
-                                  "neutral50": "hsl(0, 0%, 50%)",
-                                  "neutral60": "hsl(0, 0%, 40%)",
-                                  "neutral70": "hsl(0, 0%, 30%)",
-                                  "neutral80": "hsl(0, 0%, 20%)",
-                                  "neutral90": "hsl(0, 0%, 10%)",
-                                  "primary": "#2684FF",
-                                  "primary25": "#DEEBFF",
-                                  "primary50": "#B2D4FF",
-                                  "primary75": "#4C9AFF",
-                                },
-                                "spacing": Object {
-                                  "baseUnit": 4,
-                                  "controlHeight": 38,
-                                  "menuGutter": 8,
-                                },
-                              }
-                            }
+                          </SingleValue>
+                          <DummyInput
+                            disabled={false}
+                            id="react-select-3-input"
+                            innerRef={[Function]}
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            readOnly={true}
+                            tabIndex="0"
+                            value=""
                           >
-                            <div
-                              className="css-smfh9a"
-                            >
-                              <IndicatorSeparator
-                                clearValue={[Function]}
-                                cx={[Function]}
-                                getStyles={[Function]}
-                                getValue={[Function]}
-                                hasValue={true}
-                                isDisabled={false}
-                                isFocused={false}
-                                isMulti={false}
-                                isRtl={false}
-                                options={
-                                  Array [
-                                    Object {
-                                      "label": "label",
-                                    },
-                                  ]
-                                }
-                                selectOption={[Function]}
-                                selectProps={
-                                  Object {
-                                    "backspaceRemovesValue": true,
-                                    "blurInputOnSelect": true,
-                                    "captureMenuScroll": false,
-                                    "className": "final-form-select ",
-                                    "closeMenuOnScroll": false,
-                                    "closeMenuOnSelect": true,
-                                    "components": Object {},
-                                    "controlShouldRenderValue": true,
-                                    "escapeClearsValue": false,
-                                    "filterOption": [Function],
-                                    "formatGroupLabel": [Function],
-                                    "getOptionLabel": [Function],
-                                    "getOptionValue": [Function],
-                                    "hideSelectedOptions": false,
-                                    "id": "select-input",
-                                    "inputValue": "",
-                                    "isClearable": false,
-                                    "isDisabled": false,
-                                    "isLoading": false,
-                                    "isMulti": false,
-                                    "isOptionDisabled": [Function],
-                                    "isRtl": false,
-                                    "isSearchable": false,
-                                    "loadingMessage": [Function],
-                                    "maxMenuHeight": 300,
-                                    "menuIsOpen": false,
-                                    "menuPlacement": "bottom",
-                                    "menuPosition": "absolute",
-                                    "menuShouldBlockScroll": false,
-                                    "menuShouldScrollIntoView": true,
-                                    "minMenuHeight": 140,
-                                    "name": "select-input",
-                                    "noOptionsMessage": [Function],
-                                    "onChange": [Function],
-                                    "onInputChange": [Function],
-                                    "onMenuClose": [Function],
-                                    "onMenuOpen": [Function],
-                                    "openMenuOnClick": true,
-                                    "openMenuOnFocus": false,
-                                    "options": Array [
-                                      Object {
-                                        "label": "label",
-                                      },
-                                    ],
-                                    "pageSize": 5,
-                                    "placeholder": "Please choose",
-                                    "screenReaderStatus": [Function],
-                                    "styles": Object {
-                                      "clearIndicator": [Function],
-                                      "container": [Function],
-                                      "control": [Function],
-                                      "dropdownIndicator": [Function],
-                                      "indicatorSeparator": [Function],
-                                      "indicatorsContainer": [Function],
-                                      "input": [Function],
-                                      "menu": [Function],
-                                      "multiValue": [Function],
-                                      "multiValueLabel": [Function],
-                                      "multiValueRemove": [Function],
-                                      "option": [Function],
-                                      "placeholder": [Function],
-                                      "singleValue": [Function],
-                                    },
-                                    "tabIndex": "0",
-                                    "tabSelectsValue": true,
-                                    "value": Array [
-                                      Object {
-                                        "label": "label",
-                                      },
-                                    ],
-                                  }
-                                }
-                                setValue={[Function]}
-                                theme={
-                                  Object {
-                                    "borderRadius": 4,
-                                    "colors": Object {
-                                      "danger": "#DE350B",
-                                      "dangerLight": "#FFBDAD",
-                                      "neutral0": "hsl(0, 0%, 100%)",
-                                      "neutral10": "hsl(0, 0%, 90%)",
-                                      "neutral20": "hsl(0, 0%, 80%)",
-                                      "neutral30": "hsl(0, 0%, 70%)",
-                                      "neutral40": "hsl(0, 0%, 60%)",
-                                      "neutral5": "hsl(0, 0%, 95%)",
-                                      "neutral50": "hsl(0, 0%, 50%)",
-                                      "neutral60": "hsl(0, 0%, 40%)",
-                                      "neutral70": "hsl(0, 0%, 30%)",
-                                      "neutral80": "hsl(0, 0%, 20%)",
-                                      "neutral90": "hsl(0, 0%, 10%)",
-                                      "primary": "#2684FF",
-                                      "primary25": "#DEEBFF",
-                                      "primary50": "#B2D4FF",
-                                      "primary75": "#4C9AFF",
-                                    },
-                                    "spacing": Object {
-                                      "baseUnit": 4,
-                                      "controlHeight": 38,
-                                      "menuGutter": 8,
-                                    },
-                                  }
-                                }
-                              >
-                                <span
-                                  className="css-1hyfx7x"
-                                />
-                              </IndicatorSeparator>
-                              <DropdownIndicator
-                                clearValue={[Function]}
-                                cx={[Function]}
-                                getStyles={[Function]}
-                                getValue={[Function]}
-                                hasValue={true}
-                                innerProps={
-                                  Object {
-                                    "aria-hidden": "true",
-                                    "onMouseDown": [Function],
-                                    "onTouchEnd": [Function],
-                                  }
-                                }
-                                isDisabled={false}
-                                isFocused={false}
-                                isMulti={false}
-                                isRtl={false}
-                                options={
-                                  Array [
-                                    Object {
-                                      "label": "label",
-                                    },
-                                  ]
-                                }
-                                selectOption={[Function]}
-                                selectProps={
-                                  Object {
-                                    "backspaceRemovesValue": true,
-                                    "blurInputOnSelect": true,
-                                    "captureMenuScroll": false,
-                                    "className": "final-form-select ",
-                                    "closeMenuOnScroll": false,
-                                    "closeMenuOnSelect": true,
-                                    "components": Object {},
-                                    "controlShouldRenderValue": true,
-                                    "escapeClearsValue": false,
-                                    "filterOption": [Function],
-                                    "formatGroupLabel": [Function],
-                                    "getOptionLabel": [Function],
-                                    "getOptionValue": [Function],
-                                    "hideSelectedOptions": false,
-                                    "id": "select-input",
-                                    "inputValue": "",
-                                    "isClearable": false,
-                                    "isDisabled": false,
-                                    "isLoading": false,
-                                    "isMulti": false,
-                                    "isOptionDisabled": [Function],
-                                    "isRtl": false,
-                                    "isSearchable": false,
-                                    "loadingMessage": [Function],
-                                    "maxMenuHeight": 300,
-                                    "menuIsOpen": false,
-                                    "menuPlacement": "bottom",
-                                    "menuPosition": "absolute",
-                                    "menuShouldBlockScroll": false,
-                                    "menuShouldScrollIntoView": true,
-                                    "minMenuHeight": 140,
-                                    "name": "select-input",
-                                    "noOptionsMessage": [Function],
-                                    "onChange": [Function],
-                                    "onInputChange": [Function],
-                                    "onMenuClose": [Function],
-                                    "onMenuOpen": [Function],
-                                    "openMenuOnClick": true,
-                                    "openMenuOnFocus": false,
-                                    "options": Array [
-                                      Object {
-                                        "label": "label",
-                                      },
-                                    ],
-                                    "pageSize": 5,
-                                    "placeholder": "Please choose",
-                                    "screenReaderStatus": [Function],
-                                    "styles": Object {
-                                      "clearIndicator": [Function],
-                                      "container": [Function],
-                                      "control": [Function],
-                                      "dropdownIndicator": [Function],
-                                      "indicatorSeparator": [Function],
-                                      "indicatorsContainer": [Function],
-                                      "input": [Function],
-                                      "menu": [Function],
-                                      "multiValue": [Function],
-                                      "multiValueLabel": [Function],
-                                      "multiValueRemove": [Function],
-                                      "option": [Function],
-                                      "placeholder": [Function],
-                                      "singleValue": [Function],
-                                    },
-                                    "tabIndex": "0",
-                                    "tabSelectsValue": true,
-                                    "value": Array [
-                                      Object {
-                                        "label": "label",
-                                      },
-                                    ],
-                                  }
-                                }
-                                setValue={[Function]}
-                                theme={
-                                  Object {
-                                    "borderRadius": 4,
-                                    "colors": Object {
-                                      "danger": "#DE350B",
-                                      "dangerLight": "#FFBDAD",
-                                      "neutral0": "hsl(0, 0%, 100%)",
-                                      "neutral10": "hsl(0, 0%, 90%)",
-                                      "neutral20": "hsl(0, 0%, 80%)",
-                                      "neutral30": "hsl(0, 0%, 70%)",
-                                      "neutral40": "hsl(0, 0%, 60%)",
-                                      "neutral5": "hsl(0, 0%, 95%)",
-                                      "neutral50": "hsl(0, 0%, 50%)",
-                                      "neutral60": "hsl(0, 0%, 40%)",
-                                      "neutral70": "hsl(0, 0%, 30%)",
-                                      "neutral80": "hsl(0, 0%, 20%)",
-                                      "neutral90": "hsl(0, 0%, 10%)",
-                                      "primary": "#2684FF",
-                                      "primary25": "#DEEBFF",
-                                      "primary50": "#B2D4FF",
-                                      "primary75": "#4C9AFF",
-                                    },
-                                    "spacing": Object {
-                                      "baseUnit": 4,
-                                      "controlHeight": 38,
-                                      "menuGutter": 8,
-                                    },
-                                  }
-                                }
-                              >
-                                <div
-                                  aria-hidden="true"
-                                  className="css-awp46l"
-                                  onMouseDown={[Function]}
-                                  onTouchEnd={[Function]}
-                                >
-                                  <DownChevron>
-                                    <Svg
-                                      size={20}
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        className="css-19bqh2r"
-                                        focusable="false"
-                                        height={20}
-                                        viewBox="0 0 20 20"
-                                        width={20}
-                                      >
-                                        <path
-                                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                                        />
-                                      </svg>
-                                    </Svg>
-                                  </DownChevron>
-                                </div>
-                              </DropdownIndicator>
-                            </div>
-                          </IndicatorsContainer>
+                            <input
+                              className="css-gj7qu5-dummyInput"
+                              disabled={false}
+                              id="react-select-3-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              readOnly={true}
+                              tabIndex="0"
+                              value=""
+                            />
+                          </DummyInput>
                         </div>
-                      </Control>
-                      <input
-                        name="select-input"
-                        type="hidden"
-                      />
+                      </ValueContainer>
+                      <IndicatorsContainer
+                        clearValue={[Function]}
+                        cx={[Function]}
+                        getStyles={[Function]}
+                        getValue={[Function]}
+                        hasValue={true}
+                        isDisabled={false}
+                        isMulti={false}
+                        isRtl={false}
+                        options={
+                          Array [
+                            Object {
+                              "label": "label",
+                            },
+                          ]
+                        }
+                        selectOption={[Function]}
+                        selectProps={
+                          Object {
+                            "backspaceRemovesValue": true,
+                            "blurInputOnSelect": true,
+                            "captureMenuScroll": false,
+                            "className": "final-form-select ",
+                            "closeMenuOnScroll": false,
+                            "closeMenuOnSelect": true,
+                            "components": Object {},
+                            "controlShouldRenderValue": true,
+                            "escapeClearsValue": false,
+                            "filterOption": [Function],
+                            "formatGroupLabel": [Function],
+                            "getOptionLabel": [Function],
+                            "getOptionValue": [Function],
+                            "hideSelectedOptions": false,
+                            "id": "select-input",
+                            "inputValue": "",
+                            "isClearable": false,
+                            "isDisabled": false,
+                            "isLoading": false,
+                            "isMulti": false,
+                            "isOptionDisabled": [Function],
+                            "isRtl": false,
+                            "isSearchable": false,
+                            "loadingMessage": [Function],
+                            "maxMenuHeight": 300,
+                            "menuIsOpen": false,
+                            "menuPlacement": "bottom",
+                            "menuPosition": "absolute",
+                            "menuShouldBlockScroll": false,
+                            "menuShouldScrollIntoView": true,
+                            "minMenuHeight": 140,
+                            "name": "select-input",
+                            "noOptionsMessage": [Function],
+                            "onChange": [Function],
+                            "onInputChange": [Function],
+                            "onMenuClose": [Function],
+                            "onMenuOpen": [Function],
+                            "openMenuOnClick": true,
+                            "openMenuOnFocus": false,
+                            "options": Array [
+                              Object {
+                                "label": "label",
+                              },
+                            ],
+                            "pageSize": 5,
+                            "placeholder": "Please choose",
+                            "screenReaderStatus": [Function],
+                            "styles": Object {
+                              "clearIndicator": [Function],
+                              "container": [Function],
+                              "control": [Function],
+                              "dropdownIndicator": [Function],
+                              "indicatorSeparator": [Function],
+                              "indicatorsContainer": [Function],
+                              "input": [Function],
+                              "menu": [Function],
+                              "multiValue": [Function],
+                              "multiValueLabel": [Function],
+                              "multiValueRemove": [Function],
+                              "option": [Function],
+                              "placeholder": [Function],
+                              "singleValue": [Function],
+                            },
+                            "tabIndex": "0",
+                            "tabSelectsValue": true,
+                            "value": Array [
+                              Object {
+                                "label": "label",
+                              },
+                            ],
+                          }
+                        }
+                        setValue={[Function]}
+                        theme={
+                          Object {
+                            "borderRadius": 4,
+                            "colors": Object {
+                              "danger": "#DE350B",
+                              "dangerLight": "#FFBDAD",
+                              "neutral0": "hsl(0, 0%, 100%)",
+                              "neutral10": "hsl(0, 0%, 90%)",
+                              "neutral20": "hsl(0, 0%, 80%)",
+                              "neutral30": "hsl(0, 0%, 70%)",
+                              "neutral40": "hsl(0, 0%, 60%)",
+                              "neutral5": "hsl(0, 0%, 95%)",
+                              "neutral50": "hsl(0, 0%, 50%)",
+                              "neutral60": "hsl(0, 0%, 40%)",
+                              "neutral70": "hsl(0, 0%, 30%)",
+                              "neutral80": "hsl(0, 0%, 20%)",
+                              "neutral90": "hsl(0, 0%, 10%)",
+                              "primary": "#2684FF",
+                              "primary25": "#DEEBFF",
+                              "primary50": "#B2D4FF",
+                              "primary75": "#4C9AFF",
+                            },
+                            "spacing": Object {
+                              "baseUnit": 4,
+                              "controlHeight": 38,
+                              "menuGutter": 8,
+                            },
+                          }
+                        }
+                      >
+                        <div
+                          className="css-smfh9a"
+                        >
+                          <IndicatorSeparator
+                            clearValue={[Function]}
+                            cx={[Function]}
+                            getStyles={[Function]}
+                            getValue={[Function]}
+                            hasValue={true}
+                            isDisabled={false}
+                            isFocused={false}
+                            isMulti={false}
+                            isRtl={false}
+                            options={
+                              Array [
+                                Object {
+                                  "label": "label",
+                                },
+                              ]
+                            }
+                            selectOption={[Function]}
+                            selectProps={
+                              Object {
+                                "backspaceRemovesValue": true,
+                                "blurInputOnSelect": true,
+                                "captureMenuScroll": false,
+                                "className": "final-form-select ",
+                                "closeMenuOnScroll": false,
+                                "closeMenuOnSelect": true,
+                                "components": Object {},
+                                "controlShouldRenderValue": true,
+                                "escapeClearsValue": false,
+                                "filterOption": [Function],
+                                "formatGroupLabel": [Function],
+                                "getOptionLabel": [Function],
+                                "getOptionValue": [Function],
+                                "hideSelectedOptions": false,
+                                "id": "select-input",
+                                "inputValue": "",
+                                "isClearable": false,
+                                "isDisabled": false,
+                                "isLoading": false,
+                                "isMulti": false,
+                                "isOptionDisabled": [Function],
+                                "isRtl": false,
+                                "isSearchable": false,
+                                "loadingMessage": [Function],
+                                "maxMenuHeight": 300,
+                                "menuIsOpen": false,
+                                "menuPlacement": "bottom",
+                                "menuPosition": "absolute",
+                                "menuShouldBlockScroll": false,
+                                "menuShouldScrollIntoView": true,
+                                "minMenuHeight": 140,
+                                "name": "select-input",
+                                "noOptionsMessage": [Function],
+                                "onChange": [Function],
+                                "onInputChange": [Function],
+                                "onMenuClose": [Function],
+                                "onMenuOpen": [Function],
+                                "openMenuOnClick": true,
+                                "openMenuOnFocus": false,
+                                "options": Array [
+                                  Object {
+                                    "label": "label",
+                                  },
+                                ],
+                                "pageSize": 5,
+                                "placeholder": "Please choose",
+                                "screenReaderStatus": [Function],
+                                "styles": Object {
+                                  "clearIndicator": [Function],
+                                  "container": [Function],
+                                  "control": [Function],
+                                  "dropdownIndicator": [Function],
+                                  "indicatorSeparator": [Function],
+                                  "indicatorsContainer": [Function],
+                                  "input": [Function],
+                                  "menu": [Function],
+                                  "multiValue": [Function],
+                                  "multiValueLabel": [Function],
+                                  "multiValueRemove": [Function],
+                                  "option": [Function],
+                                  "placeholder": [Function],
+                                  "singleValue": [Function],
+                                },
+                                "tabIndex": "0",
+                                "tabSelectsValue": true,
+                                "value": Array [
+                                  Object {
+                                    "label": "label",
+                                  },
+                                ],
+                              }
+                            }
+                            setValue={[Function]}
+                            theme={
+                              Object {
+                                "borderRadius": 4,
+                                "colors": Object {
+                                  "danger": "#DE350B",
+                                  "dangerLight": "#FFBDAD",
+                                  "neutral0": "hsl(0, 0%, 100%)",
+                                  "neutral10": "hsl(0, 0%, 90%)",
+                                  "neutral20": "hsl(0, 0%, 80%)",
+                                  "neutral30": "hsl(0, 0%, 70%)",
+                                  "neutral40": "hsl(0, 0%, 60%)",
+                                  "neutral5": "hsl(0, 0%, 95%)",
+                                  "neutral50": "hsl(0, 0%, 50%)",
+                                  "neutral60": "hsl(0, 0%, 40%)",
+                                  "neutral70": "hsl(0, 0%, 30%)",
+                                  "neutral80": "hsl(0, 0%, 20%)",
+                                  "neutral90": "hsl(0, 0%, 10%)",
+                                  "primary": "#2684FF",
+                                  "primary25": "#DEEBFF",
+                                  "primary50": "#B2D4FF",
+                                  "primary75": "#4C9AFF",
+                                },
+                                "spacing": Object {
+                                  "baseUnit": 4,
+                                  "controlHeight": 38,
+                                  "menuGutter": 8,
+                                },
+                              }
+                            }
+                          >
+                            <span
+                              className="css-1hyfx7x"
+                            />
+                          </IndicatorSeparator>
+                          <DropdownIndicator
+                            clearValue={[Function]}
+                            cx={[Function]}
+                            getStyles={[Function]}
+                            getValue={[Function]}
+                            hasValue={true}
+                            innerProps={
+                              Object {
+                                "aria-hidden": "true",
+                                "onMouseDown": [Function],
+                                "onTouchEnd": [Function],
+                              }
+                            }
+                            isDisabled={false}
+                            isFocused={false}
+                            isMulti={false}
+                            isRtl={false}
+                            options={
+                              Array [
+                                Object {
+                                  "label": "label",
+                                },
+                              ]
+                            }
+                            selectOption={[Function]}
+                            selectProps={
+                              Object {
+                                "backspaceRemovesValue": true,
+                                "blurInputOnSelect": true,
+                                "captureMenuScroll": false,
+                                "className": "final-form-select ",
+                                "closeMenuOnScroll": false,
+                                "closeMenuOnSelect": true,
+                                "components": Object {},
+                                "controlShouldRenderValue": true,
+                                "escapeClearsValue": false,
+                                "filterOption": [Function],
+                                "formatGroupLabel": [Function],
+                                "getOptionLabel": [Function],
+                                "getOptionValue": [Function],
+                                "hideSelectedOptions": false,
+                                "id": "select-input",
+                                "inputValue": "",
+                                "isClearable": false,
+                                "isDisabled": false,
+                                "isLoading": false,
+                                "isMulti": false,
+                                "isOptionDisabled": [Function],
+                                "isRtl": false,
+                                "isSearchable": false,
+                                "loadingMessage": [Function],
+                                "maxMenuHeight": 300,
+                                "menuIsOpen": false,
+                                "menuPlacement": "bottom",
+                                "menuPosition": "absolute",
+                                "menuShouldBlockScroll": false,
+                                "menuShouldScrollIntoView": true,
+                                "minMenuHeight": 140,
+                                "name": "select-input",
+                                "noOptionsMessage": [Function],
+                                "onChange": [Function],
+                                "onInputChange": [Function],
+                                "onMenuClose": [Function],
+                                "onMenuOpen": [Function],
+                                "openMenuOnClick": true,
+                                "openMenuOnFocus": false,
+                                "options": Array [
+                                  Object {
+                                    "label": "label",
+                                  },
+                                ],
+                                "pageSize": 5,
+                                "placeholder": "Please choose",
+                                "screenReaderStatus": [Function],
+                                "styles": Object {
+                                  "clearIndicator": [Function],
+                                  "container": [Function],
+                                  "control": [Function],
+                                  "dropdownIndicator": [Function],
+                                  "indicatorSeparator": [Function],
+                                  "indicatorsContainer": [Function],
+                                  "input": [Function],
+                                  "menu": [Function],
+                                  "multiValue": [Function],
+                                  "multiValueLabel": [Function],
+                                  "multiValueRemove": [Function],
+                                  "option": [Function],
+                                  "placeholder": [Function],
+                                  "singleValue": [Function],
+                                },
+                                "tabIndex": "0",
+                                "tabSelectsValue": true,
+                                "value": Array [
+                                  Object {
+                                    "label": "label",
+                                  },
+                                ],
+                              }
+                            }
+                            setValue={[Function]}
+                            theme={
+                              Object {
+                                "borderRadius": 4,
+                                "colors": Object {
+                                  "danger": "#DE350B",
+                                  "dangerLight": "#FFBDAD",
+                                  "neutral0": "hsl(0, 0%, 100%)",
+                                  "neutral10": "hsl(0, 0%, 90%)",
+                                  "neutral20": "hsl(0, 0%, 80%)",
+                                  "neutral30": "hsl(0, 0%, 70%)",
+                                  "neutral40": "hsl(0, 0%, 60%)",
+                                  "neutral5": "hsl(0, 0%, 95%)",
+                                  "neutral50": "hsl(0, 0%, 50%)",
+                                  "neutral60": "hsl(0, 0%, 40%)",
+                                  "neutral70": "hsl(0, 0%, 30%)",
+                                  "neutral80": "hsl(0, 0%, 20%)",
+                                  "neutral90": "hsl(0, 0%, 10%)",
+                                  "primary": "#2684FF",
+                                  "primary25": "#DEEBFF",
+                                  "primary50": "#B2D4FF",
+                                  "primary75": "#4C9AFF",
+                                },
+                                "spacing": Object {
+                                  "baseUnit": 4,
+                                  "controlHeight": 38,
+                                  "menuGutter": 8,
+                                },
+                              }
+                            }
+                          >
+                            <div
+                              aria-hidden="true"
+                              className="css-gdx6yp-indicatorContainer"
+                              onMouseDown={[Function]}
+                              onTouchEnd={[Function]}
+                            >
+                              <DownChevron>
+                                <Svg
+                                  size={20}
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    className="css-19bqh2r"
+                                    focusable="false"
+                                    height={20}
+                                    viewBox="0 0 20 20"
+                                    width={20}
+                                  >
+                                    <path
+                                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                    />
+                                  </svg>
+                                </Svg>
+                              </DownChevron>
+                            </div>
+                          </DropdownIndicator>
+                        </div>
+                      </IndicatorsContainer>
                     </div>
-                  </SelectContainer>
-                </Select>
-              </StateManager>
+                  </Control>
+                  <input
+                    name="select-input"
+                    type="hidden"
+                  />
+                </div>
+              </SelectContainer>
             </Select>
-          </div>
-        </Col>
+          </StateManager>
+        </Select>
       </div>
     </FormGroup>
   </FieldInterface>

--- a/packages/pf3-component-mapper/src/tests/layout-components.test.js
+++ b/packages/pf3-component-mapper/src/tests/layout-components.test.js
@@ -1,11 +1,11 @@
 import { mount } from 'enzyme';
-import { Col, FormGroup, Button, ButtonGroup, Icon, HelpBlock, Form } from 'patternfly-react';
+import { FormGroup, Button, ButtonGroup, Icon, HelpBlock, Form } from 'patternfly-react';
 import { layoutComponents } from '@data-driven-forms/react-form-renderer';
 import layoutMapper from '../form-fields/layout-components';
 
 describe('Layout mapper', () => {
   it('should return PF3 Col', () => {
-    expect(mount(layoutMapper[layoutComponents.COL]({})).find(Col)).toHaveLength(1);
+    expect(mount(layoutMapper[layoutComponents.COL]({})).find('div')).toHaveLength(1);
   });
 
   it('should return PF3 Button', () => {

--- a/packages/pf4-component-mapper/demo/index.html
+++ b/packages/pf4-component-mapper/demo/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../node_modules/@patternfly/react-core/dist/styles/base.css"/>
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/@patternfly/patternfly@2.3.1/patternfly.css"/>
   <title>Data driven forms</title>
 </head>
 <body>

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
@@ -3,15 +3,17 @@
 exports[`Tabs component should render tabs correctly 1`] = `
 <Tabs
   activeKey={0}
+  aria-label={null}
   className=""
+  id={null}
   isFilled={false}
   isSecondary={false}
   leftScrollAriaLabel="Scroll left"
   onSelect={[Function]}
   rightScrollAriaLabel="Scroll Right"
+  variant="div"
 >
-  <Tab
-    className=""
+  <ForwardRef
     eventKey={0}
     key="cosiKey"
     title="cosiTitle"
@@ -23,9 +25,8 @@ exports[`Tabs component should render tabs correctly 1`] = `
         Here would be form
       </div>
     </div>
-  </Tab>
-  <Tab
-    className=""
+  </ForwardRef>
+  <ForwardRef
     eventKey={1}
     key="cosiKey2"
     title="cosiTitle2"
@@ -37,6 +38,6 @@ exports[`Tabs component should render tabs correctly 1`] = `
         Here would be form
       </div>
     </div>
-  </Tab>
+  </ForwardRef>
 </Tabs>
 `;

--- a/packages/pf4-component-mapper/src/tests/tabs.test.js
+++ b/packages/pf4-component-mapper/src/tests/tabs.test.js
@@ -36,7 +36,7 @@ describe('Tabs component', () => {
     const wrapper = mount(<Tabs { ...props } />);
     expect(wrapper.instance().state.activeTabKey).toEqual(0);
 
-    const secondTabButton = wrapper.find('[className="pf-c-tabs__button"]').at(1);
+    const secondTabButton = wrapper.find('.pf-c-tabs__button').at(6);
     secondTabButton.simulate('click');
 
     expect(wrapper.instance().state.activeTabKey).toEqual(1);


### PR DESCRIPTION
**Description**

Makes all form vertical by default.

* removes `COL` component 

WIP because design is not clear.


### Before


![image](https://user-images.githubusercontent.com/32869456/55800122-42fd3300-5ad3-11e9-8c75-8f19e107f12a.png)
![image](https://user-images.githubusercontent.com/32869456/55800140-4db7c800-5ad3-11e9-9436-a655079c6b3c.png)
![image](https://user-images.githubusercontent.com/32869456/55800151-54463f80-5ad3-11e9-92ed-4c52b92d3397.png)
![image](https://user-images.githubusercontent.com/32869456/55800160-58725d00-5ad3-11e9-9861-1e13450d92cc.png)


### After

![image](https://user-images.githubusercontent.com/32869456/55800174-5f996b00-5ad3-11e9-8522-f8be3d032364.png)
![image](https://user-images.githubusercontent.com/32869456/55800185-67f1a600-5ad3-11e9-99fb-6ee212f07fb3.png)
![image](https://user-images.githubusercontent.com/32869456/55800199-6de78700-5ad3-11e9-84c6-83f1f32a69f6.png)
![image](https://user-images.githubusercontent.com/32869456/55800212-7475fe80-5ad3-11e9-9c11-653ee966508e.png)

@terezanovotna How should switch/checkboxes/radios look in a vertical form?

cc @martinpovolny @Hyperkid123 
