### PR TITLE
Update pf4 wizard pf3 tabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 node_js:
   - "8"
 
-env:
-  global:
-    - RELEASE_DEMO=false
-
 sudo: required
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
@@ -34,7 +30,6 @@ deploy:
 - provider: surge
   on:
     branch: master
-    condition: RELEASE_DEMO = true
   project: ./packages/react-renderer-demo/public/
   domain: data-driven-forms.surge.sh 
   skip_cleanup: true

--- a/packages/pf3-component-mapper/src/form-fields/tabs.js
+++ b/packages/pf3-component-mapper/src/form-fields/tabs.js
@@ -1,21 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TabContainer, Nav, NavItem, TabContent, TabPane } from 'patternfly-react';
+import { TabContainer, Nav, NavItem, TabContent, TabPane, Icon } from 'patternfly-react';
 
-const renderTabHeader = items => items.map(({ title, key }, index) => <NavItem key={ key } eventKey={ index }>{ title }</NavItem>);
-const renderTabContet = (items, formOptions) =>
-  items.map(({ key, fields }, index) =>
-    <TabPane key={ key } eventKey={ index } >{ formOptions.renderForm(fields, formOptions) }</TabPane>
+const renderTabHeader = (items, formOptions) => items.map(({ title, key, validateFields = []}, index) => {
+  const errors = formOptions.getState().errors;
+  const hasError = validateFields.find(name => !!errors[name]);
+  return (
+    <NavItem key={ key } eventKey={ index }>
+      { hasError && <Icon style={{ marginRight: 8, color: '#CC0000' }} type="fa" name="exclamation-circle" /> }
+      { title }
+    </NavItem>
   );
+});
+const renderTabContent = (items, formOptions) =>
+  items.map(({ key, fields }, index) =>
+    <TabPane key={ key } eventKey={ index } >{ formOptions.renderForm(fields, formOptions) }</TabPane>);
 
 const FormTabs = ({ fields, formOptions }) => (
   <TabContainer id="basic-tabs-pf" defaultActiveKey={ 0 }>
     <div>
       <Nav bsClass="nav nav-tabs">
-        { renderTabHeader(fields) }
+        { renderTabHeader(fields, formOptions) }
       </Nav>
       <TabContent animation>
-        { renderTabContet(fields, formOptions) }
+        { renderTabContent(fields, formOptions) }
       </TabContent>
     </div>
   </TabContainer>

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
@@ -25,6 +25,7 @@ exports[`<FormTabs /> should render form tabs 1`] = `
   }
   formOptions={
     Object {
+      "getState": [Function],
       "renderForm": [Function],
     }
   }
@@ -222,6 +223,188 @@ exports[`<FormTabs /> should render form tabs 1`] = `
                     aria-labelledby="basic-tabs-pf-tab-1"
                     className="fade tab-pane"
                     id="basic-tabs-pf-pane-1"
+                    role="tabpanel"
+                  >
+                    <div />
+                  </div>
+                </Transition>
+              </Fade>
+            </TabPane>
+          </div>
+        </TabContent>
+      </div>
+    </TabContainer>
+  </Uncontrolled(TabContainer)>
+</FormTabs>
+`;
+
+exports[`<FormTabs /> should render form tabs with error state 1`] = `
+<FormTabs
+  fields={
+    Array [
+      Object {
+        "component": "tabs",
+        "fields": Array [
+          Object {
+            "component": "foo",
+            "name": "foo",
+          },
+        ],
+        "key": "tab1",
+        "title": "Tab 1",
+        "validateFields": Array [
+          "foo",
+        ],
+      },
+    ]
+  }
+  formOptions={
+    Object {
+      "getState": [Function],
+      "renderForm": [Function],
+    }
+  }
+>
+  <Uncontrolled(TabContainer)
+    defaultActiveKey={0}
+    id="basic-tabs-pf"
+  >
+    <TabContainer
+      activeKey={0}
+      id="basic-tabs-pf"
+      onSelect={[Function]}
+    >
+      <div
+        id="basic-tabs-pf"
+      >
+        <Nav
+          bsClass="nav nav-tabs"
+          justified={false}
+          pullLeft={false}
+          pullRight={false}
+          stacked={false}
+        >
+          <ul
+            className="nav nav-tabs"
+            role="tablist"
+          >
+            <NavItem
+              active={true}
+              activeKey={0}
+              aria-controls="basic-tabs-pf-pane-0"
+              disabled={false}
+              eventKey={0}
+              id="basic-tabs-pf-tab-0"
+              key=".$tab1"
+              onKeyDown={[Function]}
+              onSelect={[Function]}
+              role="tab"
+            >
+              <li
+                className="active"
+                role="presentation"
+              >
+                <SafeAnchor
+                  aria-controls="basic-tabs-pf-pane-0"
+                  aria-selected={true}
+                  componentClass="a"
+                  disabled={false}
+                  id="basic-tabs-pf-tab-0"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="tab"
+                >
+                  <a
+                    aria-controls="basic-tabs-pf-pane-0"
+                    aria-selected={true}
+                    href="#"
+                    id="basic-tabs-pf-tab-0"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="tab"
+                  >
+                    <Icon
+                      name="exclamation-circle"
+                      style={
+                        Object {
+                          "color": "#CC0000",
+                          "marginRight": 8,
+                        }
+                      }
+                      type="fa"
+                    >
+                      <FontAwesome
+                        name="exclamation-circle"
+                        style={
+                          Object {
+                            "color": "#CC0000",
+                            "marginRight": 8,
+                          }
+                        }
+                      >
+                        <span
+                          aria-hidden={true}
+                          className="fa fa-exclamation-circle"
+                          style={
+                            Object {
+                              "color": "#CC0000",
+                              "marginRight": 8,
+                            }
+                          }
+                        />
+                      </FontAwesome>
+                    </Icon>
+                    Tab 1
+                  </a>
+                </SafeAnchor>
+              </li>
+            </NavItem>
+          </ul>
+        </Nav>
+        <TabContent
+          animation={true}
+          bsClass="tab"
+          componentClass="div"
+          mountOnEnter={false}
+          unmountOnExit={false}
+        >
+          <div
+            className="tab-content"
+          >
+            <TabPane
+              bsClass="tab-pane"
+              eventKey={0}
+              key="tab1"
+            >
+              <Fade
+                appear={false}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onExited={[Function]}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  appear={false}
+                  enter={true}
+                  exit={true}
+                  in={true}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-hidden={false}
+                    aria-labelledby="basic-tabs-pf-tab-0"
+                    className="fade tab-pane active in"
+                    id="basic-tabs-pf-pane-0"
                     role="tabpanel"
                   >
                     <div />

--- a/packages/pf3-component-mapper/src/tests/tabs.test.js
+++ b/packages/pf3-component-mapper/src/tests/tabs.test.js
@@ -25,12 +25,39 @@ describe('<FormTabs />', () => {
       }],
       formOptions: {
         renderForm: ({ name, component }) => <div key={ name }>{ component }</div>,
+        getState: () => ({
+          errors: {},
+        }),
       },
     };
   });
 
   it('should render form tabs', () => {
     const wrapper = mount(<FormTabs { ...initialProps } />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render form tabs with error state', () => {
+    const validationSchema = {
+      ...initialProps,
+      fields: [{
+        component: componentTypes.TABS,
+        title: 'Tab 1',
+        key: 'tab1',
+        validateFields: [ 'foo' ],
+        fields: [{
+          name: 'foo',
+          component: 'foo',
+        }],
+      }],
+      formOptions: {
+        renderForm: ({ name, component }) => <div key={ name }>{ component }</div>,
+        getState: () => ({
+          errors: { foo: true },
+        }),
+      },
+    };
+    const wrapper = mount(<FormTabs { ...validationSchema } />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 

--- a/packages/pf4-component-mapper/package.json
+++ b/packages/pf4-component-mapper/package.json
@@ -45,7 +45,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "@data-driven-forms/react-form-renderer": "^1.9.3",
+    "@data-driven-forms/react-form-renderer": "*",
     "@patternfly/react-core": "^2.9.2",
     "@patternfly/react-icons": "^2.8.0",
     "@semantic-release/git": "^7.0.5",

--- a/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
@@ -7,13 +7,15 @@ const SimpleNext = ({
   valid,
   handleNext,
   submit,
+  nextLabel,
 }) => (
   <Button
     variant="primary"
     type="button"
+    isDisabled={ !valid }
     onClick={ () => valid ? handleNext(next) : submit() }
   >
-    Continue
+    { nextLabel }
   </Button>
 );
 
@@ -22,6 +24,7 @@ SimpleNext.propTypes = {
   valid: PropTypes.bool,
   handleNext: PropTypes.func.isRequired,
   submit: PropTypes.func.isRequired,
+  nextLabel: PropTypes.string.isRequired,
 };
 
 const ConditionalNext = ({
@@ -45,25 +48,38 @@ ConditionalNext.propTypes = {
   FieldProvider: PropTypes.func.isRequired,
 };
 
-const submitButton = handleSubmit => <Button type="button" variant="primary" onClick={ handleSubmit }>Submit</Button>;
+const submitButton = (handleSubmit, submitLabel) => <Button type="button" variant="primary" onClick={ handleSubmit }>{ submitLabel }</Button>;
 
-const renderNextButton = ({ nextStep, handleSubmit, ...rest }) =>
+const renderNextButton = ({ nextStep, handleSubmit, submitLabel, ...rest }) =>
   !nextStep
-    ? submitButton(handleSubmit)
+    ? submitButton(handleSubmit, submitLabel)
     : typeof nextStep === 'object'
       ? <ConditionalNext nextStep={ nextStep } { ...rest }/>
       : <SimpleNext next={ nextStep } { ...rest } />;
 
-const WizardStepButtons = ({ formOptions, disableBack, handlePrev, nextStep, FieldProvider, handleNext }) => (
-  <Toolbar className="wizard-button-toolbar">
+const WizardStepButtons = ({
+  formOptions,
+  disableBack,
+  handlePrev,
+  nextStep,
+  FieldProvider,
+  handleNext,
+  buttonsClassName,
+  buttonLabels: {
+    cancel,
+    submit,
+    back,
+    next,
+  }}) => (
+  <Toolbar className={ `wizard-button-toolbar ${buttonsClassName ? buttonsClassName : ''}` }>
     <ToolbarGroup>
       { formOptions.onCancel && (
         <ToolbarItem>
-          <Button type="button" variant="secondary" onClick={ formOptions.onCancel }>Cancel</Button>
+          <Button type="button" variant="secondary" onClick={ formOptions.onCancel }>{ cancel }</Button>
         </ToolbarItem>
       ) }
       <ToolbarItem>
-        <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>Back</Button>
+        <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
       </ToolbarItem>
       <ToolbarItem>
         { renderNextButton({
@@ -71,6 +87,8 @@ const WizardStepButtons = ({ formOptions, disableBack, handlePrev, nextStep, Fie
           handleNext,
           nextStep,
           FieldProvider,
+          nextLabel: next,
+          submitLabel: submit,
         }) }
       </ToolbarItem>
     </ToolbarGroup>
@@ -93,6 +111,13 @@ WizardStepButtons.propTypes = {
     }),
   ]),
   FieldProvider: PropTypes.func.isRequired,
+  buttonLabels: PropTypes.shape({
+    submit: PropTypes.string.isRequired,
+    cancel: PropTypes.string.isRequired,
+    back: PropTypes.string.isRequired,
+    next: PropTypes.string.isRequired,
+  }).isRequired,
+  buttonsClassName: PropTypes.string,
 };
 
 export default WizardStepButtons;

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-step.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-step.js
@@ -3,6 +3,7 @@ import {
   TextContent,
   Text,
   TextVariants,
+  Title,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import WizardStepButtons from './step-buttons';
@@ -17,9 +18,7 @@ const WizardStep = ({
   return (
     <Fragment>
       { typeof title === 'string' ? (
-        <TextContent>
-          <Text component={ TextVariants.h2 } >{ title }</Text>
-        </TextContent>
+        <Title size="2xl" >{ title }</Title>
       ) : title }
       { typeof description === 'string' ? (
         <TextContent>

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
@@ -1,8 +1,10 @@
 import React, { cloneElement, Fragment } from 'react';
+import PropTypes from 'prop-types';
 import {
   TextContent,
   Text,
   TextVariants,
+  Title,
 } from '@patternfly/react-core';
 import WizardStep from './wizard-step';
 import './wizard-styles.scss';
@@ -29,7 +31,8 @@ class Wizard extends React.Component {
   findCurrentStep = activeStep => this.props.fields.find(({ stepKey }) => stepKey === activeStep)
 
   render() {
-    const { title, description, FieldProvider, formOptions } = this.props;
+    const { title, description, FieldProvider, formOptions, buttonLabels, buttonsClassName } = this.props;
+    console.log('Foo: ', buttonsClassName)
     const handleSubmit = () =>
       formOptions.onSubmit(this.handleSubmit(formOptions.getState().values, [ ...this.state.prevSteps, this.state.activeStep ]));
 
@@ -40,15 +43,15 @@ class Wizard extends React.Component {
           ...formOptions,
           handleSubmit,
         }}
+        buttonLabels={ buttonLabels }
         FieldProvider={ FieldProvider }
+        buttonsClassName={ buttonsClassName }
       />);
 
     return (
       <Fragment>
         { typeof title === 'string' ? (
-          <TextContent>
-            <Text component={ TextVariants.h2 } >{ title }</Text>
-          </TextContent>
+          <Title size="3xl" >{ title }</Title>
         ) : title }
         { typeof description === 'string' ? (
           <TextContent>
@@ -65,6 +68,35 @@ class Wizard extends React.Component {
   }
 }
 
-const WizardFunction = props => <Wizard { ...props }/>;
+Wizard.propTypes = {
+  buttonLabels: PropTypes.shape({
+    submit: PropTypes.string.isRequired,
+    cancel: PropTypes.string.isRequired,
+    back: PropTypes.string.isRequired,
+    next: PropTypes.string.isRequired,
+  }).isRequired,
+  buttonsClassName: PropTypes.string,
+};
+
+const defaultLabels = {
+  submit: 'Submit',
+  cancel: 'Cancel',
+  back: 'Back',
+  next: 'Next',
+};
+
+const WizardFunction = ({ buttonLabels, ...props }) => <Wizard { ...props } buttonLabels={{ ...defaultLabels, ...buttonLabels }}/>;
+
+WizardFunction.propTypes = {
+  buttonLabels: PropTypes.shape({
+    submit: PropTypes.string,
+    cancel: PropTypes.string,
+    back: PropTypes.string,
+  }),
+};
+
+WizardFunction.defaultProps = {
+  buttonLabels: {},
+};
 
 export default WizardFunction;

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
@@ -32,7 +32,6 @@ class Wizard extends React.Component {
 
   render() {
     const { title, description, FieldProvider, formOptions, buttonLabels, buttonsClassName } = this.props;
-    console.log('Foo: ', buttonsClassName)
     const handleSubmit = () =>
       formOptions.onSubmit(this.handleSubmit(formOptions.getState().values, [ ...this.state.prevSteps, this.state.activeStep ]));
 

--- a/packages/react-renderer-demo/src/demo-data/wizard-schema.js
+++ b/packages/react-renderer-demo/src/demo-data/wizard-schema.js
@@ -4,7 +4,10 @@ const wizardSchema = {
   fields: [{
     component: componentTypes.WIZARD,
     name: 'wizzard',
-    assignFieldProvider: true,
+    buttonLabels: {
+      submit: 'Add new source',
+    },
+    buttonsClassName: 'Foo',
     fields: [{
       title: 'Get started with adding source',
       name: 'step-1',

--- a/packages/react-renderer-demo/src/editor-demo/common/examples-definitions.js
+++ b/packages/react-renderer-demo/src/editor-demo/common/examples-definitions.js
@@ -224,6 +224,7 @@ export const baseExamples = [{
     fields: [
       {
         component: componentTypes.TAB_ITEM,
+        validateFields: [ 'apple' ],
         key: '1',
         title: 'Fruits',
         description: 'Here you can find fruits',
@@ -233,6 +234,9 @@ export const baseExamples = [{
             label: 'Apple',
             title: 'Apple',
             component: componentTypes.TEXT_FIELD,
+            validate: [{
+              type: validatorTypes.REQUIRED,
+            }],
           },
         ],
       },

--- a/packages/react-renderer-demo/src/editor-demo/common/examples-texts/tabs.js
+++ b/packages/react-renderer-demo/src/editor-demo/common/examples-texts/tabs.js
@@ -18,4 +18,17 @@ export default ({ activeMapper }) =>
     </Typography>
     <pre>TAB_ITEM</pre> <Typography variant="body1">as an import from componentTypes</Typography>
     <pre>tab-item</pre> <Typography variant="body1">as a string</Typography>
+    { activeMapper === 'pf3' &&
+    (
+      <Fragment>
+        <Typography variant="h6" gutterBottom>
+        Validation
+        </Typography>
+        <Typography variant="body1">Because of schema flexibility there is no simple and efficient way to signal invalid tab content.</Typography>
+        <Typography variant="body1">
+          If you want to add some visual feedback for this case, please specify field names to <pre style={{ display: 'inline' }}>validateFields</pre> attribute.
+        </Typography>
+      </Fragment>
+    ) }
+
   </Fragment>;

--- a/packages/react-renderer-demo/src/editor-demo/common/examples-texts/wizard.js
+++ b/packages/react-renderer-demo/src/editor-demo/common/examples-texts/wizard.js
@@ -8,8 +8,29 @@ const text =  `This a custom component. OnSubmit will send only values from visi
 | Props  | Type  |  Decription |
 | ------------- | ------------- | ------------- |
 | stepKey  | string, number | For first step: 1, otherwise anything |
+| buttonLabels  | object  | See below  |
 | nextStep  | object/stepKey of next step | See below |
 | fields  | array | As usual |
+
+### Default buttonLabels
+
+\`\`\`jsx
+{
+  cancel: 'Cancel',
+  back: 'Back',
+  next: 'Next',
+  submit: 'Submit',
+}
+\`\`\`
+You can rewrite only selection of them, e.g.
+
+\`\`\`jsx
+{
+  submit: 'Deploy',
+}
+\`\`\`
+
+(Others will stay default)
 
 - nextStep can be stepKey of the next step
 - or you can branch the way by using of object:


### PR DESCRIPTION
### Changes
- removed demo publish condition
  - we will publish everything to demo site 
- addressed visual feedback on PF4 wizard
  - for wizard buttons customization added option to specify custom CSS class
  - added option to customize controls text
  - next button is disabled until current step is valid
  - adjusted sizes of default Wizard and Step titles
- Added visual feedback for invalid tab content for PF3 tabs
  - user can add a list of validated fields
  - no simple way to handle this by default (schema is too flexible)
![screenshot-localhost-8080-2019 04 24-17-29-10](https://user-images.githubusercontent.com/22619452/56672823-615c5480-66b7-11e9-96ea-6a7c690ebe82.png)
