### PR TITLE
fix(pf3): async options reload

### DIFF
--- a/packages/pf3-component-mapper/src/form-fields/select/index.js
+++ b/packages/pf3-component-mapper/src/form-fields/select/index.js
@@ -5,7 +5,7 @@ import customStyles from './select-styles';
 import isEqual from 'lodash/isEqual';
 import './react-select.scss';
 
-const prepareFunction = (fn = '') => fn.toString().replace(/\s+/g, ' ');
+const fnToString = (fn = '') => fn.toString().replace(/\s+/g, ' ');
 
 const ValueContainer = ({ children, ...props }) => {
   if (props.isMulti) {
@@ -41,10 +41,16 @@ class Select extends Component {
     this.setState({ isLoading: true });
 
     return loadOptions()
-    .then((data) => this.setState({
-      options: data,
-      isLoading: false,
-    }));
+    .then((data) => {
+      if (!data.map(({ value }) => value).includes(this.props.input.value)) {
+        this.props.input.onChange(undefined);
+      }
+
+      return this.setState({
+        options: data,
+        isLoading: false,
+      });
+    });
   }
 
   componentDidMount(){
@@ -57,10 +63,14 @@ class Select extends Component {
 
   componentDidUpdate(prevProps) {
     if (!isEqual(this.props.options, prevProps.options)) {
+      if (!this.props.options.map(({ value }) => value).includes(this.props.input.value)) {
+        this.props.input.onChange(undefined);
+      }
+
       this.setState({ options: this.props.options });
     }
 
-    if (this.props.loadOptions && prepareFunction(this.props.loadOptions) !== prepareFunction(prevProps.loadOptions)){
+    if (this.props.loadOptions && fnToString(this.props.loadOptions) !== fnToString(prevProps.loadOptions)){
       return this.updateOptions();
     }
   }

--- a/packages/pf3-component-mapper/src/tests/form-fields/select.test.js
+++ b/packages/pf3-component-mapper/src/tests/form-fields/select.test.js
@@ -4,6 +4,7 @@ import { SelectField } from '../../form-fields/form-fields';
 import SelectPF3 from '../../form-fields/select/index';
 import { mount } from 'enzyme';
 import Select from 'react-select';
+import isEqual from 'lodash/isEqual';
 
 describe('<SelectField />', () => {
   let initialProps;
@@ -82,5 +83,46 @@ describe('<SelectField />', () => {
       [{ value: 2, label: 'x' }, { value: 1, label: 'a' }],
     );
     expect(changeSpy).toHaveBeenCalledWith([ 2, 1 ]);
+  });
+
+  it('should change the options when options prop is changed', () => {
+    const wrapper = mount(<SelectField { ...initialProps } />);
+
+    let innerSelectProps = wrapper.find(Select).props().options;
+
+    expect(isEqual(innerSelectProps, initialProps.options)).toEqual(true);
+
+    const NEW_OPTIONS = [{ label: 'Different label', value: 'Different value' }];
+    wrapper.setProps({ options: NEW_OPTIONS });
+    wrapper.update();
+    innerSelectProps = wrapper.find(Select).props().options;
+
+    expect(isEqual(innerSelectProps, NEW_OPTIONS)).toEqual(true);
+  });
+
+  it.only('should change the options when loadOptions prop is changed', (done) => {
+    const INITIAL_OPTIONS = [{ label: 'asyncLabel' }];
+    const asyncLoading = () => Promise.resolve(INITIAL_OPTIONS);
+    const wrapper = mount(<SelectField { ...initialProps } loadOptions={ asyncLoading }/>);
+
+    setImmediate(() => {
+      wrapper.update();
+      let innerSelectProps = wrapper.find(Select).props().options;
+
+      expect(isEqual(innerSelectProps, INITIAL_OPTIONS)).toEqual(true);
+
+      const NEW_OPTIONS = [{ label: 'Different label', value: 'Different value' }];
+      const asyncLoadingNew = () => Promise.resolve(NEW_OPTIONS);
+
+      wrapper.setProps({ loadOptions: asyncLoadingNew });
+
+      setImmediate(() => {
+        wrapper.update();
+        innerSelectProps = wrapper.find(Select).props().options;
+
+        expect(isEqual(innerSelectProps, NEW_OPTIONS)).toEqual(true);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
**Description**

Fixes re-loading when `options`, `loadOptions` are changed (and clears the input value if the new options do not include the value)

**After**
![loadOptions](https://user-images.githubusercontent.com/32869456/66563404-fec01d80-eb5d-11e9-82c7-32ed89055873.gif)
