### PR TITLE
Fixed MUI mapper externals

### DIFF
--- a/packages/mui-component-mapper/config/webpack.config.js
+++ b/packages/mui-component-mapper/config/webpack.config.js
@@ -1,4 +1,3 @@
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const resolve = require('path').resolve;
@@ -39,9 +38,16 @@ const devConfig = {
   plugins: [ htmlPlugin ],
 };
 
-const externals = {
-  react: 'react',
-};
+const externals = [{
+  react: {
+    root: 'React',
+    commonjs2: 'react',
+    commonjs: [ 'react' ],
+    amd: 'react',
+  },
+},
+/@material-ui\/core\/.*/,
+];
 
 const prodConfig = {
   mode: 'production',
@@ -51,20 +57,6 @@ const prodConfig = {
     library: '[name]',
     libraryTarget: 'umd',
     filename: 'index.js',
-  },
-  optimization: {
-    minimizer: [
-      new UglifyJsPlugin({
-        uglifyOptions: {
-          warnings: 'verbose',
-          mangle: false,
-          toplevel: false,
-          nameCache: null,
-          ie8: false,
-          keep_fnames: true,
-        },
-      }),
-    ],
   },
   externals,
 };


### PR DESCRIPTION
Externals for MUI package was not configured properly. It was causing styling overrides when used in consumer app.

