### PR TITLE
feat(pf4wizard): Allow custom buttons for steps

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -1,4 +1,32 @@
+import React, { useState } from 'react';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { Button } from '@patternfly/react-core';
+
+const ValidateButtons = ({ disableBack, handlePrev, buttonLabels: { back, cancel }, formOptions, renderNextButton }) => {
+  const [ state, setState ] = useState('init');
+
+  const setValidating = () => {
+    setState('validating');
+    setTimeout(() => setState('done'), 2000);
+  };
+
+  return (
+    <React.Fragment>
+      { state === 'init' ? <Button
+        variant="primary"
+        type="button"
+        isDisabled={ !formOptions.valid }
+        onClick={ setValidating }
+      >
+        Validate
+      </Button> :
+        state === 'validating' ? <Button type="button" variant="primary" isDisabled={ true } onClick={ () => {} }>Validating...</Button> :
+          renderNextButton() }
+      <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
+      <Button type="button" variant="link" onClick={ formOptions.onCancel }>{ cancel }</Button>
+    </React.Fragment>
+  );
+};
 
 export const wizardSchema = {
   fields: [{
@@ -48,10 +76,15 @@ export const wizardSchema = {
       stepKey: 'aws',
       substepOf: 'Summary',
       nextStep: 'summary',
+      buttons: ValidateButtons,
       fields: [{
         component: componentTypes.TEXT_FIELD,
         name: 'aws-field',
         label: 'Aws field part',
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+        isRequired: true,
       }],
     }, {
       stepKey: 'google',

--- a/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
@@ -48,16 +48,17 @@ ConditionalNext.propTypes = {
   FieldProvider: PropTypes.func.isRequired,
 };
 
-const submitButton = (handleSubmit, submitLabel) => <Button type="button" variant="primary" onClick={ handleSubmit }>{ submitLabel }</Button>;
+const SubmitButton = ({ handleSubmit, submitLabel }) => <Button type="button" variant="primary" onClick={ handleSubmit }>{ submitLabel }</Button>;
 
 const renderNextButton = ({ nextStep, handleSubmit, submitLabel, ...rest }) =>
   !nextStep
-    ? submitButton(handleSubmit, submitLabel)
+    ? <SubmitButton handleSubmit={ handleSubmit } submitLabel={ submitLabel } />
     : typeof nextStep === 'object'
       ? <ConditionalNext nextStep={ nextStep } { ...rest }/>
       : <SimpleNext next={ nextStep } { ...rest } />;
 
 const WizardStepButtons = ({
+  buttons: Buttons,
   formOptions,
   disableBack,
   handlePrev,
@@ -72,16 +73,40 @@ const WizardStepButtons = ({
     next,
   }}) =>
   <footer className={ `pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}` }>
-    { renderNextButton({
-      ...formOptions,
-      handleNext,
-      nextStep,
-      FieldProvider,
-      nextLabel: next,
-      submitLabel: submit,
-    }) }
-    <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
-    <Button type="button" variant="link" onClick={ formOptions.onCancel }>{ cancel }</Button>
+    { Buttons ? <Buttons
+      ConditionalNext={ ConditionalNext }
+      SubmitButton={ SubmitButton }
+      SimpleNext={ SimpleNext }
+      formOptions={ formOptions }
+      disableBack={ disableBack }
+      handlePrev={ handlePrev }
+      nextStep={ nextStep }
+      FieldProvider={ FieldProvider }
+      handleNext={ handleNext }
+      buttonsClassName={ buttonsClassName }
+      buttonLabels={{ cancel, submit, back, next }}
+      renderNextButton={ args => renderNextButton({
+        ...formOptions,
+        handleNext,
+        nextStep,
+        FieldProvider,
+        nextLabel: next,
+        submitLabel: submit,
+        ...args,
+      }) }
+    />
+      : <React.Fragment>
+        { renderNextButton({
+          ...formOptions,
+          handleNext,
+          nextStep,
+          FieldProvider,
+          nextLabel: next,
+          submitLabel: submit,
+        }) }
+        <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
+        <Button type="button" variant="link" onClick={ formOptions.onCancel }>{ cancel }</Button>
+      </React.Fragment> }
   </footer>;
 
 WizardStepButtons.propTypes = {
@@ -107,6 +132,7 @@ WizardStepButtons.propTypes = {
     next: PropTypes.string.isRequired,
   }).isRequired,
   buttonsClassName: PropTypes.string,
+  buttons: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
 };
 
 export default WizardStepButtons;

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/step-buttons.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/step-buttons.test.js.snap
@@ -4,13 +4,10 @@ exports[`<WizardSTepButtons should add custom className to toolbar 1`] = `
 <footer
   className="pf-c-wizard__footer foo-class"
 >
-  <Button
-    onClick={[MockFunction]}
-    type="button"
-    variant="primary"
-  >
-    Submit
-  </Button>
+  <SubmitButton
+    handleSubmit={[MockFunction]}
+    submitLabel="Submit"
+  />
   <Button
     onClick={[MockFunction]}
     type="button"
@@ -32,13 +29,10 @@ exports[`<WizardSTepButtons should render correctly 1`] = `
 <footer
   className="pf-c-wizard__footer "
 >
-  <Button
-    onClick={[MockFunction]}
-    type="button"
-    variant="primary"
-  >
-    Submit
-  </Button>
+  <SubmitButton
+    handleSubmit={[MockFunction]}
+    submitLabel="Submit"
+  />
   <Button
     onClick={[MockFunction]}
     type="button"

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -240,23 +240,28 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
               <footer
                 className="pf-c-wizard__footer "
               >
-                <Button
-                  onClick={[Function]}
-                  type="button"
-                  variant="primary"
+                <SubmitButton
+                  handleSubmit={[Function]}
+                  submitLabel="Submit"
                 >
-                  <button
-                    aria-disabled={null}
-                    aria-label={null}
-                    className="pf-c-button pf-m-primary"
-                    disabled={false}
+                  <Button
                     onClick={[Function]}
-                    tabIndex={null}
                     type="button"
+                    variant="primary"
                   >
-                    Submit
-                  </button>
-                </Button>
+                    <button
+                      aria-disabled={null}
+                      aria-label={null}
+                      className="pf-c-button pf-m-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={null}
+                      type="button"
+                    >
+                      Submit
+                    </button>
+                  </Button>
+                </SubmitButton>
                 <Button
                   isDisabled={true}
                   onClick={[Function]}
@@ -773,23 +778,28 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                         <footer
                           className="pf-c-wizard__footer "
                         >
-                          <Button
-                            onClick={[Function]}
-                            type="button"
-                            variant="primary"
+                          <SubmitButton
+                            handleSubmit={[Function]}
+                            submitLabel="Submit"
                           >
-                            <button
-                              aria-disabled={null}
-                              aria-label={null}
-                              className="pf-c-button pf-m-primary"
-                              disabled={false}
+                            <Button
                               onClick={[Function]}
-                              tabIndex={null}
                               type="button"
+                              variant="primary"
                             >
-                              Submit
-                            </button>
-                          </Button>
+                              <button
+                                aria-disabled={null}
+                                aria-label={null}
+                                className="pf-c-button pf-m-primary"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={null}
+                                type="button"
+                              >
+                                Submit
+                              </button>
+                            </Button>
+                          </SubmitButton>
                           <Button
                             isDisabled={true}
                             onClick={[Function]}
@@ -1118,23 +1128,28 @@ exports[`<Wizard /> should render correctly with custom title and description 1`
               <footer
                 className="pf-c-wizard__footer "
               >
-                <Button
-                  onClick={[Function]}
-                  type="button"
-                  variant="primary"
+                <SubmitButton
+                  handleSubmit={[Function]}
+                  submitLabel="Submit"
                 >
-                  <button
-                    aria-disabled={null}
-                    aria-label={null}
-                    className="pf-c-button pf-m-primary"
-                    disabled={false}
+                  <Button
                     onClick={[Function]}
-                    tabIndex={null}
                     type="button"
+                    variant="primary"
                   >
-                    Submit
-                  </button>
-                </Button>
+                    <button
+                      aria-disabled={null}
+                      aria-label={null}
+                      className="pf-c-button pf-m-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={null}
+                      type="button"
+                    >
+                      Submit
+                    </button>
+                  </Button>
+                </SubmitButton>
                 <Button
                   isDisabled={true}
                   onClick={[Function]}

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -124,6 +124,22 @@ describe('<Wizard />', () => {
     expect(toJSon(wrapper)).toMatchSnapshot();
   });
 
+  it('should render correctly with custom buttons', () => {
+    const Buttons = () => <div>Hello</div>;
+
+    const wrapper = mount(<Wizard { ...initialProps } fields={ [{
+      title: 'foo-step',
+      stepKey: '1',
+      name: 'foo',
+      buttons: Buttons,
+      fields: [{
+        name: 'foo-field',
+      }],
+      nextStep: '2',
+    }] }/>);
+    expect(wrapper.find(Buttons).length).toEqual(1);
+  });
+
   it('should call submit function', () => {
     const onSubmit = jest.fn();
     const wrapper = mount(<Wizard { ...initialProps } formOptions={{ ...initialProps.formOptions, onSubmit }} />);

--- a/packages/react-renderer-demo/src/docs-components/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/docs-components/pf4-wizard.md
@@ -43,7 +43,8 @@ You can rewrite only selection of them, e.g.
 | nextStep  | object/stepKey of next step | See below |
 | fields  | array | As usual |
 | substep | string | Substep title (steps are grouped by this title) |
-| title | string | Step title
+| title | string | Step title |
+| buttons | node, func | Custom buttons component
 
 - nextStep can be stepKey of the next step
 - or you can branch the way by using of object:
@@ -58,6 +59,41 @@ nextStep: {
         },
 },
 ```
+
+#### Buttons
+
+Each step can implement its own buttons.
+
+```jsx
+const Buttons = () => <div>Hello</div>;
+
+[{
+  title: 'foo-step',
+  stepKey: '1',
+  name: 'foo',
+  buttons: Buttons,
+  fields: [{
+   name: 'foo-field',
+  }],
+}]
+```
+
+The components receives these props:
+
+|Props|Decription|
+| --- | -------- |
+|ConditionalNext|Conditional next button|
+|SubmitButton|Default submit button.|
+|SimpleNext|Default next button.|
+|formOptions|formOptions|
+|disableBack|If it's first step, disable back is true.|
+|handlePrev|Function to handle back button.|
+|nextStep|Next step field from the schema.|
+|FieldProvider|FieldProvider|
+|handleNext|Function to handle next click.|
+|buttonsClassName|Classname of buttons.|
+|buttonLabels|Object with labels.|
+|renderNextButton|Function which completely handle the next/submit button.|
 
 
 ### How to do substeps


### PR DESCRIPTION
**Description**

Allow to use custom buttons components for each step (and the component is provided with all parts to be able to implement its own buttons)

**Schema**

```jsx
const Buttons = () => <div>Hello</div>;

[{
  title: 'foo-step',
  stepKey: '1',
  name: 'foo',
  buttons: Buttons,
  fields: [{
   name: 'foo-field',
  }],
  nextStep: '2',
}]
```

It will allow to do crazy things like this:

![pf4wiz](https://user-images.githubusercontent.com/32869456/64350035-46500880-cff8-11e9-99a4-d76de8bb51ef.gif)

TODO
- [x] Doc