### PR TITLE
feat(pf4wizard): show titles

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -34,6 +34,7 @@ export const wizardSchema = {
     name: 'wizzard',
     //inModal: true,
     title: 'Title',
+    showTitles: true,
     description: 'Description',
     buttonsPosition: 'left',
     fields: [{
@@ -91,6 +92,7 @@ export const wizardSchema = {
       title: 'Configure google',
       name: 'step-3',
       nextStep: 'summary',
+      showTitle: false,
       fields: [{
         component: componentTypes.TEXT_FIELD,
         name: 'google.google-field',
@@ -162,6 +164,7 @@ export const wizardSchemaSubsteps = {
     buttonsPosition: 'left',
     fields: [{
       title: 'Get started with adding source',
+      showTitle: true,
       name: 'step-1',
       stepKey: 1,
       nextStep: 'aws',

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-step.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-step.js
@@ -1,19 +1,30 @@
 import React, { Fragment } from 'react';
-import { WizardBody } from '@patternfly/react-core';
+import { WizardBody, Title } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import WizardStepButtons from './step-buttons';
+
+export const RenderTitle = ({ title, customTitle }) => customTitle ? customTitle : <Title headingLevel="h1" size="xl">{ title }</Title>;
+
+RenderTitle.propTypes = {
+  title: PropTypes.node,
+  customTitle: PropTypes.node,
+};
 
 const WizardStep = ({
   title,
   description,
   fields,
   formOptions,
+  showTitles,
+  showTitle,
+  customTitle,
   ...rest
 }) => {
   return (
     <Fragment>
       <WizardBody hasBodyPadding={ true }>
         <div className="pf-c-form">
+          { ((showTitles && showTitle !== false) || showTitle) && <RenderTitle title={ title } customTitle={ customTitle } /> }
           { fields.map(item => formOptions.renderForm([ item ], formOptions)) }
         </div>
       </WizardBody>
@@ -26,12 +37,15 @@ const WizardStep = ({
 };
 
 WizardStep.propTypes = {
-  title: PropTypes.string,
-  description: PropTypes.string,
+  title: PropTypes.node,
+  description: PropTypes.node,
   fields: PropTypes.array.isRequired,
   formOptions: PropTypes.shape({
     renderForm: PropTypes.func.isRequired,
   }).isRequired,
+  showTitles: PropTypes.bool,
+  showTitle: PropTypes.bool,
+  customTitle: PropTypes.node,
 };
 
 export default WizardStep;

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
@@ -161,7 +161,7 @@ class Wizard extends React.Component {
     }
 
     const {
-      title, description, FieldProvider, formOptions, buttonLabels, buttonsClassName, inModal, setFullWidth, setFullHeight, isCompactNav,
+      title, description, FieldProvider, formOptions, buttonLabels, buttonsClassName, inModal, setFullWidth, setFullHeight, isCompactNav, showTitles,
     } = this.props;
     const { activeStepIndex, navSchema, maxStepIndex } = this.state;
 
@@ -184,6 +184,7 @@ class Wizard extends React.Component {
         buttonLabels={ buttonLabels }
         FieldProvider={ FieldProvider }
         buttonsClassName={ buttonsClassName }
+        showTitles={ showTitles }
       />);
 
     const createStepsMap = () => navSchema
@@ -266,6 +267,7 @@ Wizard.propTypes = {
   setFullWidth: PropTypes.bool,
   setFullHeight: PropTypes.bool,
   isDynamic: PropTypes.bool,
+  showTitles: PropTypes.bool,
 };
 
 const defaultLabels = {

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard-step.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard-step.test.js.snap
@@ -76,7 +76,7 @@ exports[`<WizardStep /> should render custom description 1`] = `
 </Fragment>
 `;
 
-exports[`<WizardStep /> should render custom title 1`] = `
+exports[`<WizardStep /> should render title with showTitle 1`] = `
 <Fragment>
   <WizardBody
     hasBodyPadding={true}
@@ -84,6 +84,13 @@ exports[`<WizardStep /> should render custom title 1`] = `
     <div
       className="pf-c-form"
     >
+      <RenderTitle
+        title={
+          <div>
+            title
+          </div>
+        }
+      />
       <div
         key="foo"
       >

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard-step.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard-step.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 
-import WizardStep from '../../form-fields/wizard/wizard-step';
+import WizardStep, { RenderTitle } from '../../form-fields/wizard/wizard-step';
 import FieldProvider from '../../../../../__mocks__/mock-field-provider';
 
 describe('<WizardStep />', () => {
@@ -32,15 +32,48 @@ describe('<WizardStep />', () => {
   it('should render correctly', () => {
     const wrapper = shallow(<WizardStep  { ...initialProps }/>);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('RenderTitle')).toHaveLength(0);
   });
 
-  it('should render custom title', () => {
-    const wrapper = shallow(<WizardStep  { ...initialProps } title={ <div>title</div> }/>);
+  it('should render title with showTitle', () => {
+    const wrapper = shallow(<WizardStep  { ...initialProps } showTitle title={ <div>title</div> }/>);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('RenderTitle')).toHaveLength(1);
+  });
+
+  it('should render title with showTitles', () => {
+    const wrapper = shallow(<WizardStep  { ...initialProps } showTitles title={ <div>title</div> }/>);
+    expect(wrapper.find('RenderTitle')).toHaveLength(1);
+  });
+
+  it('should not render title with showTitles and showTitle = false', () => {
+    const wrapper = shallow(<WizardStep  { ...initialProps } showTitles showTitle={ false } title={ <div>title</div> }/>);
+    expect(wrapper.find('RenderTitle')).toHaveLength(0);
   });
 
   it('should render custom description', () => {
     const wrapper = shallow(<WizardStep  { ...initialProps } description={ <div>description</div> }/>);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  describe('<RenderTitle />', () => {
+    const TITLE = 'I am a title';
+    const CUSTOM_TITLE = 'Custom title';
+    const CustomTitle = <h3>{ CUSTOM_TITLE }</h3>;
+
+    it('should render title', () => {
+      const wrapper = shallow(<RenderTitle title={ TITLE }/>);
+
+      expect(wrapper.find('Title')).toHaveLength(1);
+      expect(wrapper.find('Title').html().includes(TITLE)).toEqual(true);
+    });
+
+    it('should render custom title', () => {
+      const wrapper = mount(<RenderTitle title={ TITLE } customTitle={ CustomTitle }/>);
+
+      expect(wrapper.find('Title')).toHaveLength(0);
+      expect(wrapper.find('h3')).toHaveLength(1);
+      expect(wrapper.find('h3').html().includes(CUSTOM_TITLE)).toEqual(true);
+    });
   });
 });

--- a/packages/react-renderer-demo/src/docs-components/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/docs-components/pf4-wizard.md
@@ -14,6 +14,7 @@ Don't forget hide form controls by settinng \`showFormControls\` to \`false\` as
 | setFullWidth  | bool  | undefined  | see Patternfly  |
 | setFullHeight  | bool  | undefined  | see Patternfly  |
 | isDynamic  | bool  | undefined  | will dynamically generate steps navigation (=progressive wizard), please use if you use any condition fields which changes any field in other steps (wizards with conditional steps are dynamic by default) |
+|showTitles|bool|undefined|If true, step titles will be shown in the wizard body|
 
 ### Default buttonLabels
 
@@ -44,7 +45,10 @@ You can rewrite only selection of them, e.g.
 | fields  | array | As usual |
 | substep | string | Substep title (steps are grouped by this title) |
 | title | string | Step title |
-| buttons | node, func | Custom buttons component
+| buttons | node, func | Custom buttons component|
+|showTitle|bool|If true, step titles will (not if false) be shown in the wizard body|
+|Custom title|node|Use if you want to render as the title different/custom title (for example, title with a popover|
+
 
 - nextStep can be stepKey of the next step
 - or you can branch the way by using of object:


### PR DESCRIPTION
closes https://github.com/data-driven-forms/react-forms/issues/151

**Description**

Adds these:

### Wizard props

| Prop  | Type | Default |  Decription |
| ------------- | ------------- | ------------- | ------------- |
|showTitles|bool|undefined|If true, step titles will be shown in the wizard body|

### Wizard step

| Props  | Type  |  Decription |
| ------------- | ------------- | ------------- |
|showTitle|bool|If true, step titles will (not if false) be shown in the wizard body|
|Custom title|node|Use if you want to render as the title different/custom title (for example, title with a popover|

![image](https://user-images.githubusercontent.com/32869456/66650950-208ad480-ec32-11e9-84a9-36df03df4be0.png)
