### PR TITLE
fix(renderer): Allow undefined value for validate attribute in schema.

### DIFF
--- a/packages/pf3-component-mapper/demo/demo-schemas/sandbox.js
+++ b/packages/pf3-component-mapper/demo/demo-schemas/sandbox.js
@@ -42,6 +42,7 @@ const output = {
                   bsSize: 'mn',
                   onText: 'True',
                   offText: 'False',
+                  validate: undefined,
                 },
                 {
                   name: 'text_box_111',

--- a/packages/react-form-renderer/src/parsers/default-schema-validator.js
+++ b/packages/react-form-renderer/src/parsers/default-schema-validator.js
@@ -60,6 +60,10 @@ const checkCondition = (condition, fieldName) => {
 };
 
 const checkValidators = (validate, fieldName) => {
+  if (validate === undefined) {
+    return;
+  }
+
   if (!Array.isArray(validate)) {
     throw new DefaultSchemaError(`
       Error occured in field definition with name: "${fieldName}".

--- a/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
+++ b/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
@@ -104,6 +104,14 @@ describe('Default schema validator', () => {
     }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
   });
 
+  it('should not fail if validate is undefined.', () => {
+    expect(() => defaultSchemaValidator({ fields: [{
+      component: 'foo',
+      name: 'foo',
+      validate: undefined,
+    }]}, formFieldsMapper)).not.toThrow();
+  });
+
   it('should not fail if field validate item is a function.', () => {
     const functionValidator = (value) => 'cosi';
     expect(() => defaultSchemaValidator({ fields: [{


### PR DESCRIPTION
closes #174

This was an issue only in schema validator. Renderer does not use validate property if it is not an array.