### PR TITLE
feat(pf4): predict the future in the wizard nav

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -32,6 +32,7 @@ export const wizardSchema = {
   fields: [{
     component: componentTypes.WIZARD,
     name: 'wizzard',
+    predictSteps: true,
     //inModal: true,
     title: 'Title',
     showTitles: true,
@@ -206,9 +207,10 @@ export const wizardSchemaMoreSubsteps = {
     component: componentTypes.WIZARD,
     isDynamic: true,
     name: 'wizzard',
-    title: 'Title',
+    title: 'Dynamic with steps predicting',
     description: 'Description',
     buttonsPosition: 'left',
+    predictSteps: true,
     fields: [{
       title: 'Get started with adding source',
       name: 'step-1',
@@ -232,15 +234,16 @@ export const wizardSchemaMoreSubsteps = {
         label: 'Aws field part',
       }],
     }, {
-      title: 'Configure AWS part 2',
+      title: 'Configure AWS part 2 - disabled jumping',
       name: 'step-88',
+      disableForwardJumping: true,
       stepKey: 'aws2',
       nextStep: 'summary',
       substepOf: 'Summary',
       fields: [{
         component: componentTypes.TEXT_FIELD,
-        name: 'aws-field',
-        label: 'Aws field part',
+        name: 'aws-field-1',
+        label: 'Aws field part 1',
       }],
     },
     {

--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -7,7 +7,7 @@ const ValidateButtons = ({ disableBack, handlePrev, buttonLabels: { back, cancel
 
   const setValidating = () => {
     setState('validating');
-    setTimeout(() => setState('done'), 2000);
+    setTimeout(() => setState('done'), 0);
   };
 
   return (
@@ -97,6 +97,9 @@ export const wizardSchema = {
         component: componentTypes.TEXT_FIELD,
         name: 'google.google-field',
         label: 'Google field part',
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
       }],
     }, {
       fields: [{
@@ -201,6 +204,7 @@ export const wizardSchemaSubsteps = {
 export const wizardSchemaMoreSubsteps = {
   fields: [{
     component: componentTypes.WIZARD,
+    isDynamic: true,
     name: 'wizzard',
     title: 'Title',
     description: 'Description',

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
@@ -59,10 +59,6 @@ class Wizard extends React.Component {
 
   handlePrev = () => this.jumpToStep(this.state.activeStepIndex - 1);
 
-  findActiveFields = visitedSteps =>
-    visitedSteps.map(key =>this.findCurrentStep(key).fields.map(({ name }) => name))
-    .reduce((acc, curr) => curr.concat(acc.map(item => item)), []);
-
   handleSubmit = (values, visitedSteps, getRegisteredFields) => {
     // Add the final step fields to history
     const finalRegisteredFieldsHistory = {

--- a/packages/react-renderer-demo/src/docs-components/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/docs-components/pf4-wizard.md
@@ -15,6 +15,7 @@ Don't forget hide form controls by settinng \`showFormControls\` to \`false\` as
 | setFullHeight  | bool  | undefined  | see Patternfly  |
 | isDynamic  | bool  | undefined  | will dynamically generate steps navigation (=progressive wizard), please use if you use any condition fields which changes any field in other steps (wizards with conditional steps are dynamic by default) |
 |showTitles|bool|undefined|If true, step titles will be shown in the wizard body|
+|predictSteps|bool|undefined|If true, dynamic wizard will predict steps in the navigation.|
 
 ### Default buttonLabels
 
@@ -48,6 +49,7 @@ You can rewrite only selection of them, e.g.
 | buttons | node, func | Custom buttons component|
 |showTitle|bool|If true, step titles will (not if false) be shown in the wizard body|
 |Custom title|node|Use if you want to render as the title different/custom title (for example, title with a popover|
+|disableForwardJumping|bool|When use return to this step, jumping forward in the navigation is disabled.|
 
 
 - nextStep can be stepKey of the next step
@@ -164,6 +166,8 @@ First step should have `stepKey: 1` or as a string: `'1'`
 - steps are visible as user visits them
 - user can jump only back
 - use `isDynamic` prop to enforce it
+- use `predictSteps` to allow navigation to show future steps
+    - if you have any conditional fields in the step, you should use `disableForwardJumping` in the step definition, to disable jumping forward in the navigation, otherwise user could miss the changed fields in next steps.
 
 ![progressivewizard](https://user-images.githubusercontent.com/32869456/58427241-5b370a80-809f-11e9-8e79-a4a829b8d181.gif)
 


### PR DESCRIPTION
**Description**

Back to the future with PF4 wizard!

- jumping back on a step with compile mapper will disable jumping forward
- jumping can be disabled by a prop `disableForwardJumping`
- it's opt-in, wizard has to get `predictSteps` prop to predict the steps in the navigation

- Adds props

**Wizard**

| Prop  | Type | Default |  Decription |
| ------------- | ------------- | ------------- | ------------- |
|predictSteps|bool|undefined|If true, dynamic wizard will predict steps in the navigation.|

**Wizard step**

| Props  | Type  |  Decription |
| ------------- | ------------- | ------------- |
|disableForwardJumping|bool|When use return to this step, jumping forward in the navigation is disabled.| 


Predicting
![predicting](https://user-images.githubusercontent.com/32869456/67007094-f1b7a700-f0e6-11e9-8ade-53952d69a6fa.gif)


Disable jumping forward
![disabledJumping](https://user-images.githubusercontent.com/32869456/67007103-f67c5b00-f0e6-11e9-8e15-3e818fb43faa.gif)




