### PR TITLE
Data types feature

### DIFF
--- a/__mocks__/mock-layout-mapper.js
+++ b/__mocks__/mock-layout-mapper.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { layoutComponents } from "../packages/react-form-renderer/src/constants";
+
+export const layoutMapper = {
+  [layoutComponents.FORM_WRAPPER]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.BUTTON]: ({ label, ...rest }) =>  <button { ...rest }>{ label }</button>,
+  [layoutComponents.COL]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.FORM_GROUP]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.BUTTON_GROUP]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.ICON]: props => <div>Icon</div>,
+  [layoutComponents.ARRAY_FIELD_WRAPPER]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.HELP_BLOCK]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.TITLE]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.DESCRIPTION]: ({ children }) => <div>{ children }</div>,
+};

--- a/packages/react-form-renderer/src/constants/index.js
+++ b/packages/react-form-renderer/src/constants/index.js
@@ -71,5 +71,5 @@ export const dataTypes = {
   FLOAT: 'float',
   NUMBER: 'number',
   BOOLEAN: 'boolean',
-  STRING: 'stirng',
+  STRING: 'string',
 };

--- a/packages/react-form-renderer/src/constants/index.js
+++ b/packages/react-form-renderer/src/constants/index.js
@@ -62,3 +62,14 @@ export const layoutComponents = {
   TITLE: 'Title',
   DESCRIPTION: 'Description',
 };
+
+/**
+ * @enum {String}
+ */
+export const dataTypes = {
+  INTEGER: 'integer',
+  FLOAT: 'float',
+  NUMBER: 'number',
+  BOOLEAN: 'boolean',
+  STRING: 'stirng',
+};

--- a/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
+++ b/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
@@ -1,0 +1,45 @@
+import { dataTypes } from '../constants';
+
+/**
+ * Pick a value from event object and returns it
+ * @param {Object|Any} event event value returned from form field
+ */
+const sanytyzeValue = event =>
+  (typeof event === 'object' && event.target && event.target.value)
+    ? event.target.value
+    : event;
+
+/**
+ * Casts string true/false to boolean
+ * @param {String} value value
+ */
+const castToBoolean = value => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return value === 'true';
+};
+
+/**
+ * Changes the value type
+ * @param {FieldDataTypes} dataType type for value conversion
+ * @param {Any} value value to be converted
+ */
+const convertType = (dataType, value) => ({
+  [dataTypes.INTEGER]: !isNaN(Number(value)) && parseInt(value),
+  [dataTypes.FLOAT]: !isNaN(Number(value)) && parseFloat(value),
+  [dataTypes.NUMBER]: Number(value),
+  [dataTypes.BOOLEAN]: castToBoolean(value),
+})[dataType] || value;
+
+/**
+ * Casts input value into selected data type
+ * @param {FieldDataTypes} dataType intended data type of output value
+ * @param {Function} onChange original function to be modified
+ * @param {Any} value value to be type casted
+ * @param  {...any} args rest of orininal function arguments
+ */
+const enhancedOnChange = (dataType, onChange, value, ...args) => onChange(convertType(dataType, sanytyzeValue(value)), ...args);
+
+export default enhancedOnChange;

--- a/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
+++ b/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
@@ -4,7 +4,7 @@ import { dataTypes } from '../constants';
  * Pick a value from event object and returns it
  * @param {Object|Any} event event value returned from form field
  */
-const sanytyzeValue = event =>
+const sanitizeValue = event =>
   (typeof event === 'object' && event.target && event.target.value)
     ? event.target.value
     : event;
@@ -40,6 +40,6 @@ const convertType = (dataType, value) => ({
  * @param {Any} value value to be type casted
  * @param  {...any} args rest of orininal function arguments
  */
-const enhancedOnChange = (dataType, onChange, value, ...args) => onChange(convertType(dataType, sanytyzeValue(value)), ...args);
+const enhancedOnChange = (dataType, onChange, value, ...args) => onChange(convertType(dataType, sanitizeValue(value)), ...args);
 
 export default enhancedOnChange;

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -41,7 +41,6 @@ const prepareValidator = (validator) => ((typeof validator === 'function')
 
 const prepareFieldProps = field => ({
   ...field,
-  dataType: undefined,
   validate: field.validate
     ? [
       ...field.validate.map((validator) => prepareValidator(validator)),

--- a/packages/react-form-renderer/src/index.js
+++ b/packages/react-form-renderer/src/index.js
@@ -2,7 +2,7 @@ import mozillaParser from './parsers/mozilla-parser/mozilla-schema-parser';
 import miqParser from './parsers/miq-parser/miq-parser';
 
 export { default } from './form-renderer/';
-export { components as componentTypes, layoutComponents, validators as validatorTypes } from './constants';
+export { components as componentTypes, layoutComponents, validators as validatorTypes, dataTypes } from './constants';
 export { composeValidators } from './form-renderer/helpers';
 export { default as Validators } from './validators/validators';
 export { default as defaultSchemaValidator } from './parsers/default-schema-validator';

--- a/packages/react-form-renderer/src/parsers/default-schema-validator.js
+++ b/packages/react-form-renderer/src/parsers/default-schema-validator.js
@@ -1,6 +1,6 @@
 import DefaultSchemaError from './schema-errors';
 import isValidComponent from './isValidComponent';
-import { validators, components } from '../constants';
+import { validators, components, dataTypes } from '../constants';
 
 const componentBlackList = [ components.FIELD_ARRAY, components.FIXED_LIST, 'tab-item' ];
 
@@ -94,6 +94,22 @@ const checkValidators = (validate, fieldName) => {
   });
 };
 
+const checkDataType = (type, fieldName) => {
+  if (typeof type !== 'string') {
+    throw new DefaultSchemaError(`
+    Error occured in field definition with name: "${fieldName}".
+    Unknow dataType. Data type must be string
+    `);
+  }
+
+  if (!Object.values(dataTypes).includes(type)) {
+    throw new DefaultSchemaError(`
+    Error occured in field definition with name: "${fieldName}".
+    Unknow dataType ${type}. Must be one these values: ${Object.values(dataTypes)}
+    `);
+  }
+};
+
 const iterateOverFields = (fields, formFieldsMapper, layoutMapper, parent = {}) => {
   fields.forEach(field => {
     if (Array.isArray(field)) {
@@ -129,6 +145,10 @@ const iterateOverFields = (fields, formFieldsMapper, layoutMapper, parent = {}) 
 
     if (field.hasOwnProperty('validate')) {
       checkValidators(field.validate, field.name);
+    }
+
+    if (field.hasOwnProperty('dataType')) {
+      checkDataType(field.dataType, field.name);
     }
 
     if (field.hasOwnProperty('fields')) {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/array-form-component.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/array-form-component.test.js.snap
@@ -224,7 +224,6 @@ exports[`renderForm function should render array field correctly 1`] = `
                 <ReactFinalForm(Field)
                   FieldProvider={[Function]}
                   arrayValidator={[Function]}
-                  component={[Function]}
                   fields={
                     Array [
                       Object {
@@ -276,11 +275,11 @@ exports[`renderForm function should render array field correctly 1`] = `
                   }
                   hasFixedItems={false}
                   name="foo"
+                  render={[Function]}
                 >
                   <Field
                     FieldProvider={[Function]}
                     arrayValidator={[Function]}
-                    component={[Function]}
                     fields={
                       Array [
                         Object {
@@ -369,6 +368,7 @@ exports[`renderForm function should render array field correctly 1`] = `
                         "subscribe": [Function],
                       }
                     }
+                    render={[Function]}
                   >
                     <Component
                       FieldProvider={[Function]}
@@ -1090,7 +1090,6 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                     }
                   }
                   arrayValidator={[Function]}
-                  component={[Function]}
                   description="description"
                   fields={
                     Array [
@@ -1143,6 +1142,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                   }
                   hasFixedItems={true}
                   name="foo"
+                  render={[Function]}
                   title="Title"
                 >
                   <Field
@@ -1156,7 +1156,6 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                       }
                     }
                     arrayValidator={[Function]}
-                    component={[Function]}
                     description="description"
                     fields={
                       Array [
@@ -1246,6 +1245,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                         "subscribe": [Function],
                       }
                     }
+                    render={[Function]}
                     title="Title"
                   >
                     <Component
@@ -1652,7 +1652,6 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                               >
                                 <ReactFinalForm(Field)
                                   FieldProvider={[Function]}
-                                  component={[Function]}
                                   formOptions={
                                     Object {
                                       "batch": [Function],
@@ -1695,11 +1694,11 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                                   }
                                   label="foo"
                                   name="nested component"
+                                  render={[Function]}
                                   validate={[Function]}
                                 >
                                   <Field
                                     FieldProvider={[Function]}
-                                    component={[Function]}
                                     formOptions={
                                       Object {
                                         "batch": [Function],
@@ -1779,6 +1778,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                                         "subscribe": [Function],
                                       }
                                     }
+                                    render={[Function]}
                                     validate={[Function]}
                                   >
                                     <Component
@@ -1967,7 +1967,6 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                               >
                                 <ReactFinalForm(Field)
                                   FieldProvider={[Function]}
-                                  component={[Function]}
                                   fields={Array []}
                                   formOptions={
                                     Object {
@@ -2010,11 +2009,11 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                                     }
                                   }
                                   name="foo"
+                                  render={[Function]}
                                   validate={[Function]}
                                 >
                                   <Field
                                     FieldProvider={[Function]}
-                                    component={[Function]}
                                     fields={Array []}
                                     formOptions={
                                       Object {
@@ -2094,6 +2093,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                                         "subscribe": [Function],
                                       }
                                     }
+                                    render={[Function]}
                                     validate={[Function]}
                                   >
                                     <Component

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -851,6 +851,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             autoFocus={false}
             component={[Function]}
             componentType="text-field"
+            dataType="string"
             default="I'm a hidden string."
             formOptions={
               Object {
@@ -905,6 +906,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
+              dataType="string"
               default="I'm a hidden string."
               formOptions={
                 Object {
@@ -954,7 +956,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
-                component={[Function]}
                 default="I'm a hidden string."
                 formOptions={
                   Object {
@@ -998,13 +999,13 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 }
                 label="secret"
                 name="secret"
+                render={[Function]}
                 type="text"
                 validate={[Function]}
               >
                 <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
-                  component={[Function]}
                   default="I'm a hidden string."
                   formOptions={
                     Object {
@@ -1085,6 +1086,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "subscribe": [Function],
                     }
                   }
+                  render={[Function]}
                   type="text"
                   validate={[Function]}
                 >
@@ -1180,6 +1182,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             autoFocus={false}
             component={[Function]}
             componentType="text-field"
+            dataType="string"
             default="I am disabled."
             formOptions={
               Object {
@@ -1235,6 +1238,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
+              dataType="string"
               default="I am disabled."
               formOptions={
                 Object {
@@ -1285,7 +1289,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
-                component={[Function]}
                 default="I am disabled."
                 formOptions={
                   Object {
@@ -1329,6 +1332,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 }
                 label="A disabled field"
                 name="disabled"
+                render={[Function]}
                 title="A disabled field"
                 type="text"
                 validate={[Function]}
@@ -1336,7 +1340,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
-                  component={[Function]}
                   default="I am disabled."
                   formOptions={
                     Object {
@@ -1417,6 +1420,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "subscribe": [Function],
                     }
                   }
+                  render={[Function]}
                   title="A disabled field"
                   type="text"
                   validate={[Function]}
@@ -1514,6 +1518,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             autoFocus={false}
             component={[Function]}
             componentType="text-field"
+            dataType="string"
             default="I am read-only."
             formOptions={
               Object {
@@ -1569,6 +1574,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
+              dataType="string"
               default="I am read-only."
               formOptions={
                 Object {
@@ -1619,7 +1625,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
-                component={[Function]}
                 default="I am read-only."
                 formOptions={
                   Object {
@@ -1663,6 +1668,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 }
                 label="A readonly field"
                 name="readonly"
+                render={[Function]}
                 title="A readonly field"
                 type="text"
                 validate={[Function]}
@@ -1670,7 +1676,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
-                  component={[Function]}
                   default="I am read-only."
                   formOptions={
                     Object {
@@ -1751,6 +1756,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "subscribe": [Function],
                     }
                   }
+                  render={[Function]}
                   title="A readonly field"
                   type="text"
                   validate={[Function]}
@@ -1848,6 +1854,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             autoFocus={false}
             component={[Function]}
             componentType="text-field"
+            dataType="string"
             default="I am yellow"
             formOptions={
               Object {
@@ -1903,6 +1910,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
+              dataType="string"
               default="I am yellow"
               formOptions={
                 Object {
@@ -1953,7 +1961,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
-                component={[Function]}
                 default="I am yellow"
                 formOptions={
                   Object {
@@ -1997,6 +2004,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 }
                 label="Custom widget with options"
                 name="widgetOptions"
+                render={[Function]}
                 title="Custom widget with options"
                 type="text"
                 validate={[Function]}
@@ -2004,7 +2012,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
-                  component={[Function]}
                   default="I am yellow"
                   formOptions={
                     Object {
@@ -2085,6 +2092,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "subscribe": [Function],
                     }
                   }
+                  render={[Function]}
                   title="Custom widget with options"
                   type="text"
                   validate={[Function]}
@@ -2182,6 +2190,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             autoFocus={false}
             component={[Function]}
             componentType="select-field"
+            dataType="string"
             formOptions={
               Object {
                 "batch": [Function],
@@ -2252,6 +2261,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
+              dataType="string"
               formOptions={
                 Object {
                   "batch": [Function],
@@ -2317,7 +2327,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
-                component={[Function]}
                 formOptions={
                   Object {
                     "batch": [Function],
@@ -2376,6 +2385,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     },
                   ]
                 }
+                render={[Function]}
                 title="Custom select widget with options"
                 type="string"
                 validate={[Function]}
@@ -2383,7 +2393,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
-                  component={[Function]}
                   formOptions={
                     Object {
                       "batch": [Function],
@@ -2479,6 +2488,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "subscribe": [Function],
                     }
                   }
+                  render={[Function]}
                   title="Custom select widget with options"
                   type="string"
                   validate={[Function]}

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -1559,7 +1559,6 @@ exports[`renderForm function should render array field 1`] = `
           <ReactFinalForm(Field)
             FieldProvider={[Function]}
             arrayValidator={[Function]}
-            component={[Function]}
             fields={Array []}
             formOptions={
               Object {
@@ -1568,11 +1567,11 @@ exports[`renderForm function should render array field 1`] = `
             }
             hasFixedItems={false}
             name="foo"
+            render={[Function]}
           >
             <Field
               FieldProvider={[Function]}
               arrayValidator={[Function]}
-              component={[Function]}
               fields={Array []}
               formOptions={
                 Object {
@@ -1618,6 +1617,7 @@ exports[`renderForm function should render array field 1`] = `
                   "subscribe": [Function],
                 }
               }
+              render={[Function]}
             >
               <Component
                 FieldProvider={[Function]}
@@ -2006,18 +2006,17 @@ exports[`renderForm function should render single field from defined componentTy
         >
           <ReactFinalForm(Field)
             FieldProvider={[Function]}
-            component={[Function]}
             formOptions={
               Object {
                 "renderForm": [Function],
               }
             }
             name="foo"
+            render={[Function]}
             validate={[Function]}
           >
             <Field
               FieldProvider={[Function]}
-              component={[Function]}
               formOptions={
                 Object {
                   "renderForm": [Function],
@@ -2061,6 +2060,7 @@ exports[`renderForm function should render single field from defined componentTy
                   "subscribe": [Function],
                 }
               }
+              render={[Function]}
               validate={[Function]}
             >
               <Component

--- a/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import FormRenderer, { componentTypes } from '../../';
+import { layoutMapper } from '../../../../../__mocks__/mock-layout-mapper';
+
+const DataTypeInput = ({ input, dataType: _dataType, type, label }) => (
+  <div>
+    <label htmlFor={ input.name }>{ label }</label>
+    <input type={ type } id={ input.name } { ...input } />
+  </div>
+);
+
+const PropComponent = ({ FieldProvider, ...props }) => (
+  <FieldProvider component={ DataTypeInput } { ...props } />
+);
+
+const RenderComponent = ({ FieldProvider, ...props }) => (
+  <FieldProvider render={ renderProps => <DataTypeInput { ...renderProps } /> } { ...props } />
+);
+
+const ChildrenComponent = ({ FieldProvider, ...props }) => (
+  <FieldProvider { ...props }>
+    { props => <DataTypeInput { ...props } /> }
+  </FieldProvider>
+);
+
+describe('data types', () => {
+  let initialProps;
+  beforeEach(() => {
+    initialProps = {
+      onSubmit: jest.fn(),
+      layoutMapper,
+      formFieldsMapper: {
+        [componentTypes.TEXT_FIELD]: DataTypeInput,
+        'prop-component': PropComponent,
+        'render-component': RenderComponent,
+        'children-component': ChildrenComponent,
+      },
+      schema: {
+        fields: [{
+          component: componentTypes.TEXT_FIELD,
+          name: 'data-type-text',
+          label: 'Data type test',
+          type: 'text',
+          dataType: 'integer',
+        }],
+      },
+    };
+  });
+
+  it('should add integer data type validator and save interger to form state', () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } />);
+    expect(wrapper.find(DataTypeInput)).toHaveLength(1);
+    const input = wrapper.find('input');
+    /**
+     * should not allow submit
+     * validator should prevent submit if anything else than number is passed to the input
+     */
+    input.simulate('change', { target: { value: 'sadsad' }});
+    wrapper.find('button').first().simulate('click');
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    input.simulate('change', { target: { value: '123' }});
+    wrapper.find('button').first().simulate('click');
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      'data-type-text': 123,
+    }), expect.anything(), expect.anything());
+  });
+
+  it('should correctly add dataType to component which uses component prop', () => {
+    const onSubmit = jest.fn();
+    const propSchema = {
+      fields: [{
+        component: 'prop-component',
+        name: 'data-type-text',
+        label: 'Data type test',
+        type: 'text',
+        dataType: 'integer',
+      }],
+    };
+    const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } schema={ propSchema } />);
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: '123' }});
+    wrapper.find('button').first().simulate('click');
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      'data-type-text': 123,
+    }), expect.anything(), expect.anything());
+  });
+
+  it('should correctly add dataType to component which uses render prop', () => {
+    const onSubmit = jest.fn();
+    const renderSchema = {
+      fields: [{
+        component: 'render-component',
+        name: 'data-type-text',
+        label: 'Data type test',
+        type: 'text',
+        dataType: 'integer',
+      }],
+    };
+    const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } schema={ renderSchema } />);
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: '123' }});
+    wrapper.find('button').first().simulate('click');
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      'data-type-text': 123,
+    }), expect.anything(), expect.anything());
+  });
+
+  it('should correctly add dataType to component which uses children', () => {
+    const onSubmit = jest.fn();
+    const childSchema = {
+      fields: [{
+        component: 'children-component',
+        name: 'data-type-text',
+        label: 'Data type test',
+        type: 'text',
+        dataType: 'integer',
+      }],
+    };
+    const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } schema={ childSchema } />);
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: '123' }});
+    wrapper.find('button').first().simulate('click');
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      'data-type-text': 123,
+    }), expect.anything(), expect.anything());
+  });
+});

--- a/packages/react-form-renderer/src/tests/parsers/__snapshots__/default-schema-validator.test.js.snap
+++ b/packages/react-form-renderer/src/tests/parsers/__snapshots__/default-schema-validator.test.js.snap
@@ -90,3 +90,17 @@ exports[`Default schema validator should fail if input is not a object 1`] = `"F
 exports[`Default schema validator should fail if input object does fields key that is not array 1`] = `"Component of type schema must contain \\"fields\\" property of type array, received type: object!"`;
 
 exports[`Default schema validator should fail if input object does not have fields key 1`] = `"Component of type schema must contain \\"fields\\" property of type array, received undefined!"`;
+
+exports[`Default schema validator should fail validation when using wrong data type 1`] = `
+"
+    Error occured in field definition with name: \\"foo\\".
+    Unknow dataType foo. Must be one these values: integer,float,number,boolean,string
+    "
+`;
+
+exports[`Default schema validator should fail validation when using wrong data type 2`] = `
+"
+    Error occured in field definition with name: \\"foo\\".
+    Unknow dataType. Data type must be string
+    "
+`;

--- a/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
+++ b/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
@@ -141,6 +141,19 @@ describe('Default schema validator', () => {
     }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
   });
 
+  it('should fail validation when using wrong data type', () => {
+    expect(() => defaultSchemaValidator({ fields: [{
+      component: 'foo',
+      name: 'foo',
+      dataType: 'foo',
+    }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
+    expect(() => defaultSchemaValidator({ fields: [{
+      component: 'foo',
+      name: 'foo',
+      dataType: {},
+    }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
+  });
+
   it('should pass validation', () => {
     expect(() => defaultSchemaValidator(output, {
       ...formFieldsMapper, 'sub-form': () => <div />,

--- a/packages/react-form-renderer/src/validators/index.js
+++ b/packages/react-form-renderer/src/validators/index.js
@@ -163,4 +163,7 @@ export const dataTypeValidator = type => ({
   number: options => pattern({
     pattern: /^\d*[.]{0,1}\d*$/, message: 'Values mut be number', ...options,
   }),
+  float: options => pattern({
+    pattern: /^\d*[.]{0,1}\d*$/, message: 'Values mut be number', ...options,
+  }),
 })[type];

--- a/packages/react-form-renderer/src/validators/index.js
+++ b/packages/react-form-renderer/src/validators/index.js
@@ -161,9 +161,9 @@ export const dataTypeValidator = type => ({
   }),
   boolean: options => booleanValidator({ message: 'Field value has to be boolean', ...options }),
   number: options => pattern({
-    pattern: /^\d*[.]{0,1}\d*$/, message: 'Values mut be number', ...options,
+    pattern: /^\d*[.]{0,1}\d*$/, message: 'Values must be number', ...options,
   }),
   float: options => pattern({
-    pattern: /^\d*[.]{0,1}\d*$/, message: 'Values mut be number', ...options,
+    pattern: /^\d*[.]{0,1}\d*$/, message: 'Values must be number', ...options,
   }),
 })[type];

--- a/packages/react-renderer-demo/src/common/doc-texts/validators.js
+++ b/packages/react-renderer-demo/src/common/doc-texts/validators.js
@@ -3,29 +3,6 @@ import ReactMarkdown from '../md-helper';
 import TableOfContent from '../helpers/list-of-content';
 
 const text = `
-You can validate a form by using of \`dataType\` or \`validate\`.
-
-DataTypes is used when you need validate only a data type of a value. For more complicated validators, you have to use validate.
-
-### dataType
-
-You can specify a type of a component by providing \`dataType\`, which will automatically validates the component.
-
-\`\`\`jsx
-{
-  component: 'text-field',
-  name: 'number',
-  type: 'number',
-  label: 'Integer number',
-  dataType: 'integer',
-}
-\`\`\`
-
-Currently, there are four types supported:
-\`\`\`jsx
-['integer', 'number', 'bool', 'string']
-\`\`\`
-
 ### Overwriting default messages
 
 Validators is a singleton. You can change its default messages:

--- a/packages/react-renderer-demo/src/common/documenation-pages.js
+++ b/packages/react-renderer-demo/src/common/documenation-pages.js
@@ -8,6 +8,7 @@ import Validators from './doc-texts/validators';
 import FieldProvider from './doc-texts/field-provider';
 import Unmounting from './doc-texts/unmounting';
 import FormControls from './doc-texts/form-controls';
+import DataTypes from './doc-texts/data-types';
 
 export const docs = [{
   component: 'installation',
@@ -41,6 +42,10 @@ export const docs = [{
   component: 'validators',
   linkText: 'Validators',
   contentText: Validators,
+}, {
+  component: 'data-types',
+  linkText: 'Data types',
+  contentText: DataTypes,
 }, {
   component: 'field-provider',
   linkText: 'FieldProvider',

--- a/packages/react-renderer-demo/src/editor-demo/common/doc-texts/data-types.js
+++ b/packages/react-renderer-demo/src/editor-demo/common/doc-texts/data-types.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import MdxContent from 'docs/components/data-types.md';
+import ListOfContent from '../helpers/list-of-content';
+
+const reqSource = require.context(
+  '!raw-loader!docs/components/',
+  true,
+  /\.md/,
+);
+
+export default (
+  <React.Fragment>
+    <ListOfContent text={ reqSource('./data-types.md').default } />
+    <MdxContent />
+  </React.Fragment>
+);

--- a/packages/react-renderer-demo/src/editor-demo/docs-components/data-types.md
+++ b/packages/react-renderer-demo/src/editor-demo/docs-components/data-types.md
@@ -1,0 +1,13 @@
+import RawComponent from '../common/component/raw-component';
+
+## Introduction
+
+You can specify a type of a component by providing `dataType`, which will automatically validates the component value.
+Because almost everything in html inputs is outputed as a string, adding the `dataType` props will also cast the value to given type.
+
+### Available dataTypes
+
+```jsx
+['integer', 'float', 'number', 'bool', 'string']
+```
+<RawComponent source="data-types/data-types-example" />

--- a/packages/react-renderer-demo/src/editor-demo/docs-components/data-types.md
+++ b/packages/react-renderer-demo/src/editor-demo/docs-components/data-types.md
@@ -8,6 +8,6 @@ Because almost everything in html inputs is outputed as a string, adding the `da
 ### Available dataTypes
 
 ```jsx
-['integer', 'float', 'number', 'bool', 'string']
+['integer', 'float', 'number', 'boolean', 'string']
 ```
 <RawComponent source="data-types/data-types-example" />

--- a/packages/react-renderer-demo/src/editor-demo/docs-components/data-types/data-types-example.js
+++ b/packages/react-renderer-demo/src/editor-demo/docs-components/data-types/data-types-example.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import FormRenderer, { componentTypes, dataTypes } from '@data-driven-forms/react-form-renderer';
+import { layoutMapper, formFieldsMapper } from '@data-driven-forms/pf4-component-mapper';
+import { Title } from '@patternfly/react-core';
+
+const schema = {
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    name: 'typed-number',
+    label: 'Typed number',
+    type: 'number',
+    dataType: dataTypes.FLOAT,
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    name: 'untyped-number',
+    label: 'Number withouth type',
+    type: 'number',
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    name: 'string-as-number',
+    label: 'String as number',
+    type: 'string',
+    dataType: dataTypes.INTEGER,
+  }],
+};
+
+const DataTypesExample = () => {
+  const [ values, setValues ] = useState({});
+  return (
+    <div className="pf4">
+      <FormRenderer
+        layoutMapper={ layoutMapper }
+        formFieldsMapper={ formFieldsMapper }
+        schema={ schema }
+        onSubmit={ console.log }
+        onStateUpdate={ ({ values }) => setValues(values) }
+      />
+      <div style={{ marginTop: 16 }}>
+        <Title size="md">Form values</Title>
+        <pre>
+          { JSON.stringify(values, null, 2) }
+        </pre>
+      </div>
+    </div>
+  );};
+
+export default DataTypesExample;
+


### PR DESCRIPTION
closes: #65 

Adds data types casting to form fields (both default and custom)
- enhances FieldProvider `onChange` function with type casting if the `dataType` prop has been given
- supported data types
  - integer
  - float
  - number
  - boolean
  - string