### PR TITLE
feat(pf4wizard): update according to PF4

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -4,7 +4,11 @@ export const wizardSchema = {
   fields: [{
     component: componentTypes.WIZARD,
     name: 'wizzard',
+    //inModal: true,
     assignFieldProvider: true,
+    title: 'Title',
+    description: 'Description',
+    buttonsPosition: 'left',
     fields: [{
       title: 'Get started with adding source',
       name: 'step-1',
@@ -43,6 +47,7 @@ export const wizardSchema = {
       title: 'Configure AWS',
       name: 'step-2',
       stepKey: 'aws',
+      substepOf: 'Summary',
       nextStep: 'summary',
       fields: [{
         component: componentTypes.TEXT_FIELD,
@@ -67,6 +72,165 @@ export const wizardSchema = {
       }],
       stepKey: 'summary',
       name: 'summary',
+      substepOf: 'Summary',
+      title: 'Summary',
+    }],
+  }],
+};
+
+export const wizardSchemaSimple = {
+  fields: [{
+    component: componentTypes.WIZARD,
+    name: 'wizzard',
+    assignFieldProvider: true,
+    title: 'Title',
+    description: 'Description',
+    buttonsPosition: 'left',
+    fields: [{
+      title: 'Get started with adding source',
+      name: 'step-1',
+      stepKey: 1,
+      nextStep: 'aws',
+      fields: [{
+        component: componentTypes.TEXTAREA_FIELD,
+        name: 'source-name',
+        type: 'text',
+        label: 'Source name',
+      }],
+    }, {
+      title: 'Configure AWS',
+      name: 'step-2',
+      stepKey: 'aws',
+      nextStep: 'summary',
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        name: 'aws-field',
+        label: 'Aws field part',
+        isRequired: true,
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+      }],
+    }, {
+      fields: [{
+        name: 'summary',
+        component: 'summary',
+        assignFieldProvider: true,
+      }],
+      stepKey: 'summary',
+      name: 'summary',
+      title: 'Summary',
+    }],
+  }],
+};
+
+export const wizardSchemaSubsteps = {
+  fields: [{
+    component: componentTypes.WIZARD,
+    name: 'wizzard',
+    assignFieldProvider: true,
+    title: 'Title',
+    description: 'Description',
+    buttonsPosition: 'left',
+    fields: [{
+      title: 'Get started with adding source',
+      name: 'step-1',
+      stepKey: 1,
+      nextStep: 'aws',
+      fields: [{
+        component: componentTypes.TEXTAREA_FIELD,
+        name: 'source-name',
+        type: 'text',
+        label: 'Source name',
+      }],
+    }, {
+      title: 'Configure AWS',
+      name: 'step-2',
+      stepKey: 'aws',
+      nextStep: 'summary',
+      substepOf: 'Summary',
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        name: 'aws-field',
+        label: 'Aws field part',
+      }],
+    }, {
+      fields: [{
+        name: 'summary',
+        component: 'summary',
+        assignFieldProvider: true,
+      }],
+      stepKey: 'summary',
+      name: 'summary',
+      title: 'Summary',
+      substepOf: 'Summary',
+    }],
+  }],
+};
+
+export const wizardSchemaMoreSubsteps = {
+  fields: [{
+    component: componentTypes.WIZARD,
+    name: 'wizzard',
+    assignFieldProvider: true,
+    title: 'Title',
+    description: 'Description',
+    buttonsPosition: 'left',
+    fields: [{
+      title: 'Get started with adding source',
+      name: 'step-1',
+      stepKey: 1,
+      nextStep: 'aws',
+      fields: [{
+        component: componentTypes.TEXTAREA_FIELD,
+        name: 'source-name',
+        type: 'text',
+        label: 'Source name',
+      }],
+    }, {
+      title: 'Configure AWS',
+      name: 'step-2',
+      stepKey: 'aws',
+      nextStep: 'aws2',
+      substepOf: 'Summary',
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        name: 'aws-field',
+        label: 'Aws field part',
+      }],
+    }, {
+      title: 'Configure AWS part 2',
+      name: 'step-88',
+      stepKey: 'aws2',
+      nextStep: 'summary',
+      substepOf: 'Summary',
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        name: 'aws-field',
+        label: 'Aws field part',
+      }],
+    },
+    {
+      fields: [{
+        name: 'summary',
+        component: 'summary',
+        assignFieldProvider: true,
+      }],
+      stepKey: 'summary',
+      name: 'summary',
+      title: 'Summary',
+      substepOf: 'Finish',
+      nextStep: 'summary2',
+    }, {
+      fields: [{
+        name: 'summary',
+        component: 'summary',
+        assignFieldProvider: true,
+      }],
+      stepKey: 'summary2',
+      name: 'summary2',
+      title: 'Summary2',
+      substepOf: 'Finish',
     }],
   }],
 };

--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -6,14 +6,14 @@ import miqSchema from './demo-schemas/miq-schema';
 import { uiArraySchema, arraySchema, schema, uiSchema, conditionalSchema } from './demo-schemas/widget-schema';
 import { formFieldsMapper, layoutMapper } from '../src';
 import { Title, Button, Toolbar, ToolbarGroup } from '@patternfly/react-core';
-import { wizardSchema } from './demo-schemas/wizard-schema';
+import { wizardSchema, wizardSchemaSimple, wizardSchemaSubsteps, wizardSchemaMoreSubsteps } from './demo-schemas/wizard-schema';
 import sandboxSchema from './demo-schemas/sandbox';
 
 const Summary = props => <div>Custom summary component.</div>;
 class App extends React.Component {
     constructor(props) {
         super(props);
-        this.state = { schema: wizardSchema, schemaString: 'default', additionalOptions: { showFormControls: false }};
+        this.state = { schema: wizardSchema, schemaString: 'default', additionalOptions: { showFormControls: false, wizard: true, }};
     }
 
     render() {
@@ -22,7 +22,7 @@ class App extends React.Component {
             <Title size="4xl">Pf4 component mapper</Title>
             <Toolbar style={{ marginBottom: 20, marginTop: 20 }}>
                 <ToolbarGroup>
-                    <Button onClick={() => this.setState(state => ({ schema: wizardSchema, schemaString: 'default', additionalOptions: { showFormControls: false } }))}>Wizard</Button>
+                    <Button onClick={() => this.setState(state => ({ schema: wizardSchema, schemaString: 'default', additionalOptions: { showFormControls: false, wizard: true } }))}>Wizard</Button>
                 </ToolbarGroup>
                 <ToolbarGroup>
                     <Button onClick={() => this.setState(state => ({ schema: arraySchema, schemaString: 'mozilla', ui: uiArraySchema, additionalOptions: {}}))}>arraySchema</Button>
@@ -53,6 +53,44 @@ class App extends React.Component {
                 uiSchema={this.state.ui}
                 {...this.state.additionalOptions}
             />
+            {this.state.additionalOptions.wizard && <>
+                <div>Substeps</div>
+                <FormRenderer
+                    onSubmit={console.log}
+                    formFieldsMapper={{
+                        ...formFieldsMapper,
+                        summary: Summary
+                    }}
+                    onCancel={() => console.log('Cancel action')}
+                    layoutMapper={layoutMapper}
+                    schema={wizardSchemaSubsteps}
+                    {...this.state.additionalOptions}
+                    />
+                <div>More substep</div>
+                <FormRenderer
+                    onSubmit={console.log}
+                    formFieldsMapper={{
+                        ...formFieldsMapper,
+                        summary: Summary
+                    }}
+                    onCancel={() => console.log('Cancel action')}
+                    layoutMapper={layoutMapper}
+                    schema={wizardSchemaMoreSubsteps}
+                    {...this.state.additionalOptions}
+                    />
+                <div>Simple wizard</div>
+                <FormRenderer
+                    onSubmit={console.log}
+                    formFieldsMapper={{
+                        ...formFieldsMapper,
+                        summary: Summary
+                    }}
+                    onCancel={() => console.log('Cancel action')}
+                    layoutMapper={layoutMapper}
+                    schema={wizardSchemaSimple}
+                    {...this.state.additionalOptions}
+                    />
+            </>}
         </div>
     </div>)
     };

--- a/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Toolbar, ToolbarGroup, ToolbarItem, Button } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 
 const SimpleNext = ({
   next,
@@ -70,30 +70,19 @@ const WizardStepButtons = ({
     submit,
     back,
     next,
-  }}) => (
-  <Toolbar className={ `wizard-button-toolbar ${buttonsClassName ? buttonsClassName : ''}` }>
-    <ToolbarGroup>
-      { formOptions.onCancel && (
-        <ToolbarItem>
-          <Button type="button" variant="secondary" onClick={ formOptions.onCancel }>{ cancel }</Button>
-        </ToolbarItem>
-      ) }
-      <ToolbarItem>
-        <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
-      </ToolbarItem>
-      <ToolbarItem>
-        { renderNextButton({
-          ...formOptions,
-          handleNext,
-          nextStep,
-          FieldProvider,
-          nextLabel: next,
-          submitLabel: submit,
-        }) }
-      </ToolbarItem>
-    </ToolbarGroup>
-  </Toolbar>
-);
+  }}) =>
+  <footer className={ `pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}` }>
+    { renderNextButton({
+      ...formOptions,
+      handleNext,
+      nextStep,
+      FieldProvider,
+      nextLabel: next,
+      submitLabel: submit,
+    }) }
+    <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
+    <Button type="button" variant="link" onClick={ formOptions.onCancel }>{ cancel }</Button>
+  </footer>;
 
 WizardStepButtons.propTypes = {
   formOptions: PropTypes.shape({

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-step.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-step.js
@@ -1,10 +1,5 @@
 import React, { Fragment } from 'react';
-import {
-  TextContent,
-  Text,
-  TextVariants,
-  Title,
-} from '@patternfly/react-core';
+import { WizardBody } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import WizardStepButtons from './step-buttons';
 
@@ -17,15 +12,11 @@ const WizardStep = ({
 }) => {
   return (
     <Fragment>
-      { typeof title === 'string' ? (
-        <Title size="2xl" >{ title }</Title>
-      ) : title }
-      { typeof description === 'string' ? (
-        <TextContent>
-          <Text component={ TextVariants.p } >{ description }</Text>
-        </TextContent>
-      ) : description }
-      { fields.map(item => formOptions.renderForm([ item ], formOptions)) }
+      <WizardBody hasBodyPadding={ true }>
+        <div className="pf-c-form">
+          { fields.map(item => formOptions.renderForm([ item ], formOptions)) }
+        </div>
+      </WizardBody>
       <WizardStepButtons
         formOptions={ formOptions }
         { ...rest }

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-styles.scss
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-styles.scss
@@ -1,10 +1,7 @@
-.wizard-button-toolbar {
+.no-shadow {
+  box-shadow: none;
+}
+
+.pull-right {
   justify-content: flex-end;
-  margin-top: 1em;
-  button {
-    margin: 0 8px;
-    &:last-child {
-      margin-right: 0;
-    }
-  }
 }

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
@@ -1,23 +1,82 @@
-import React, { cloneElement, Fragment } from 'react';
+import React, { cloneElement } from 'react';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
-import {
-  TextContent,
-  Text,
-  TextVariants,
-  Title,
-} from '@patternfly/react-core';
+import { WizardHeader, WizardNav, WizardNavItem, Backdrop, Bullseye } from '@patternfly/react-core';
 import WizardStep from './wizard-step';
 import './wizard-styles.scss';
 
+const Modal = ({ children, container, inModal }) => inModal ? createPortal(<Backdrop>
+  <Bullseye>
+    { children }
+  </Bullseye>
+</Backdrop>, container) : children;
+
 class Wizard extends React.Component {
-  state = {
-    activeStep: this.props.fields[0].stepKey,
-    prevSteps: [],
+  constructor(props){
+    super(props);
+
+    // find if wizard contains any dynamic steps (nextStep is mapper object)
+    const isDynamic = this.props.isDynamic ? true : this.props.fields.find(({ nextStep }) => typeof nextStep === 'object') ? true : false;
+
+    // insert into navigation schema first step if dynamic, otherwise create the whole schema
+    // if the wizard is dynamic, the navigation is build progressively
+    const firstStep = this.props.fields.find(({ stepKey }) => stepKey === 1 || stepKey === '1');
+
+    const navSchema = isDynamic ?
+      [{ title: firstStep.title, index: 0, primary: true, substepOf: firstStep.substepOf }]
+      : this.createSchema();
+
+    this.state = {
+      activeStep: this.props.fields[0].stepKey,
+      prevSteps: [],
+      activeStepIndex: 0,
+      maxStepIndex: 0,
+      isDynamic, // wizard contains nextStep mapper
+      navSchema, // schema of navigation
+      loading: true,
+    };
   }
 
-  handleNext = nextStep => this.setState(prevState => ({ activeStep: nextStep, prevSteps: [ ...prevState.prevSteps, prevState.activeStep ]}));
+  componentDidMount() {
+    if (this.props.inModal) {
+      this.container = document.createElement('div');
+      document.body.appendChild(this.container);
+    }
+    this.setState({loading: false});
+  }
 
-  handlePrev = () => this.setState(({ prevSteps }) => ({ activeStep: prevSteps.pop(), prevSteps: [ ...prevSteps ]}))
+  componentWillUnmount() {
+    if (this.props.inModal && this.container) {
+      document.body.removeChild(this.container);
+    }
+  }
+
+  insertDynamicStep = (nextStep, navSchema) => {
+    const { title, substepOf } = this.props.fields.find(({ stepKey }) => stepKey === nextStep);
+    const lastStep = navSchema[navSchema.length - 1];
+
+    return [
+      ...navSchema,
+      {
+        title,
+        substepOf,
+        index: lastStep.index + 1,
+        primary: (!substepOf) || (substepOf && substepOf !== lastStep.substepOf),
+      },
+    ];
+  }
+
+  handleNext = nextStep =>
+    this.setState(prevState =>
+      ({
+        activeStep: nextStep,
+        prevSteps: prevState.prevSteps.includes(prevState.activeStep) ? prevState.prevSteps : [ ...prevState.prevSteps, prevState.activeStep ],
+        activeStepIndex: prevState.activeStepIndex + 1,
+        maxStepIndex: (prevState.activeStepIndex + 1) > prevState.maxStepIndex ? prevState.maxStepIndex + 1 : prevState.maxStepIndex,
+        navSchema: this.state.isDynamic ? this.insertDynamicStep(nextStep, prevState.navSchema) : prevState.navSchema,
+      }));
+
+  handlePrev = () => this.jumpToStep(this.state.activeStepIndex - 1);
 
   findActiveFields = visitedSteps =>
     visitedSteps.map(key =>this.findCurrentStep(key).fields.map(({ name }) => name))
@@ -30,8 +89,65 @@ class Wizard extends React.Component {
 
   findCurrentStep = activeStep => this.props.fields.find(({ stepKey }) => stepKey === activeStep)
 
+  // jumping in the wizzard by clicking on nav links
+  jumpToStep = (index, valid) => {
+    if (this.state.prevSteps[index]) {
+      this.setState((prevState) =>
+        ({
+          activeStep: this.state.prevSteps[index],
+          prevSteps: prevState.prevSteps.includes(prevState.activeStep) ? prevState.prevSteps : [ ...prevState.prevSteps, prevState.activeStep ],
+          activeStepIndex: index,
+        }));
+
+      // jumping in dynamic form disables returning to back (!)
+      if (this.state.isDynamic) {
+        this.setState((prevState) => ({
+          navSchema: prevState.navSchema.slice(0, index + 1),
+          prevSteps: prevState.prevSteps.slice(0, index + 1),
+        }));
+      }
+
+      // invalid state disables jumping forward until it fixed (!)
+      if (valid === false) {
+        this.setState((prevState) => ({
+          prevSteps: prevState.prevSteps.slice(0, index + 2),
+          maxStepIndex: prevState.prevSteps.slice(0, index + 1).length,
+        }));
+      }
+    }
+  };
+
+  // builds schema used for generating of the navigation links
+  createSchema = () => {
+    let schema = [];
+    let field = this.props.fields.find(({ stepKey }) => stepKey === 1 || stepKey === '1'); // find first wizard step
+    let index = 0;
+
+    while (field){
+      schema = [
+        ...schema,
+        { title: field.title,
+          substepOf: field.substepOf,
+          index: index++,
+          primary: (!schema[schema.length - 1] || !field.substepOf || field.substepOf !== schema[schema.length - 1].substepOf) },
+      ];
+
+      field = this.props.fields.find(({ stepKey }) => stepKey === field.nextStep);
+    }
+
+    return schema;
+  };
+
   render() {
-    const { title, description, FieldProvider, formOptions, buttonLabels, buttonsClassName } = this.props;
+    if(this.state.loading) {
+      return null;
+    }
+
+    const {
+      title, description, FieldProvider, formOptions, buttonLabels, buttonsClassName, inModal, setFullWidth, setFullHeight, isCompactNav,
+    } = this.props;
+    const { activeStepIndex, navSchema, maxStepIndex } = this.state;
+
     const handleSubmit = () =>
       formOptions.onSubmit(this.handleSubmit(formOptions.getState().values, [ ...this.state.prevSteps, this.state.activeStep ]));
 
@@ -47,22 +163,57 @@ class Wizard extends React.Component {
         buttonsClassName={ buttonsClassName }
       />);
 
+    const createStepsMap = () => navSchema
+    .filter(field => field.primary)
+    .map(step => {
+      const substeps = step.substepOf && navSchema.filter(field => field.substepOf === step.substepOf);
+
+      return <WizardNavItem
+        key={ step.substepOf || step.title }
+        text={ step.substepOf || step.title }
+        isCurrent={ substeps ? activeStepIndex >= step.index && activeStepIndex < step.index + substeps.length : activeStepIndex === step.index }
+        isDisabled={ formOptions.valid ? maxStepIndex < step.index : step.index > activeStepIndex }
+        onNavItemClick={ (ind) => this.jumpToStep(ind, formOptions.valid) }
+        step={ step.index }
+      >
+        { substeps && <WizardNav returnList>
+          { substeps.map(substep => <WizardNavItem
+            key={ substep.title }
+            text={ substep.title }
+            isCurrent={ activeStepIndex === substep.index }
+            isDisabled={ formOptions.valid ?
+              maxStepIndex < substep.index
+              : substep.index > activeStepIndex }
+            onNavItemClick={ (ind) => this.jumpToStep(ind, formOptions.valid) }
+            step={ substep.index }
+          />) }
+        </WizardNav> }
+      </WizardNavItem>;
+    });
+
     return (
-      <Fragment>
-        { typeof title === 'string' ? (
-          <Title size="3xl" >{ title }</Title>
-        ) : title }
-        { typeof description === 'string' ? (
-          <TextContent>
-            <Text component={ TextVariants.p } >{ description }</Text>
-          </TextContent>
-        ) : description }
-        { cloneElement(currentStep, {
-          handleNext: this.handleNext,
-          handlePrev: this.handlePrev,
-          disableBack: this.state.prevSteps.length === 0,
-        }) }
-      </Fragment>
+      <Modal inModal={inModal} container={this.container}>
+        <div className={ `pf-c-wizard ${inModal ? '' : 'no-shadow'} ${isCompactNav ? 'pf-m-compact-nav' : ''} ${setFullWidth ? 'pf-m-full-width' : ''} ${setFullHeight ? 'pf-m-full-height' : ''}` }
+        role="dialog"
+        aria-modal={ inModal ? 'true' : undefined }
+        >
+          { title && <WizardHeader
+            title={ title }
+            description={ description }
+            onClose={ formOptions.onCancel }
+          /> }
+          <div className="pf-c-wizard__outer-wrap">
+            <WizardNav>
+              { createStepsMap() }
+            </WizardNav>
+            { cloneElement(currentStep, {
+              handleNext: this.handleNext,
+              handlePrev: this.handlePrev,
+              disableBack: this.state.activeStepIndex === 0,
+            }) }
+          </div>
+        </div>
+      </Modal>
     );
   }
 }
@@ -81,10 +232,16 @@ Wizard.propTypes = {
   formOptions: PropTypes.shape({
     getState: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    onCancel: PropTypes.func,
   }),
   fields: PropTypes.arrayOf(PropTypes.shape({
-    stepKey: PropTypes.string.isRequired,
+    stepKey: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]).isRequired,
   })).isRequired,
+  isCompactNav: PropTypes.bool,
+  inModal: PropTypes.bool,
+  setFullWidth: PropTypes.bool,
+  setFullHeight: PropTypes.bool,
+  isDynamic: PropTypes.bool,
 };
 
 const defaultLabels = {

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/step-buttons.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/step-buttons.test.js.snap
@@ -1,89 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<WizardSTepButtons should add custom className to toolbar 1`] = `
-<Toolbar
-  className="wizard-button-toolbar foo-class"
+<footer
+  className="pf-c-wizard__footer foo-class"
 >
-  <ToolbarGroup
-    className={null}
+  <Button
+    onClick={[MockFunction]}
+    type="button"
+    variant="primary"
   >
-    <ToolbarItem
-      className={null}
-    >
-      <Button
-        onClick={[MockFunction]}
-        type="button"
-        variant="secondary"
-      >
-        Cancel
-      </Button>
-    </ToolbarItem>
-    <ToolbarItem
-      className={null}
-    >
-      <Button
-        onClick={[MockFunction]}
-        type="button"
-        variant="secondary"
-      >
-        Back
-      </Button>
-    </ToolbarItem>
-    <ToolbarItem
-      className={null}
-    >
-      <Button
-        onClick={[MockFunction]}
-        type="button"
-        variant="primary"
-      >
-        Submit
-      </Button>
-    </ToolbarItem>
-  </ToolbarGroup>
-</Toolbar>
+    Submit
+  </Button>
+  <Button
+    onClick={[MockFunction]}
+    type="button"
+    variant="secondary"
+  >
+    Back
+  </Button>
+  <Button
+    onClick={[MockFunction]}
+    type="button"
+    variant="link"
+  >
+    Cancel
+  </Button>
+</footer>
 `;
 
 exports[`<WizardSTepButtons should render correctly 1`] = `
-<Toolbar
-  className="wizard-button-toolbar "
+<footer
+  className="pf-c-wizard__footer "
 >
-  <ToolbarGroup
-    className={null}
+  <Button
+    onClick={[MockFunction]}
+    type="button"
+    variant="primary"
   >
-    <ToolbarItem
-      className={null}
-    >
-      <Button
-        onClick={[MockFunction]}
-        type="button"
-        variant="secondary"
-      >
-        Cancel
-      </Button>
-    </ToolbarItem>
-    <ToolbarItem
-      className={null}
-    >
-      <Button
-        onClick={[MockFunction]}
-        type="button"
-        variant="secondary"
-      >
-        Back
-      </Button>
-    </ToolbarItem>
-    <ToolbarItem
-      className={null}
-    >
-      <Button
-        onClick={[MockFunction]}
-        type="button"
-        variant="primary"
-      >
-        Submit
-      </Button>
-    </ToolbarItem>
-  </ToolbarGroup>
-</Toolbar>
+    Submit
+  </Button>
+  <Button
+    onClick={[MockFunction]}
+    type="button"
+    variant="secondary"
+  >
+    Back
+  </Button>
+  <Button
+    onClick={[MockFunction]}
+    type="button"
+    variant="link"
+  >
+    Cancel
+  </Button>
+</footer>
 `;

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard-step.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard-step.test.js.snap
@@ -2,23 +2,19 @@
 
 exports[`<WizardStep /> should render correctly 1`] = `
 <Fragment>
-  <Title
-    size="2xl"
+  <WizardBody
+    hasBodyPadding={true}
   >
-    title
-  </Title>
-  <TextContent>
-    <Text
-      component="p"
+    <div
+      className="pf-c-form"
     >
-      description
-    </Text>
-  </TextContent>
-  <div
-    key="foo"
-  >
-    foo
-  </div>
+      <div
+        key="foo"
+      >
+        foo
+      </div>
+    </div>
+  </WizardBody>
   <WizardStepButtons
     FieldProvider={[Function]}
     buttonLabels={
@@ -44,19 +40,19 @@ exports[`<WizardStep /> should render correctly 1`] = `
 
 exports[`<WizardStep /> should render custom description 1`] = `
 <Fragment>
-  <Title
-    size="2xl"
+  <WizardBody
+    hasBodyPadding={true}
   >
-    title
-  </Title>
-  <div>
-    description
-  </div>
-  <div
-    key="foo"
-  >
-    foo
-  </div>
+    <div
+      className="pf-c-form"
+    >
+      <div
+        key="foo"
+      >
+        foo
+      </div>
+    </div>
+  </WizardBody>
   <WizardStepButtons
     FieldProvider={[Function]}
     buttonLabels={
@@ -82,21 +78,19 @@ exports[`<WizardStep /> should render custom description 1`] = `
 
 exports[`<WizardStep /> should render custom title 1`] = `
 <Fragment>
-  <div>
-    title
-  </div>
-  <TextContent>
-    <Text
-      component="p"
-    >
-      description
-    </Text>
-  </TextContent>
-  <div
-    key="foo"
+  <WizardBody
+    hasBodyPadding={true}
   >
-    foo
-  </div>
+    <div
+      className="pf-c-form"
+    >
+      <div
+        key="foo"
+      >
+        foo
+      </div>
+    </div>
+  </WizardBody>
   <WizardStepButtons
     FieldProvider={[Function]}
     buttonLabels={

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Wizard /> should render correctly 1`] = `
+exports[`<Wizard /> should render correctly and unmount 1`] = `
 <WizardFunction
   FieldProvider={[Function]}
   buttonLabels={Object {}}
@@ -58,183 +58,784 @@ exports[`<Wizard /> should render correctly 1`] = `
     }
     title="Wizard"
   >
-    <Title
-      size="3xl"
-    >
-      <h1
-        className="pf-c-title pf-m-3xl"
-      >
-        Wizard
-      </h1>
-    </Title>
-    <TextContent>
+    <Modal>
       <div
-        className="pf-c-content"
+        className="pf-c-wizard no-shadow   "
+        role="dialog"
       >
-        <Text
-          component="p"
-        >
-          <p
-            className=""
-            data-pf-content={true}
-          >
-            wizard description
-          </p>
-        </Text>
-      </div>
-    </TextContent>
-    <WizardStep
-      FieldProvider={[Function]}
-      buttonLabels={
-        Object {
-          "back": "Back",
-          "cancel": "Cancel",
-          "next": "Next",
-          "submit": "Submit",
-        }
-      }
-      disableBack={true}
-      fields={Array []}
-      formOptions={
-        Object {
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "onCancel": [MockFunction],
-          "onSubmit": [MockFunction],
-          "renderForm": [Function],
-          "submit": [MockFunction],
-          "valid": true,
-        }
-      }
-      handleNext={[Function]}
-      handlePrev={[Function]}
-      name="foo"
-      stepKey="1"
-    >
-      <WizardStepButtons
-        FieldProvider={[Function]}
-        buttonLabels={
-          Object {
-            "back": "Back",
-            "cancel": "Cancel",
-            "next": "Next",
-            "submit": "Submit",
-          }
-        }
-        disableBack={true}
-        formOptions={
-          Object {
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "onCancel": [MockFunction],
-            "onSubmit": [MockFunction],
-            "renderForm": [Function],
-            "submit": [MockFunction],
-            "valid": true,
-          }
-        }
-        handleNext={[Function]}
-        handlePrev={[Function]}
-        name="foo"
-        stepKey="1"
-      >
-        <Toolbar
-          className="wizard-button-toolbar "
+        <WizardHeader
+          description="wizard description"
+          onClose={[MockFunction]}
+          title="Wizard"
         >
           <div
-            className="pf-l-toolbar wizard-button-toolbar "
+            className="pf-c-wizard__header"
           >
-            <ToolbarGroup
-              className={null}
+            <Button
+              className="pf-c-wizard__close"
+              onClick={[MockFunction]}
+              variant="plain"
+            >
+              <button
+                aria-disabled={null}
+                aria-label={null}
+                className="pf-c-button pf-m-plain pf-c-wizard__close"
+                disabled={false}
+                onClick={[MockFunction]}
+                tabIndex={null}
+                type="button"
+              >
+                <TimesIcon
+                  aria-hidden="true"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 352 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
+                    />
+                  </svg>
+                </TimesIcon>
+              </button>
+            </Button>
+            <Title
+              aria-label="Wizard"
+              className="pf-c-wizard__title"
+              size="3xl"
+            >
+              <h1
+                aria-label="Wizard"
+                className="pf-c-title pf-m-3xl pf-c-wizard__title"
+              >
+                Wizard
+              </h1>
+            </Title>
+            <p
+              className="pf-c-wizard__description"
+            >
+              wizard description
+            </p>
+          </div>
+        </WizardHeader>
+        <div
+          className="pf-c-wizard__outer-wrap"
+        >
+          <WizardNav>
+            <nav
+              className="pf-c-wizard__nav"
+            >
+              <ol
+                className="pf-c-wizard__nav-list"
+              >
+                <WizardNavItem
+                  isCurrent={true}
+                  isDisabled={false}
+                  onNavItemClick={[Function]}
+                  step={0}
+                >
+                  <li
+                    className="pf-c-wizard__nav-item"
+                  >
+                    <a
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="pf-c-wizard__nav-link pf-m-current"
+                      onClick={[Function]}
+                    />
+                  </li>
+                </WizardNavItem>
+              </ol>
+            </nav>
+          </WizardNav>
+          <WizardStep
+            FieldProvider={[Function]}
+            buttonLabels={
+              Object {
+                "back": "Back",
+                "cancel": "Cancel",
+                "next": "Next",
+                "submit": "Submit",
+              }
+            }
+            disableBack={true}
+            fields={Array []}
+            formOptions={
+              Object {
+                "getState": [Function],
+                "handleSubmit": [Function],
+                "onCancel": [MockFunction],
+                "onSubmit": [MockFunction],
+                "renderForm": [Function],
+                "submit": [MockFunction],
+                "valid": true,
+              }
+            }
+            handleNext={[Function]}
+            handlePrev={[Function]}
+            name="foo"
+            stepKey="1"
+          >
+            <WizardBody
+              hasBodyPadding={true}
+            >
+              <main
+                className="pf-c-wizard__main"
+              >
+                <div
+                  className="pf-c-wizard__main-body"
+                >
+                  <div
+                    className="pf-c-form"
+                  />
+                </div>
+              </main>
+            </WizardBody>
+            <WizardStepButtons
+              FieldProvider={[Function]}
+              buttonLabels={
+                Object {
+                  "back": "Back",
+                  "cancel": "Cancel",
+                  "next": "Next",
+                  "submit": "Submit",
+                }
+              }
+              disableBack={true}
+              formOptions={
+                Object {
+                  "getState": [Function],
+                  "handleSubmit": [Function],
+                  "onCancel": [MockFunction],
+                  "onSubmit": [MockFunction],
+                  "renderForm": [Function],
+                  "submit": [MockFunction],
+                  "valid": true,
+                }
+              }
+              handleNext={[Function]}
+              handlePrev={[Function]}
+              name="foo"
+              stepKey="1"
+            >
+              <footer
+                className="pf-c-wizard__footer "
+              >
+                <Button
+                  onClick={[Function]}
+                  type="button"
+                  variant="primary"
+                >
+                  <button
+                    aria-disabled={null}
+                    aria-label={null}
+                    className="pf-c-button pf-m-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={null}
+                    type="button"
+                  >
+                    Submit
+                  </button>
+                </Button>
+                <Button
+                  isDisabled={true}
+                  onClick={[Function]}
+                  type="button"
+                  variant="secondary"
+                >
+                  <button
+                    aria-disabled={null}
+                    aria-label={null}
+                    className="pf-c-button pf-m-secondary pf-m-disabled"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={null}
+                    type="button"
+                  >
+                    Back
+                  </button>
+                </Button>
+                <Button
+                  onClick={[MockFunction]}
+                  type="button"
+                  variant="link"
+                >
+                  <button
+                    aria-disabled={null}
+                    aria-label={null}
+                    className="pf-c-button pf-m-link"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                    tabIndex={null}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </Button>
+              </footer>
+            </WizardStepButtons>
+          </WizardStep>
+        </div>
+      </div>
+    </Modal>
+  </Wizard>
+</WizardFunction>
+`;
+
+exports[`<Wizard /> should render correctly and unmount 2`] = `null`;
+
+exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
+<WizardFunction
+  FieldProvider={[Function]}
+  buttonLabels={Object {}}
+  description="wizard description"
+  fields={
+    Array [
+      Object {
+        "fields": Array [],
+        "name": "foo",
+        "stepKey": "1",
+      },
+    ]
+  }
+  formOptions={
+    Object {
+      "getState": [Function],
+      "onCancel": [MockFunction],
+      "onSubmit": [MockFunction],
+      "renderForm": [Function],
+      "submit": [MockFunction],
+      "valid": true,
+    }
+  }
+  inModal={true}
+  title="Wizard"
+>
+  <Wizard
+    FieldProvider={[Function]}
+    buttonLabels={
+      Object {
+        "back": "Back",
+        "cancel": "Cancel",
+        "next": "Next",
+        "submit": "Submit",
+      }
+    }
+    description="wizard description"
+    fields={
+      Array [
+        Object {
+          "fields": Array [],
+          "name": "foo",
+          "stepKey": "1",
+        },
+      ]
+    }
+    formOptions={
+      Object {
+        "getState": [Function],
+        "onCancel": [MockFunction],
+        "onSubmit": [MockFunction],
+        "renderForm": [Function],
+        "submit": [MockFunction],
+        "valid": true,
+      }
+    }
+    inModal={true}
+    title="Wizard"
+  >
+    <Modal
+      container={
+        <div>
+          <div
+            class="pf-c-backdrop"
+          >
+            <div
+              class="pf-l-bullseye"
             >
               <div
-                className="pf-l-toolbar__group"
+                aria-modal="true"
+                class="pf-c-wizard    "
+                role="dialog"
               >
-                <ToolbarItem
-                  className={null}
+                <div
+                  class="pf-c-wizard__header"
                 >
-                  <div
-                    className="pf-l-toolbar__item"
+                  <button
+                    class="pf-c-button pf-m-plain pf-c-wizard__close"
+                    type="button"
                   >
-                    <Button
-                      onClick={[MockFunction]}
-                      type="button"
-                      variant="secondary"
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 352 512"
+                      width="1em"
                     >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-secondary"
-                        disabled={false}
-                        onClick={[MockFunction]}
-                        tabIndex={null}
-                        type="button"
+                      <path
+                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                        transform=""
+                      />
+                    </svg>
+                  </button>
+                  <h1
+                    aria-label="Wizard"
+                    class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                  >
+                    Wizard
+                  </h1>
+                  <p
+                    class="pf-c-wizard__description"
+                  >
+                    wizard description
+                  </p>
+                </div>
+                <div
+                  class="pf-c-wizard__outer-wrap"
+                >
+                  <nav
+                    class="pf-c-wizard__nav"
+                  >
+                    <ol
+                      class="pf-c-wizard__nav-list"
+                    >
+                      <li
+                        class="pf-c-wizard__nav-item"
                       >
-                        Cancel
-                      </button>
-                    </Button>
-                  </div>
-                </ToolbarItem>
-                <ToolbarItem
-                  className={null}
+                        <a
+                          aria-current="page"
+                          aria-disabled="false"
+                          class="pf-c-wizard__nav-link pf-m-current"
+                        />
+                      </li>
+                    </ol>
+                  </nav>
+                  <main
+                    class="pf-c-wizard__main"
+                  >
+                    <div
+                      class="pf-c-wizard__main-body"
+                    >
+                      <div
+                        class="pf-c-form"
+                      />
+                    </div>
+                  </main>
+                  <footer
+                    class="pf-c-wizard__footer "
+                  >
+                    <button
+                      class="pf-c-button pf-m-primary"
+                      type="button"
+                    >
+                      Submit
+                    </button>
+                    <button
+                      class="pf-c-button pf-m-secondary pf-m-disabled"
+                      disabled=""
+                      type="button"
+                    >
+                      Back
+                    </button>
+                    <button
+                      class="pf-c-button pf-m-link"
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </footer>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+      inModal={true}
+    >
+      <Portal
+        containerInfo={
+          <div>
+            <div
+              class="pf-c-backdrop"
+            >
+              <div
+                class="pf-l-bullseye"
+              >
+                <div
+                  aria-modal="true"
+                  class="pf-c-wizard    "
+                  role="dialog"
                 >
                   <div
-                    className="pf-l-toolbar__item"
+                    class="pf-c-wizard__header"
                   >
-                    <Button
-                      isDisabled={true}
-                      onClick={[Function]}
+                    <button
+                      class="pf-c-button pf-m-plain pf-c-wizard__close"
                       type="button"
-                      variant="secondary"
                     >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-secondary pf-m-disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 352 512"
+                        width="1em"
                       >
-                        Back
-                      </button>
-                    </Button>
+                        <path
+                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          transform=""
+                        />
+                      </svg>
+                    </button>
+                    <h1
+                      aria-label="Wizard"
+                      class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                    >
+                      Wizard
+                    </h1>
+                    <p
+                      class="pf-c-wizard__description"
+                    >
+                      wizard description
+                    </p>
                   </div>
-                </ToolbarItem>
-                <ToolbarItem
-                  className={null}
-                >
                   <div
-                    className="pf-l-toolbar__item"
+                    class="pf-c-wizard__outer-wrap"
                   >
-                    <Button
-                      onClick={[Function]}
-                      type="button"
-                      variant="primary"
+                    <nav
+                      class="pf-c-wizard__nav"
+                    >
+                      <ol
+                        class="pf-c-wizard__nav-list"
+                      >
+                        <li
+                          class="pf-c-wizard__nav-item"
+                        >
+                          <a
+                            aria-current="page"
+                            aria-disabled="false"
+                            class="pf-c-wizard__nav-link pf-m-current"
+                          />
+                        </li>
+                      </ol>
+                    </nav>
+                    <main
+                      class="pf-c-wizard__main"
+                    >
+                      <div
+                        class="pf-c-wizard__main-body"
+                      >
+                        <div
+                          class="pf-c-form"
+                        />
+                      </div>
+                    </main>
+                    <footer
+                      class="pf-c-wizard__footer "
                     >
                       <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-primary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={null}
+                        class="pf-c-button pf-m-primary"
                         type="button"
                       >
                         Submit
                       </button>
-                    </Button>
+                      <button
+                        class="pf-c-button pf-m-secondary pf-m-disabled"
+                        disabled=""
+                        type="button"
+                      >
+                        Back
+                      </button>
+                      <button
+                        class="pf-c-button pf-m-link"
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                    </footer>
                   </div>
-                </ToolbarItem>
+                </div>
               </div>
-            </ToolbarGroup>
+            </div>
           </div>
-        </Toolbar>
-      </WizardStepButtons>
-    </WizardStep>
+        }
+      >
+        <Backdrop>
+          <div
+            className="pf-c-backdrop"
+          >
+            <Bullseye
+              className=""
+              component="div"
+            >
+              <div
+                className="pf-l-bullseye"
+              >
+                <div
+                  aria-modal="true"
+                  className="pf-c-wizard    "
+                  role="dialog"
+                >
+                  <WizardHeader
+                    description="wizard description"
+                    onClose={[MockFunction]}
+                    title="Wizard"
+                  >
+                    <div
+                      className="pf-c-wizard__header"
+                    >
+                      <Button
+                        className="pf-c-wizard__close"
+                        onClick={[MockFunction]}
+                        variant="plain"
+                      >
+                        <button
+                          aria-disabled={null}
+                          aria-label={null}
+                          className="pf-c-button pf-m-plain pf-c-wizard__close"
+                          disabled={false}
+                          onClick={[MockFunction]}
+                          tabIndex={null}
+                          type="button"
+                        >
+                          <TimesIcon
+                            aria-hidden="true"
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                            title={null}
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-labelledby={null}
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style={
+                                Object {
+                                  "verticalAlign": "-0.125em",
+                                }
+                              }
+                              viewBox="0 0 352 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                transform=""
+                              />
+                            </svg>
+                          </TimesIcon>
+                        </button>
+                      </Button>
+                      <Title
+                        aria-label="Wizard"
+                        className="pf-c-wizard__title"
+                        size="3xl"
+                      >
+                        <h1
+                          aria-label="Wizard"
+                          className="pf-c-title pf-m-3xl pf-c-wizard__title"
+                        >
+                          Wizard
+                        </h1>
+                      </Title>
+                      <p
+                        className="pf-c-wizard__description"
+                      >
+                        wizard description
+                      </p>
+                    </div>
+                  </WizardHeader>
+                  <div
+                    className="pf-c-wizard__outer-wrap"
+                  >
+                    <WizardNav>
+                      <nav
+                        className="pf-c-wizard__nav"
+                      >
+                        <ol
+                          className="pf-c-wizard__nav-list"
+                        >
+                          <WizardNavItem
+                            isCurrent={true}
+                            isDisabled={false}
+                            onNavItemClick={[Function]}
+                            step={0}
+                          >
+                            <li
+                              className="pf-c-wizard__nav-item"
+                            >
+                              <a
+                                aria-current="page"
+                                aria-disabled={false}
+                                className="pf-c-wizard__nav-link pf-m-current"
+                                onClick={[Function]}
+                              />
+                            </li>
+                          </WizardNavItem>
+                        </ol>
+                      </nav>
+                    </WizardNav>
+                    <WizardStep
+                      FieldProvider={[Function]}
+                      buttonLabels={
+                        Object {
+                          "back": "Back",
+                          "cancel": "Cancel",
+                          "next": "Next",
+                          "submit": "Submit",
+                        }
+                      }
+                      disableBack={true}
+                      fields={Array []}
+                      formOptions={
+                        Object {
+                          "getState": [Function],
+                          "handleSubmit": [Function],
+                          "onCancel": [MockFunction],
+                          "onSubmit": [MockFunction],
+                          "renderForm": [Function],
+                          "submit": [MockFunction],
+                          "valid": true,
+                        }
+                      }
+                      handleNext={[Function]}
+                      handlePrev={[Function]}
+                      name="foo"
+                      stepKey="1"
+                    >
+                      <WizardBody
+                        hasBodyPadding={true}
+                      >
+                        <main
+                          className="pf-c-wizard__main"
+                        >
+                          <div
+                            className="pf-c-wizard__main-body"
+                          >
+                            <div
+                              className="pf-c-form"
+                            />
+                          </div>
+                        </main>
+                      </WizardBody>
+                      <WizardStepButtons
+                        FieldProvider={[Function]}
+                        buttonLabels={
+                          Object {
+                            "back": "Back",
+                            "cancel": "Cancel",
+                            "next": "Next",
+                            "submit": "Submit",
+                          }
+                        }
+                        disableBack={true}
+                        formOptions={
+                          Object {
+                            "getState": [Function],
+                            "handleSubmit": [Function],
+                            "onCancel": [MockFunction],
+                            "onSubmit": [MockFunction],
+                            "renderForm": [Function],
+                            "submit": [MockFunction],
+                            "valid": true,
+                          }
+                        }
+                        handleNext={[Function]}
+                        handlePrev={[Function]}
+                        name="foo"
+                        stepKey="1"
+                      >
+                        <footer
+                          className="pf-c-wizard__footer "
+                        >
+                          <Button
+                            onClick={[Function]}
+                            type="button"
+                            variant="primary"
+                          >
+                            <button
+                              aria-disabled={null}
+                              aria-label={null}
+                              className="pf-c-button pf-m-primary"
+                              disabled={false}
+                              onClick={[Function]}
+                              tabIndex={null}
+                              type="button"
+                            >
+                              Submit
+                            </button>
+                          </Button>
+                          <Button
+                            isDisabled={true}
+                            onClick={[Function]}
+                            type="button"
+                            variant="secondary"
+                          >
+                            <button
+                              aria-disabled={null}
+                              aria-label={null}
+                              className="pf-c-button pf-m-secondary pf-m-disabled"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex={null}
+                              type="button"
+                            >
+                              Back
+                            </button>
+                          </Button>
+                          <Button
+                            onClick={[MockFunction]}
+                            type="button"
+                            variant="link"
+                          >
+                            <button
+                              aria-disabled={null}
+                              aria-label={null}
+                              className="pf-c-button pf-m-link"
+                              disabled={false}
+                              onClick={[MockFunction]}
+                              tabIndex={null}
+                              type="button"
+                            >
+                              Cancel
+                            </button>
+                          </Button>
+                        </footer>
+                      </WizardStepButtons>
+                    </WizardStep>
+                  </div>
+                </div>
+              </div>
+            </Bullseye>
+          </div>
+        </Backdrop>
+      </Portal>
+    </Modal>
   </Wizard>
 </WizardFunction>
 `;
+
+exports[`<Wizard /> should render correctly in modal and unmount 2`] = `null`;
 
 exports[`<Wizard /> should render correctly with custom title and description 1`] = `
 <WizardFunction
@@ -310,161 +911,262 @@ exports[`<Wizard /> should render correctly with custom title and description 1`
       </div>
     }
   >
-    <div>
-      Title
-    </div>
-    <div>
-      description
-    </div>
-    <WizardStep
-      FieldProvider={[Function]}
-      buttonLabels={
-        Object {
-          "back": "Back",
-          "cancel": "Cancel",
-          "next": "Next",
-          "submit": "Submit",
-        }
-      }
-      disableBack={true}
-      fields={Array []}
-      formOptions={
-        Object {
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "onCancel": [MockFunction],
-          "onSubmit": [MockFunction],
-          "renderForm": [Function],
-          "submit": [MockFunction],
-          "valid": true,
-        }
-      }
-      handleNext={[Function]}
-      handlePrev={[Function]}
-      name="foo"
-      stepKey="1"
-    >
-      <WizardStepButtons
-        FieldProvider={[Function]}
-        buttonLabels={
-          Object {
-            "back": "Back",
-            "cancel": "Cancel",
-            "next": "Next",
-            "submit": "Submit",
-          }
-        }
-        disableBack={true}
-        formOptions={
-          Object {
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "onCancel": [MockFunction],
-            "onSubmit": [MockFunction],
-            "renderForm": [Function],
-            "submit": [MockFunction],
-            "valid": true,
-          }
-        }
-        handleNext={[Function]}
-        handlePrev={[Function]}
-        name="foo"
-        stepKey="1"
+    <Modal>
+      <div
+        className="pf-c-wizard no-shadow   "
+        role="dialog"
       >
-        <Toolbar
-          className="wizard-button-toolbar "
+        <WizardHeader
+          description={
+            <div>
+              description
+            </div>
+          }
+          onClose={[MockFunction]}
+          title={
+            <div>
+              Title
+            </div>
+          }
         >
           <div
-            className="pf-l-toolbar wizard-button-toolbar "
+            className="pf-c-wizard__header"
           >
-            <ToolbarGroup
-              className={null}
+            <Button
+              className="pf-c-wizard__close"
+              onClick={[MockFunction]}
+              variant="plain"
             >
-              <div
-                className="pf-l-toolbar__group"
+              <button
+                aria-disabled={null}
+                aria-label={null}
+                className="pf-c-button pf-m-plain pf-c-wizard__close"
+                disabled={false}
+                onClick={[MockFunction]}
+                tabIndex={null}
+                type="button"
               >
-                <ToolbarItem
-                  className={null}
+                <TimesIcon
+                  aria-hidden="true"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 >
-                  <div
-                    className="pf-l-toolbar__item"
+                  <svg
+                    aria-hidden="true"
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 352 512"
+                    width="1em"
                   >
-                    <Button
-                      onClick={[MockFunction]}
-                      type="button"
-                      variant="secondary"
-                    >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-secondary"
-                        disabled={false}
-                        onClick={[MockFunction]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                    </Button>
+                    <path
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
+                    />
+                  </svg>
+                </TimesIcon>
+              </button>
+            </Button>
+            <Title
+              aria-label={
+                <div>
+                  Title
+                </div>
+              }
+              className="pf-c-wizard__title"
+              size="3xl"
+            >
+              <h1
+                aria-label={
+                  <div>
+                    Title
                   </div>
-                </ToolbarItem>
-                <ToolbarItem
-                  className={null}
-                >
-                  <div
-                    className="pf-l-toolbar__item"
-                  >
-                    <Button
-                      isDisabled={true}
-                      onClick={[Function]}
-                      type="button"
-                      variant="secondary"
-                    >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-secondary pf-m-disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Back
-                      </button>
-                    </Button>
-                  </div>
-                </ToolbarItem>
-                <ToolbarItem
-                  className={null}
-                >
-                  <div
-                    className="pf-l-toolbar__item"
-                  >
-                    <Button
-                      onClick={[Function]}
-                      type="button"
-                      variant="primary"
-                    >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-primary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Submit
-                      </button>
-                    </Button>
-                  </div>
-                </ToolbarItem>
+                }
+                className="pf-c-title pf-m-3xl pf-c-wizard__title"
+              >
+                <div>
+                  Title
+                </div>
+              </h1>
+            </Title>
+            <p
+              className="pf-c-wizard__description"
+            >
+              <div>
+                description
               </div>
-            </ToolbarGroup>
+            </p>
           </div>
-        </Toolbar>
-      </WizardStepButtons>
-    </WizardStep>
+        </WizardHeader>
+        <div
+          className="pf-c-wizard__outer-wrap"
+        >
+          <WizardNav>
+            <nav
+              className="pf-c-wizard__nav"
+            >
+              <ol
+                className="pf-c-wizard__nav-list"
+              >
+                <WizardNavItem
+                  isCurrent={true}
+                  isDisabled={false}
+                  onNavItemClick={[Function]}
+                  step={0}
+                >
+                  <li
+                    className="pf-c-wizard__nav-item"
+                  >
+                    <a
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="pf-c-wizard__nav-link pf-m-current"
+                      onClick={[Function]}
+                    />
+                  </li>
+                </WizardNavItem>
+              </ol>
+            </nav>
+          </WizardNav>
+          <WizardStep
+            FieldProvider={[Function]}
+            buttonLabels={
+              Object {
+                "back": "Back",
+                "cancel": "Cancel",
+                "next": "Next",
+                "submit": "Submit",
+              }
+            }
+            disableBack={true}
+            fields={Array []}
+            formOptions={
+              Object {
+                "getState": [Function],
+                "handleSubmit": [Function],
+                "onCancel": [MockFunction],
+                "onSubmit": [MockFunction],
+                "renderForm": [Function],
+                "submit": [MockFunction],
+                "valid": true,
+              }
+            }
+            handleNext={[Function]}
+            handlePrev={[Function]}
+            name="foo"
+            stepKey="1"
+          >
+            <WizardBody
+              hasBodyPadding={true}
+            >
+              <main
+                className="pf-c-wizard__main"
+              >
+                <div
+                  className="pf-c-wizard__main-body"
+                >
+                  <div
+                    className="pf-c-form"
+                  />
+                </div>
+              </main>
+            </WizardBody>
+            <WizardStepButtons
+              FieldProvider={[Function]}
+              buttonLabels={
+                Object {
+                  "back": "Back",
+                  "cancel": "Cancel",
+                  "next": "Next",
+                  "submit": "Submit",
+                }
+              }
+              disableBack={true}
+              formOptions={
+                Object {
+                  "getState": [Function],
+                  "handleSubmit": [Function],
+                  "onCancel": [MockFunction],
+                  "onSubmit": [MockFunction],
+                  "renderForm": [Function],
+                  "submit": [MockFunction],
+                  "valid": true,
+                }
+              }
+              handleNext={[Function]}
+              handlePrev={[Function]}
+              name="foo"
+              stepKey="1"
+            >
+              <footer
+                className="pf-c-wizard__footer "
+              >
+                <Button
+                  onClick={[Function]}
+                  type="button"
+                  variant="primary"
+                >
+                  <button
+                    aria-disabled={null}
+                    aria-label={null}
+                    className="pf-c-button pf-m-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={null}
+                    type="button"
+                  >
+                    Submit
+                  </button>
+                </Button>
+                <Button
+                  isDisabled={true}
+                  onClick={[Function]}
+                  type="button"
+                  variant="secondary"
+                >
+                  <button
+                    aria-disabled={null}
+                    aria-label={null}
+                    className="pf-c-button pf-m-secondary pf-m-disabled"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={null}
+                    type="button"
+                  >
+                    Back
+                  </button>
+                </Button>
+                <Button
+                  onClick={[MockFunction]}
+                  type="button"
+                  variant="link"
+                >
+                  <button
+                    aria-disabled={null}
+                    aria-label={null}
+                    className="pf-c-button pf-m-link"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                    tabIndex={null}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </Button>
+              </footer>
+            </WizardStepButtons>
+          </WizardStep>
+        </div>
+      </div>
+    </Modal>
   </Wizard>
 </WizardFunction>
 `;

--- a/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
@@ -40,7 +40,7 @@ describe('<WizardSTepButtons', () => {
   it('should call next with correct arguments when next step is string', () => {
     const handleNext = jest.fn();
     const wrapper = mount(<WizardStepButtons { ...initialProps } handleNext={ handleNext }  nextStep="next-step" />);
-    wrapper.find('button').at(2).simulate('click');
+    wrapper.find('button').at(0).simulate('click');
     expect(handleNext).toHaveBeenCalledWith('next-step');
   });
 
@@ -58,7 +58,7 @@ describe('<WizardSTepButtons', () => {
             qux: 'quaxx',
           },
         }} />);
-    wrapper.find('button').at(2).simulate('click');
+    wrapper.find('button').at(0).simulate('click');
     expect(handleNext).toHaveBeenCalledWith('bar');
   });
 
@@ -69,14 +69,14 @@ describe('<WizardSTepButtons', () => {
       formOptions={{ ...initialProps.formOptions, handleSubmit }}
       nextStep={ undefined }
     />);
-    wrapper.find('button').at(2).simulate('click');
+    wrapper.find('button').at(0).simulate('click');
     expect(handleSubmit).toHaveBeenCalled();
   });
 
   it('should call cancel function', () => {
     const onCancel = jest.fn();
     const wrapper = mount(<WizardStepButtons { ...initialProps } formOptions={{ ...initialProps.formOptions, onCancel }} />);
-    wrapper.find('button').first().simulate('click');
+    wrapper.find('button').last().simulate('click');
     expect(onCancel).toHaveBeenCalled();
   });
 

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -2,11 +2,15 @@ import React from 'react';
 import { mount } from 'enzyme';
 import toJSon from 'enzyme-to-json';
 
+import FormRenderer, { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+
+import { formFieldsMapper, layoutMapper } from '../../index';
 import Wizard from '../../form-fields/wizard/wizard';
 import FieldProvider from '../../../../../__mocks__/mock-field-provider';
 
 describe('<Wizard />', () => {
   let initialProps;
+  let schema;
 
   beforeEach(() => {
     initialProps = {
@@ -14,7 +18,7 @@ describe('<Wizard />', () => {
       title: 'Wizard',
       description: 'wizard description',
       formOptions: {
-        renderForm: ({ name }) => <div key={ name }>{ name }</div>,
+        renderForm: ([{ name }]) => <div key={ name }>{ name }</div>,
         getState: () => ({
           values: {
             'foo-field': 'foo-field-value',
@@ -33,28 +37,8 @@ describe('<Wizard />', () => {
         fields: [],
       }],
     };
-  });
 
-  it('should render correctly', () => {
-    const wrapper = mount(<Wizard { ...initialProps } />);
-    expect(toJSon(wrapper)).toMatchSnapshot();
-  });
-
-  it('should render correctly with custom title and description', () => {
-    const wrapper = mount(<Wizard { ...initialProps } title={ <div>Title</div> } description={ <div>description</div> } />);
-    expect(toJSon(wrapper)).toMatchSnapshot();
-  });
-
-  it('should call submit function', () => {
-    const onSubmit = jest.fn();
-    const wrapper = mount(<Wizard { ...initialProps } formOptions={{ ...initialProps.formOptions, onSubmit }} />);
-    wrapper.find('button').last().simulate('click');
-    expect(onSubmit).toHaveBeenCalled();
-  });
-
-  it('should go to next step correctly and submit data', () => {
-    const onSubmit = jest.fn();
-    const wrapper = mount(<Wizard { ...initialProps } formOptions={{ ...initialProps.formOptions, onSubmit }}   fields={ [{
+    schema = [{
       title: 'foo-step',
       stepKey: '1',
       name: 'foo',
@@ -69,17 +53,341 @@ describe('<Wizard />', () => {
       fields: [{
         name: 'bar-field',
       }],
-    }] } />);
-    // go to next step
-    wrapper.find('button').at(2).simulate('click');
+    }];
+  });
+
+  it('should render correctly and unmount', () => {
+    const wrapper = mount(<Wizard { ...initialProps } />);
+    expect(toJSon(wrapper)).toMatchSnapshot();
+    wrapper.unmount();
     wrapper.update();
-    expect(wrapper.children().instance().state).toEqual({ activeStep: '2', prevSteps: [ '1' ]});
+    expect(toJSon(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render correctly in modal and unmount', () => {
+    const wrapper = mount(<Wizard inModal { ...initialProps } />);
+    expect(toJSon(wrapper)).toMatchSnapshot();
+    wrapper.unmount();
+    wrapper.update();
+    expect(toJSon(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render correctly with custom title and description', () => {
+    const wrapper = mount(<Wizard { ...initialProps } title={ <div>Title</div> } description={ <div>description</div> } />);
+    expect(toJSon(wrapper)).toMatchSnapshot();
+  });
+
+  it('should call submit function', () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(<Wizard { ...initialProps } formOptions={{ ...initialProps.formOptions, onSubmit }} />);
+    wrapper.find('button').at(1).simulate('click');
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('should go to next step correctly and submit data', () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(<Wizard { ...initialProps } formOptions={{ ...initialProps.formOptions, onSubmit }} fields={ schema } />);
+    // go to next step
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+    expect(wrapper.children().instance().state.activeStep).toEqual('2');
+    expect(wrapper.children().instance().state.prevSteps).toEqual([ '1' ]);
 
     // submit wizard
-    wrapper.find('button').at(2).simulate('click');
+    wrapper.find('button').at(1).simulate('click');
     expect(onSubmit).toHaveBeenCalledWith({
       'foo-field': 'foo-field-value',
       'bar-field': 'bar-field-value',
     });
+  });
+
+  it('should build simple navigation', () => {
+    const wrapper = mount(<Wizard { ...initialProps } fields={ schema } />);
+
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(2);
+    expect(wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).text()).toEqual('foo-step');
+    expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).text()).toEqual('bar-step');
+  });
+
+  it('should build progressive navigation', () => {
+    const wrapper = mount(<Wizard { ...initialProps } isDynamic fields={ schema }  />);
+
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
+    expect(wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).text()).toEqual('foo-step');
+
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(2);
+    expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).text()).toEqual('bar-step');
+  });
+
+  it('should jump when click simple navigation', () => {
+    const wrapper = mount(<Wizard { ...initialProps } fields={ schema } />);
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+
+    // click on first nav link
+    wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+
+    // go back
+    wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+
+  });
+
+  it('should build simple navigation with substeps', () => {
+    const wrapper = mount(<Wizard { ...initialProps } fields={ [{
+      title: 'foo-step',
+      stepKey: '1',
+      name: 'foo',
+      fields: [{
+        name: 'foo-field',
+      }],
+      nextStep: '2',
+    }, {
+      stepKey: '2',
+      title: 'bar-step',
+      name: 'bar',
+      substepOf: 'barbar',
+      fields: [{
+        name: 'bar-field',
+      }],
+    }] } />);
+
+    expect(wrapper.find('.pf-c-wizard__nav-list')).toHaveLength(2);
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
+    expect(wrapper.find('.pf-c-wizard__nav-item').at(1).childAt(0).text()).toEqual('barbar');
+    expect(wrapper.find('.pf-c-wizard__nav-list').last().childAt(0).childAt(0).text()).toEqual('bar-step');
+
+  });
+
+  it('should jumb with substeps', () => {
+    const wrapper = mount(<Wizard { ...initialProps } fields={ [{
+      title: 'foo-step',
+      stepKey: '1',
+      name: 'foo',
+      fields: [{
+        name: 'foo-field',
+      }],
+      nextStep: '2',
+    }, {
+      stepKey: '2',
+      title: 'bar-step',
+      name: 'bar',
+      substepOf: 'barbar',
+      fields: [{
+        name: 'bar-field',
+      }],
+    }] } />);
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+
+    // go next
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+
+    // click on first nav link
+    wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+
+    // go back through the primary step
+    wrapper.find('.pf-c-wizard__nav-item').at(1).childAt(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+
+    // go back
+    wrapper.find('button').at(2).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+
+    // go back through the substep
+    wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+  });
+
+  it('should jumb with substeps and dynamic', () => {
+    const wrapper = mount(<Wizard { ...initialProps } isDynamic fields={ [{
+      title: 'foo-step',
+      stepKey: '1',
+      name: 'foo',
+      fields: [{
+        name: 'foo-field',
+      }],
+      nextStep: '2',
+    }, {
+      stepKey: '2',
+      title: 'bar-step',
+      name: 'bar',
+      substepOf: 'barbar',
+      fields: [{
+        name: 'bar-field',
+      }],
+    }] } />);
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
+
+    // go next
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
+
+    // click on first nav link
+    wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    // visited step perished from navigation
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
+
+    // go next
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
+  });
+
+  it('should disable steps when invalid', () => {
+    const schema = { fields: [{
+      component: componentTypes.WIZARD,
+      name: 'wizard',
+      fields: [{
+        title: 'foo-step',
+        stepKey: '1',
+        name: 'foo',
+        fields: [{
+          name: 'foo-field',
+          label: 'foo',
+          component: componentTypes.TEXT_FIELD,
+        }],
+        nextStep: '2',
+      }, {
+        stepKey: '2',
+        title: 'bar-step',
+        name: 'bar',
+        substepOf: 'barbar',
+        nextStep: '3',
+        fields: [{
+          name: 'bar-field',
+          label: 'bar',
+          component: componentTypes.TEXT_FIELD,
+          validate: [{
+            type: validatorTypes.REQUIRED,
+          }],
+        }],
+      }, {
+        stepKey: '3',
+        title: 'conan-step',
+        name: 'conan',
+        substepOf: 'barbar',
+        fields: [{
+          name: 'conan-field',
+          label: 'conan',
+          component: componentTypes.TEXT_FIELD,
+        }],
+      }],
+    }],
+    };
+
+    const wrapper = mount(<FormRenderer
+      schema={ schema }
+      formFieldsMapper={ formFieldsMapper }
+      layoutMapper={ layoutMapper }
+      onSubmit={ jest.fn() }
+      onCancel={ jest.fn() }
+      showFormControls={ false }
+    />);
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo');
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(4);
+
+    // go next
+    wrapper.find('button').at(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar');
+
+    // go next
+    wrapper.find('button').at(0).simulate('click');
+    wrapper.update();
+
+    // however, it is not possible because form is invalid
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar');
+
+    // let's write
+    wrapper.find('input').instance().value = 'hello';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    // go next
+    wrapper.find('button').at(0).simulate('click');
+    wrapper.update();
+
+    // voila
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('conan');
+    expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).prop('aria-disabled')).toEqual(false);
+
+    // go back and make it invalid
+    wrapper.find('button').at(1).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar');
+
+    wrapper.find('input').instance().value = '';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    // go next
+    wrapper.find('button').at(0).simulate('click');
+    wrapper.update();
+
+    // it is invalid :(
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar');
+
+    // let's look if last nav item is disabled (click event is working with 'disabled' <a> element)
+    expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).prop('aria-disabled')).toEqual(true);
+
+    // go to first step
+    wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
+    wrapper.update();
+
+    // still invalid :(
+    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo');
+    expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).prop('aria-disabled')).toEqual(true);
+
+    // make form valid again
+    wrapper.find('button').at(0).simulate('click');
+    wrapper.update();
+
+    wrapper.find('input').instance().value = 'hello';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    wrapper.find('button').at(0).simulate('click');
+    wrapper.update();
+
+    expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).prop('aria-disabled')).toEqual(false);
   });
 });

--- a/packages/react-renderer-demo/src/editor-demo/common/examples-texts/wizard.js
+++ b/packages/react-renderer-demo/src/editor-demo/common/examples-texts/wizard.js
@@ -122,4 +122,140 @@ nextStep: {
 [Wizard design](https://www.patternfly.org/pattern-library/communication/wizard/#design)
 `;
 
-export default ({ activeMapper }) => <ReactMarkdown source={ activeMapper === 'pf3' ? pf3Text : text } />;
+const pf4text = `This a custom component. OnSubmit will send only values from visited steps.
+
+Don't forget hide form controls by settinng \`showFormControls\` to \`false\` as a prop of the renderer component.
+
+### Props
+
+| Prop  | Type | Default |  Decription |
+| ------------- | ------------- | ------------- | ------------- |
+| title  | string  | undefined  | Title in header (will show header) |
+| description  | string  | undefined  | Description in header |
+| buttonLabels  | object  | see below  | Labels for buttons |
+| inModal  | bool  | undefined  | show form in modal  |
+| isCompactNav  | bool  | undefined  | see Patternfly |
+| setFullWidth  | bool  | undefined  | see Patternfly  |
+| setFullHeight  | bool  | undefined  | see Patternfly  |
+| isDynamic  | bool  | undefined  | will dynamically generate steps navigation (=progressive wizard), please use if you use any condition fields which changes any field in other steps (wizards with conditional steps are dynamic by default) |
+
+### Default buttonLabels
+
+\`\`\`jsx
+{
+  cancel: 'Cancel',
+  back: 'Back',
+  next: 'Next',
+  submit: 'Submit',
+}
+\`\`\`
+You can rewrite only selection of them, e.g.
+
+\`\`\`jsx
+{
+  submit: 'Deploy',
+}
+\`\`\`
+
+(Others will stay default)
+
+### Docs for steps
+
+| Props  | Type  |  Decription |
+| ------------- | ------------- | ------------- |
+| stepKey  | string, number | For first step: 1, otherwise anything |
+| nextStep  | object/stepKey of next step | See below |
+| fields  | array | As usual |
+| substep | string | Substep title (steps are grouped by this title) |
+| title | string | Step title
+
+- nextStep can be stepKey of the next step
+- or you can branch the way by using of object:
+
+\`\`\`jsx
+nextStep: {
+        when: 'source-type', // name of field, where deciding value is stored
+        stepMapper: {
+          aws: 'aws', // value: 'stepKey' of next step
+          google: 'google',
+          ...
+        },
+},
+\`\`\`
+
+
+### How to do substeps
+
+Field in Wizard fields should contain \`substep\` <\`string\`> which is title of the primary step. Steps with the same substep are grouped together by the title of primary step.
+
+#### Example
+
+Structure:
+
+\`\`\`jsx
+                     //            index
+Select Type          // step       1
+Configuration        // step       2
+  Security           // substep    2 (there is no step 'configuration')
+  Credentials        // substep    3
+Summary              // step       4
+\`\`\`
+
+\`\`\`jsx
+Schema: [
+  {
+    stepKey: '1',
+    title: 'Select Type',
+    nextStep: 'security'
+  },
+  {
+    stepKey: 'security',
+    title: 'Security',
+    nextStep: 'credentials',
+    substep: 'Configuration'
+  },{
+    stepKey: 'credentials',
+    title: 'Credentials',
+    nextStep: 'summary',
+    substep: 'Configuration'
+  },{
+    stepKey: 'summary',
+    title: 'Summary'
+  },
+]
+\`\`\`
+
+Progressive Wizard works same way. It checks if previous step has the same \`substep\` value and if so, it grouped them together.
+If the value is different, a new primary step is created with the step as a substep.
+
+### First step
+
+First step should have \`stepKey: 1\` or as a string: \`'1'\`
+
+### Variants of Wizard
+
+#### Simple wizard
+
+- steps navigation is visible, user can jump back and forward (after visiting the step)
+- does not contain any conditional steps
+- if you need to change one step according to another (dynamic fields), do not use this (there is no way how to check which fields was changed), instead of that use **progressive wizard**
+- if user change some field and make the form invalid, he cannot jump forward until he fix the form
+
+![simplewizard](https://user-images.githubusercontent.com/32869456/58427234-56725680-809f-11e9-8e22-3ce7286b30d2.gif)
+
+#### Progressive wizard
+
+- steps are visible as user visits them
+- user can jump only back
+- use \`isDynamic\` prop to enforce it
+
+![progressivewizard](https://user-images.githubusercontent.com/32869456/58427241-5b370a80-809f-11e9-8e79-a4a829b8d181.gif)
+
+### Useful links
+
+[PF4 wizard implementation](https://www.patternfly.org/v4/documentation/react/components/wizard/)
+
+[Wizard design](https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/wizard)
+`;
+
+export default ({ activeMapper }) => <ReactMarkdown source={ activeMapper === 'pf3' ? pf3Text : activeMapper === 'pf4' ? pf4text : text } />;

--- a/packages/react-renderer-demo/src/vendor.scss
+++ b/packages/react-renderer-demo/src/vendor.scss
@@ -9100,6 +9100,383 @@ select.pf-c-form-control[aria-invalid="true"] {
   .pf-u-py-3xl-on-xl {
     padding-top: var(--pf-global--spacer--3xl) !important;
     padding-bottom: var(--pf-global--spacer--3xl) !important; } }
+
+    /* stylelint-enable */
+.pf-c-wizard__header {
+  --pf-global--Color--100: var(--pf-global--Color--light-100);
+  --pf-global--Color--200: var(--pf-global--Color--light-200);
+  --pf-global--BorderColor--100: var(--pf-global--BorderColor--light-100);
+  --pf-global--primary-color--100: var(--pf-global--primary-color--light-100);
+  --pf-global--link--Color: var(--pf-global--link--Color--light);
+  --pf-global--link--Color--hover: var(--pf-global--link--Color--light);
+  --pf-global--BackgroundColor--100: var(--pf-global--BackgroundColor--dark-100); }
+  .pf-c-wizard__header .pf-c-card {
+    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200); }
+  .pf-c-wizard__header .pf-c-button {
+    --pf-c-button--m-primary--Color: var(--pf-global--primary-color--dark-100);
+    --pf-c-button--m-primary--hover--Color: var(--pf-global--primary-color--dark-100);
+    --pf-c-button--m-primary--focus--Color: var(--pf-global--primary-color--dark-100);
+    --pf-c-button--m-primary--active--Color: var(--pf-global--primary-color--dark-100);
+    --pf-c-button--m-primary--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-button--m-primary--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+    --pf-c-button--m-primary--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+    --pf-c-button--m-primary--active--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+    --pf-c-button--m-secondary--Color: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--hover--Color: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--focus--Color: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--active--Color: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--BorderColor: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--hover--BorderColor: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--focus--BorderColor: var(--pf-global--Color--light-100);
+    --pf-c-button--m-secondary--active--BorderColor: var(--pf-global--Color--light-100); }
+
+/* stylelint-disable */
+/* stylelint-enable */
+.pf-c-wizard {
+  --pf-c-wizard--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-wizard--Height: 100%;
+  --pf-c-wizard--Width: 100vw;
+  --pf-c-wizard--lg--Width: calc(100% - (var(--pf-global--spacer--2xl) * 2));
+  --pf-c-wizard--lg--MaxWidth: 77rem;
+  --pf-c-wizard--lg--Height: 47.625rem;
+  --pf-c-wizard--lg--MaxHeight: calc(100% - (var(--pf-global--spacer--2xl) * 2));
+  --pf-c-wizard--m-full-width--lg--MaxWidth: auto;
+  --pf-c-wizard--m-full-height--lg--Height: 100%;
+  --pf-c-wizard__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
+  --pf-c-wizard__header--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-wizard__header--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__header--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-wizard__header--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard__header--lg--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-wizard__header--lg--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard__close--Top: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--form-element));
+  --pf-c-wizard__close--Right: 0;
+  --pf-c-wizard__close--lg--Right: var(--pf-global--spacer--md);
+  --pf-c-wizard__close--FontSize: var(--pf-global--FontSize--xl);
+  --pf-c-wizard__title--PaddingRight: var(--pf-global--spacer--2xl);
+  --pf-c-wizard__description--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-wizard__description--Color: var(--pf-global--Color--light-200);
+  --pf-c-wizard__toggle--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-wizard__toggle--ZIndex: var(--pf-global--ZIndex--sm);
+  --pf-c-wizard__toggle--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
+  --pf-c-wizard__toggle--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-wizard__toggle--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__toggle--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-wizard__toggle--PaddingLeft: calc(var(--pf-global--spacer--md) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard__toggle-num--before--Top: 0.125rem;
+  --pf-c-wizard__toggle-list--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-wizard__toggle-list--MarginBottom: calc(var(--pf-c-wizard__toggle-list-item--MarginBottom) * -1);
+  --pf-c-wizard__toggle-list-item--first-child--FontSize: var(--pf-global--FontSize--lg);
+  --pf-c-wizard__toggle-list-item--not-last-child--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-wizard__toggle-list-item--MarginBottom: var(--pf-global--spacer--xs);
+  --pf-c-wizard__toggle-separator--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-wizard__toggle-separator--Color: var(--pf-global--BorderColor--200);
+  --pf-c-wizard__toggle-icon--MarginTop: 0.375rem;
+  --pf-c-wizard__nav--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-wizard__nav--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-wizard__nav--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
+  --pf-c-wizard__nav--lg--BoxShadow: var(--pf-global--BoxShadow--lg-right);
+  --pf-c-wizard__nav--Width: 100%;
+  --pf-c-wizard__nav--lg--Width: 18.75rem;
+  --pf-c-wizard--m-compact-nav__nav--lg--Width: 15.625rem;
+  --pf-c-wizard__nav-list--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-wizard__nav-list--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-list--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-wizard__nav-list--PaddingLeft: calc(var(--pf-global--spacer--md) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard__nav-list--lg--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-wizard__nav-list--lg--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard__nav-list--nested--MarginLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-list--nested--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-item--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-link--Color: var(--pf-global--Color--100);
+  --pf-c-wizard__nav-link--TextDecoration: var(--pf-global--link--TextDecoration);
+  --pf-c-wizard__nav-link--hover--Color: var(--pf-global--link--Color);
+  --pf-c-wizard__nav-link--focus--Color: var(--pf-global--link--Color);
+  --pf-c-wizard__nav-link--m-current--Color: var(--pf-global--link--Color);
+  --pf-c-wizard__nav-link--m-disabled--Color: var(--pf-global--Color--dark-200);
+  --pf-c-wizard__nav-link--before--Width: 1.5rem;
+  --pf-c-wizard__nav-link--before--Height: 1.5rem;
+  --pf-c-wizard__nav-link--before--Top: 0;
+  --pf-c-wizard__nav-link--before--BackgroundColor: var(--pf-global--BackgroundColor--300);
+  --pf-c-wizard__nav-link--before--BorderRadius: var(--pf-global--BorderRadius--lg);
+  --pf-c-wizard__nav-link--before--Color: var(--pf-global--Color--100);
+  --pf-c-wizard__nav-link--before--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-wizard__nav-link--before--Transform: translateX(calc(-100% - var(--pf-global--spacer--sm)));
+  --pf-c-wizard__nav-link--m-current--before--BackgroundColor: var(--pf-global--active-color--100);
+  --pf-c-wizard__nav-link--m-current--before--Color: var(--pf-global--Color--light-100);
+  --pf-c-wizard__nav-link--m-disabled--before--BackgroundColor: transparent;
+  --pf-c-wizard__nav-link--m-disabled--before--Color: var(--pf-global--Color--dark-200);
+  --pf-c-wizard__outer-wrap--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-wizard__outer-wrap--lg--PaddingLeft: var(--pf-c-wizard__nav--lg--Width);
+  --pf-c-wizard__main-body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-wizard__main-body--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__main-body--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-wizard__main-body--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard__main-body--lg--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-wizard__main-body--lg--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-wizard__main-body--lg--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-wizard__main-body--lg--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard__footer--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-wizard__footer--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__footer--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-wizard__footer--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard__footer--lg--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-wizard__footer--lg--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-wizard__footer--lg--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-wizard__footer--lg--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard__footer--child--MarginRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__footer--child--MarginBottom: var(--pf-global--spacer--sm);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: var(--pf-c-wizard--Width);
+  height: var(--pf-c-wizard--Height);
+  box-shadow: var(--pf-c-wizard--BoxShadow); }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard--Width: var(--pf-c-wizard--lg--Width);
+      --pf-c-wizard--Height: var(--pf-c-wizard--lg--Height); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard__header--PaddingRight: var(--pf-c-wizard__header--lg--PaddingRight);
+      --pf-c-wizard__header--PaddingLeft: var(--pf-c-wizard__header--lg--PaddingLeft); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard__close--Right: var(--pf-c-wizard__close--lg--Right); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard__nav--BoxShadow: var(--pf-c-wizard__nav--lg--BoxShadow); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard__nav-list--PaddingRight: var(--pf-c-wizard__nav-list--lg--PaddingRight);
+      --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard__nav-list--lg--PaddingLeft); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard__main-body--PaddingTop: var(--pf-c-wizard__main-body--lg--PaddingTop);
+      --pf-c-wizard__main-body--PaddingRight: var(--pf-c-wizard__main-body--lg--PaddingRight);
+      --pf-c-wizard__main-body--PaddingBottom: var(--pf-c-wizard__main-body--lg--PaddingBottom);
+      --pf-c-wizard__main-body--PaddingLeft: var(--pf-c-wizard__main-body--lg--PaddingLeft); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      --pf-c-wizard__footer--PaddingTop: var(--pf-c-wizard__footer--lg--PaddingTop);
+      --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard__footer--lg--PaddingRight);
+      --pf-c-wizard__footer--PaddingBottom: var(--pf-c-wizard__footer--lg--PaddingBottom);
+      --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard__footer--lg--PaddingLeft); } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard {
+      max-width: var(--pf-c-wizard--lg--MaxWidth);
+      max-height: var(--pf-c-wizard--lg--MaxHeight); }
+      .pf-c-wizard.pf-m-full-width {
+        --pf-c-wizard--lg--MaxWidth: var(--pf-c-wizard--m-full-width--lg--MaxWidth); }
+      .pf-c-wizard.pf-m-full-height {
+        --pf-c-wizard--lg--Height: var(--pf-c-wizard--m-full-height--lg--Height); }
+      .pf-c-wizard.pf-m-compact-nav {
+        --pf-c-wizard__nav--lg--Width: var(--pf-c-wizard--m-compact-nav__nav--lg--Width); } }
+  .pf-c-wizard > *:not(.pf-c-wizard__outer-wrap) {
+    flex-shrink: 0; }
+  .pf-c-wizard.pf-m-finished {
+    --pf-c-wizard__outer-wrap--lg--PaddingLeft: 0; }
+    .pf-c-wizard.pf-m-finished .pf-c-wizard__nav,
+    .pf-c-wizard.pf-m-finished .pf-c-wizard__footer,
+    .pf-c-wizard.pf-m-finished .pf-c-wizard__toggle {
+      display: none;
+      visibility: hidden; }
+
+.pf-c-wizard__header {
+  color: var(--pf-global--Color--100);
+  position: relative;
+  padding: var(--pf-c-wizard__header--PaddingTop) var(--pf-c-wizard__header--PaddingRight) var(--pf-c-wizard__header--PaddingBottom) var(--pf-c-wizard__header--PaddingLeft);
+  background-color: var(--pf-c-wizard__header--BackgroundColor); }
+  .pf-c-wizard__header .pf-c-wizard__close {
+    position: absolute;
+    top: var(--pf-c-wizard__close--Top);
+    right: var(--pf-c-wizard__close--Right);
+    font-size: var(--pf-c-wizard__close--FontSize); }
+
+.pf-c-wizard__title {
+  padding-right: var(--pf-c-wizard__title--PaddingRight);
+  word-wrap: break-word; }
+
+.pf-c-wizard__description {
+  display: none;
+  padding-top: var(--pf-c-wizard__description--PaddingTop);
+  color: var(--pf-c-wizard__description--Color);
+  visibility: hidden; }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard__description {
+      display: block;
+      visibility: visible; } }
+
+.pf-c-wizard__toggle {
+  position: relative;
+  z-index: var(--pf-c-wizard__toggle--ZIndex);
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--pf-c-wizard__toggle--PaddingTop) var(--pf-c-wizard__toggle--PaddingRight) var(--pf-c-wizard__toggle--PaddingBottom) var(--pf-c-wizard__toggle--PaddingLeft);
+  background-color: var(--pf-c-wizard__toggle--BackgroundColor);
+  border: 0;
+  box-shadow: var(--pf-c-wizard__toggle--BoxShadow); }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard__toggle {
+      display: none;
+      visibility: hidden; } }
+  .pf-c-wizard__toggle.pf-m-expanded .pf-c-wizard__toggle-icon {
+    transform: rotate(180deg); }
+
+.pf-c-wizard__toggle-list {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin-right: var(--pf-c-wizard__toggle-list--MarginRight);
+  margin-bottom: var(--pf-c-wizard__toggle-list--MarginBottom);
+  list-style: none; }
+
+.pf-c-wizard__toggle-list-item {
+  margin-bottom: var(--pf-c-wizard__toggle-list-item--MarginBottom);
+  text-align: left;
+  word-break: break-word; }
+  .pf-c-wizard__toggle-list-item:first-child {
+    font-size: var(--pf-c-wizard__toggle-list-item--first-child--FontSize); }
+  .pf-c-wizard__toggle-list-item:not(:last-child) {
+    margin-right: var(--pf-c-wizard__toggle-list-item--not-last-child--MarginRight); }
+
+.pf-c-wizard__toggle-num {
+  --pf-c-wizard__nav-link--before--Top: var(--pf-c-wizard__toggle-num--before--Top); }
+
+.pf-c-wizard__toggle-separator {
+  margin-left: var(--pf-c-wizard__toggle-separator--MarginLeft);
+  color: var(--pf-c-wizard__toggle-separator--Color); }
+
+.pf-c-wizard__toggle-icon {
+  margin-top: var(--pf-c-wizard__toggle-icon--MarginTop); }
+
+.pf-c-wizard__outer-wrap {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0;
+  background-color: var(--pf-c-wizard__outer-wrap--BackgroundColor); }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard__outer-wrap {
+      padding-left: var(--pf-c-wizard__outer-wrap--lg--PaddingLeft); } }
+
+.pf-c-wizard__inner-wrap {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0; }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard__inner-wrap {
+      position: static; } }
+
+.pf-c-wizard__nav {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: var(--pf-c-wizard__nav--ZIndex);
+  display: none;
+  width: var(--pf-c-wizard__nav--Width);
+  max-height: 100%;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  visibility: hidden;
+  background-color: var(--pf-c-wizard__nav--BackgroundColor);
+  box-shadow: var(--pf-c-wizard__nav--BoxShadow); }
+  @media screen and (max-width: 992px) {
+    .pf-c-wizard__nav.pf-m-expanded {
+      display: block;
+      visibility: visible; } }
+  @media screen and (min-width: 992px) {
+    .pf-c-wizard__nav {
+      --pf-c-wizard__nav--Width: var(--pf-c-wizard__nav--lg--Width);
+      display: block;
+      height: 100%;
+      visibility: visible; } }
+
+.pf-c-wizard__nav-list {
+  padding-top: var(--pf-c-wizard__nav-list--PaddingTop);
+  padding-right: var(--pf-c-wizard__nav-list--PaddingRight);
+  padding-bottom: var(--pf-c-wizard__nav-list--PaddingBottom);
+  padding-left: var(--pf-c-wizard__nav-list--PaddingLeft);
+  list-style: none;
+  counter-reset: wizard-nav-count; }
+  .pf-c-wizard__nav-list .pf-c-wizard__nav-list {
+    padding: 0;
+    margin-top: var(--pf-c-wizard__nav-list--nested--MarginTop);
+    margin-left: var(--pf-c-wizard__nav-list--nested--MarginLeft); }
+    .pf-c-wizard__nav-list .pf-c-wizard__nav-list .pf-c-wizard__nav-link::before {
+      content: none; }
+
+.pf-c-wizard__nav-item {
+  cursor: not-allowed; }
+  .pf-c-wizard__nav-item + .pf-c-wizard__nav-item {
+    margin-top: var(--pf-c-wizard__nav-item--MarginTop); }
+
+.pf-c-wizard__nav-link {
+  position: relative;
+  display: inline-block;
+  color: var(--pf-c-wizard__nav-link--Color);
+  text-decoration: var(--pf-c-wizard__nav-link--TextDecoration);
+  word-break: break-word; }
+  .pf-c-wizard__toggle-num, .pf-c-wizard__nav-link::before {
+    position: absolute;
+    top: var(--pf-c-wizard__nav-link--before--Top);
+    left: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--pf-c-wizard__nav-link--before--Width);
+    height: var(--pf-c-wizard__nav-link--before--Height);
+    font-size: var(--pf-c-wizard__nav-link--before--FontSize);
+    line-height: 1;
+    color: var(--pf-c-wizard__nav-link--before--Color);
+    background-color: var(--pf-c-wizard__nav-link--before--BackgroundColor);
+    border-radius: var(--pf-c-wizard__nav-link--before--BorderRadius);
+    transform: var(--pf-c-wizard__nav-link--before--Transform); }
+  .pf-c-wizard__nav-link::before {
+    top: 0;
+    content: counter(wizard-nav-count);
+    counter-increment: wizard-nav-count; }
+  .pf-c-wizard__nav-link:hover, .pf-c-wizard__nav-link.pf-m-hover {
+    --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--hover--Color); }
+  .pf-c-wizard__nav-link:focus, .pf-c-wizard__nav-link.pf-m-focus {
+    --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--focus--Color); }
+  .pf-c-wizard__nav-link.pf-m-current {
+    --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--m-current--Color); }
+    .pf-c-wizard__toggle-num, .pf-c-wizard__nav-link.pf-m-current::before {
+      --pf-c-wizard__nav-link--before--BackgroundColor: var(--pf-c-wizard__nav-link--m-current--before--BackgroundColor);
+      --pf-c-wizard__nav-link--before--Color: var(--pf-c-wizard__nav-link--m-current--before--Color); }
+  .pf-c-wizard__nav-link.pf-m-disabled {
+    --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--m-disabled--Color);
+    pointer-events: none; }
+    .pf-c-wizard__nav-link.pf-m-disabled::before {
+      --pf-c-wizard__nav-link--before--BackgroundColor: var(--pf-c-wizard__nav-link--m-disabled--before--BackgroundColor);
+      --pf-c-wizard__nav-link--before--Color: var(--pf-c-wizard__nav-link--m-disabled--before--Color); }
+
+.pf-c-wizard__main {
+  flex: 1 1 auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  word-break: break-word; }
+  .pf-c-wizard__main.pf-m-no-padding .pf-c-wizard__main-body {
+    padding: 0; }
+
+.pf-c-wizard__main-body {
+  padding: var(--pf-c-wizard__main-body--PaddingTop) var(--pf-c-wizard__main-body--PaddingRight) var(--pf-c-wizard__main-body--PaddingBottom) var(--pf-c-wizard__main-body--PaddingLeft); }
+
+.pf-c-wizard__footer {
+  display: flex;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  padding: var(--pf-c-wizard__footer--PaddingTop) var(--pf-c-wizard__footer--PaddingRight) var(--pf-c-wizard__footer--PaddingBottom) var(--pf-c-wizard__footer--PaddingLeft); }
+  .pf-c-wizard__footer > * {
+    margin-bottom: var(--pf-c-wizard__footer--child--MarginBottom); }
+    .pf-c-wizard__footer > *:not(:last-child) {
+      margin-right: var(--pf-c-wizard__footer--child--MarginRight); }
 }
 
 .pf3 {


### PR DESCRIPTION
**Description**

- updates wizard according to PF4 component (however, it isn't using the component!)

**Props**

| Props  | Type | Default |  Decription |
| ------------- | ------------- | ------------- | ------------- |
| fields  | array  |   |   |
| isCompactNav  | bool  |   |  |
| setFullWidth  | bool  |   |   |
| setFullHeight  | bool  |   |   |
| isDynamic  | bool  |   |  |
| title  | node  |   |   |
| buttonsClassName  | string  |   |   |
| buttonLabels | object  |   |   |
| description  | node  |   |  |

**How to do substeps**

Field in Wizard fields should contain `substep` <`string`> which is title of the primary step. Steps with the same substep are combined together in the primary step.

**First step**

First step should have `stepKey: 1`

**Variants of Wizard**

**Simple wizard**

- steps navigation is visible, user can jump back and forward (after visiting the step)
- does not contain any conditional steps
- if you are need to change one step according to another (dynamic fields), do not use this (there is no way how to check which fields was changed), instead of that use **progressive wizard**
- if user change some field and make the form invalid, he cannot jump forward

![simplewizard](https://user-images.githubusercontent.com/32869456/58427234-56725680-809f-11e9-8e22-3ce7286b30d2.gif)

**Progressive wizard**

- steps are visible as user visits them
- user can jump only back

![progressivewizard](https://user-images.githubusercontent.com/32869456/58427241-5b370a80-809f-11e9-8e79-a4a829b8d181.gif)

TODO
- [x] substep in progressive wizard
- [x] css styling (missing expanded option)
- [x] **tests**
- [x] doc for demo
- [x] demo css issue