### PR TITLE
fix(renderer): added formSpy option to export form state.

### DIFF
--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -21,6 +21,7 @@ const App = () => (
             uiSchema={uiArraySchema}
             buttonOrder={['cancel', 'reset', 'submit']}
             buttonClassName="Foo"
+            onStateUpdate={console.log}
         />
     </div>
 )

--- a/packages/react-form-renderer/src/form-renderer/index.js
+++ b/packages/react-form-renderer/src/form-renderer/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form } from 'react-final-form';
+import { Form, FormSpy } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
 import PropTypes from 'prop-types';
 import createFocusDecorator from 'final-form-focus';
@@ -41,6 +41,7 @@ const FormRenderer = ({
   buttonClassName,
   clearOnUnmount,
   validate,
+  onStateUpdate,
 }) => {
   const inputSchema = schemaMapper(schemaType)(schema, uiSchema);
   let schemaError;
@@ -107,6 +108,7 @@ const FormRenderer = ({
                   disableSubmit: isDisabled(disableSubmit, getState),
                   ...buttonsLabels,
                 }) }
+                { onStateUpdate && <FormSpy onChange={ onStateUpdate } /> }
               </FormWrapper>
             ) }
           </RendererContext.Consumer>
@@ -134,6 +136,7 @@ FormRenderer.propTypes = {
   buttonClassName: PropTypes.string,
   clearOnUnmount: PropTypes.bool,
   validate: PropTypes.func,
+  onStateUpdate: PropTypes.func,
 };
 
 FormRenderer.defaultProps = {

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import { Form } from 'react-final-form';
+import { Form, FormSpy } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
 import renderForm from '../../form-renderer/render-form';
 import RendererContext, { configureContext } from '../../form-renderer/renderer-context';
@@ -17,7 +17,7 @@ describe('renderForm function', () => {
       formOptions: {
         renderForm,
         ...props.formOptions,
-      }
+      },
     }) }>
       <Form onSubmit={ jest.fn() } mutators={{ ...arrayMutators }}>
         { () =>  children }
@@ -546,5 +546,35 @@ describe('renderForm function', () => {
       wrapper.update();
       expect(wrapper.find(Form).instance().form.getState().values.foocon).toEqual(undefined);
     });
+  });
+
+  describe('#formSpy', () => {
+    const TextField = ({ input, meta, label, formOptions, helperText, isRequired, dataType, isDisabled, isReadOnly, ...rest }) => (
+      <div>
+        <label>{ label }</label>
+        <input { ...input } { ...rest } />
+        { meta.error && <div><span>{ meta.error }</span></div> }
+      </div>
+    );
+    it('should add formSpy and call update function on each state change', () => {
+      const onStateUpdate = jest.fn();
+      const wrapper = mount(
+        <FormRenderer
+          onStateUpdate={ onStateUpdate }
+          layoutMapper={ layoutMapper }
+          formFieldsMapper={{
+            [components.TEXT_FIELD]: TextField,
+          }}
+          schema={{ fields: [{ component: components.TEXT_FIELD, name: 'foo', label: 'bar' }]}}
+          onSubmit={ jest.fn() }
+          clearOnUnmount
+        />
+      );
+      expect(wrapper.find(FormSpy)).toHaveLength(1);
+      wrapper.find('input').first().simulate('change', { target: { value: 'bar' }});
+      wrapper.find('input').last().simulate('change', { target: { value: 'foovalue' }});
+      expect(onStateUpdate).toHaveBeenCalledTimes(3);
+    });
+
   });
 });


### PR DESCRIPTION
solves: #50 

@rvsia we should add this prop to the document renderer API issue.

### Changes
- allows adding a callback which is triggered on every state update and sends the form state as an argument.