### PR TITLE
fix(PF3: tabs): fixed scoped fields validation

### DIFF
--- a/packages/pf3-component-mapper/src/form-fields/tabs.js
+++ b/packages/pf3-component-mapper/src/form-fields/tabs.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import { TabContainer, Nav, NavItem, TabContent, TabPane, Icon } from 'patternfly-react';
 
 const renderTabHeader = (items, formOptions) => items.map(({ title, key, validateFields = []}, index) => {
   const errors = formOptions.getState().errors;
-  const hasError = validateFields.find(name => !!errors[name]);
+  const hasError = validateFields.find(name => !!get(errors, name));
   return (
     <NavItem key={ key } eventKey={ index }>
       { hasError && <Icon style={{ marginRight: 8, color: '#CC0000' }} type="fa" name="exclamation-circle" /> }

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
@@ -249,11 +249,16 @@ exports[`<FormTabs /> should render form tabs with error state 1`] = `
             "component": "foo",
             "name": "foo",
           },
+          Object {
+            "component": "foo",
+            "name": "nested.field",
+          },
         ],
         "key": "tab1",
         "title": "Tab 1",
         "validateFields": Array [
           "foo",
+          "nested.field",
         ],
       },
     ]

--- a/packages/pf3-component-mapper/src/tests/tabs.test.js
+++ b/packages/pf3-component-mapper/src/tests/tabs.test.js
@@ -44,16 +44,19 @@ describe('<FormTabs />', () => {
         component: componentTypes.TABS,
         title: 'Tab 1',
         key: 'tab1',
-        validateFields: [ 'foo' ],
+        validateFields: [ 'foo', 'nested.field' ],
         fields: [{
           name: 'foo',
+          component: 'foo',
+        }, {
+          name: 'nested.field',
           component: 'foo',
         }],
       }],
       formOptions: {
         renderForm: ({ name, component }) => <div key={ name }>{ component }</div>,
         getState: () => ({
-          errors: { foo: true },
+          errors: { foo: true, nested: { field: true }},
         }),
       },
     };


### PR DESCRIPTION
### Bug
When using scoped field names tabs validation was not working.
```javascript
name: 'field.nested' // in form state {field: { nested: 'value' }}
```
Before it was directly accessing `{"field.nested": "value"}`. Fixed by using lodash `get` function on object.