### PR TITLE
fix(pf3): give select menu higher z-index than input.

### DIFF
--- a/packages/pf3-component-mapper/demo/demo-schemas/sandbox.js
+++ b/packages/pf3-component-mapper/demo/demo-schemas/sandbox.js
@@ -149,18 +149,18 @@ const output = {
                   label: 'Check Box',
                   title: 'Check Box',
                   component: components.CHECKBOX,
-                  'options': [
+                  options: [
                     {
-                      'label': 'Dog',
+                      label: 'Dog',
                       value: '1',
                     },
                     {
-                      'label': 'Cats',
-                      'value': '2',
+                      label: 'Cats',
+                      value: '2',
                     },
                     {
-                      'label': 'Hamsters',
-                      'value': '3',
+                      label: 'Hamsters',
+                      value: '3',
                     },
                   ],
                 },
@@ -398,6 +398,18 @@ const output = {
               title: 'Datepickers',
               key: '642',
               fields: [
+                {
+                  component: components.SELECT,
+                  name: 'date_control_select',
+                  label: 'Select',
+                  options: [{
+                    value: 'foo',
+                    label: 'Foo',
+                  }, {
+                    value: 'bar',
+                    label: 'Bar',
+                  }],
+                },
                 {
                   name: 'date_control_1',
                   label: 'Datepicker',

--- a/packages/pf3-component-mapper/src/form-fields/select/select-styles.js
+++ b/packages/pf3-component-mapper/src/form-fields/select/select-styles.js
@@ -107,6 +107,7 @@ const customStyles = {
     paddingTop: isSearchable ? 36 : 5,
     paddingBottom: 5,
     marginTop: 1,
+    zIndex: 3,
   }),
   control: provided => ({
     ...provided,


### PR DESCRIPTION
closes #160
For some reason normal form input with selector `.input-group .form-control` has z-index value of 2.

Since there is probably some reason for it and removing that might break everything, I just added higher value to select menu.