### PR TITLE
fix(common): fixed data type conversion of array values.

### DIFF
--- a/packages/pf3-component-mapper/demo/demo-schemas/sandbox.js
+++ b/packages/pf3-component-mapper/demo/demo-schemas/sandbox.js
@@ -13,6 +13,24 @@ const output = {
           name: '553',
           fields: [
             {
+              component: 'select-field',
+              name: 'select-field-1',
+              label: 'Dropdown 1',
+              visible: true,
+              dataType: 'number',
+              options: [
+                {
+                  value: 1,
+                  label: 'foo',
+                },
+                {
+                  value: 2,
+                  label: 'bar',
+                },
+              ],
+              multi: true,
+            },
+            {
               title: 'Text boxes',
               key: '637',
               fields: [

--- a/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
+++ b/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
@@ -47,6 +47,12 @@ const convertType = (dataType, value) => ({
  * @param {Any} value value to be type casted
  * @param  {...any} args rest of orininal function arguments
  */
-const enhancedOnChange = (dataType, onChange, value, ...args) => onChange(convertType(dataType, sanitizeValue(value)), ...args);
+const enhancedOnChange = (dataType, onChange, value, ...args) => {
+  const sanitizedValue = sanitizeValue(value);
+  return onChange(
+    Array.isArray(sanitizedValue)
+      ? sanitizedValue.map(item => convertType(dataType, sanitizeValue(item)))
+      : convertType(dataType, sanitizedValue),
+    ...args);};
 
 export default enhancedOnChange;

--- a/packages/react-form-renderer/src/tests/form-renderer/enhanced-on-change.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/enhanced-on-change.test.js
@@ -26,4 +26,9 @@ describe('#enhancedOnChange', () => {
     };
     expect(enhancedOnChange(undefined, value => value, value)).toEqual('Me');
   });
+
+  it('should correctly convert array datatype from strings to integers', () => {
+    const value = [ '1', '2', 3 ];
+    expect(enhancedOnChange('integer', value => value, value)).toEqual([ 1, 2, 3 ]);
+  });
 });


### PR DESCRIPTION
closes #187 

On change callback was converting arrays instead of the items if those arrays
```jsx
["1"] => /*1 instead of*/ ["1"] => [1]
```