### PR TITLE
fix(pf3title): make it <h1 />

### DIFF
--- a/packages/pf3-component-mapper/src/form-fields/layout-components.js
+++ b/packages/pf3-component-mapper/src/form-fields/layout-components.js
@@ -34,7 +34,7 @@ ButtonGroupWrapper.defaultProps = {
   className: '',
 };
 
-const TitleWrapper = ({ children }) => <h3>{ children }</h3>;
+const TitleWrapper = ({ children }) => <h1>{ children }</h1>;
 
 TitleWrapper.propTypes = {
   children: PropTypes.oneOfType([ PropTypes.node, PropTypes.arrayOf(PropTypes.node) ]).isRequired,

--- a/packages/pf3-component-mapper/src/tests/layout-components.test.js
+++ b/packages/pf3-component-mapper/src/tests/layout-components.test.js
@@ -13,7 +13,7 @@ describe('Layout mapper', () => {
   });
 
   it('should return PF3 Title', () => {
-    expect(mount(layoutMapper[layoutComponents.TITLE]({})).find('h3')).toHaveLength(1);
+    expect(mount(layoutMapper[layoutComponents.TITLE]({})).find('h1')).toHaveLength(1);
   });
 
   it('should return PF3 Description', () => {


### PR DESCRIPTION
**Description**

Changes `h3` PF3 title to `h1`

see https://github.com/data-driven-forms/react-forms/pull/172