### PR TITLE
Remove size-snapshot from git

### DIFF
--- a/packages/mui-component-mapper/size-snapshot.json
+++ b/packages/mui-component-mapper/size-snapshot.json
@@ -1,7 +1,0 @@
-{
-  "dist/index.js": {
-    "bundled": 633496,
-    "minified": 264412,
-    "gzipped": 74673
-  }
-}

--- a/packages/pf3-component-mapper/size-snapshot.json
+++ b/packages/pf3-component-mapper/size-snapshot.json
@@ -1,7 +1,0 @@
-{
-  "dist/index.js": {
-    "bundled": 669922,
-    "minified": 271580,
-    "gzipped": 74248
-  }
-}

--- a/packages/pf4-component-mapper/size-snapshot.json
+++ b/packages/pf4-component-mapper/size-snapshot.json
@@ -1,7 +1,0 @@
-{
-  "dist/index.js": {
-    "bundled": 354331,
-    "minified": 147276,
-    "gzipped": 42033
-  }
-}

--- a/packages/react-form-renderer/size-snapshot.json
+++ b/packages/react-form-renderer/size-snapshot.json
@@ -1,7 +1,0 @@
-{
-  "dist/index.js": {
-    "bundled": 246500,
-    "minified": 87931,
-    "gzipped": 26546
-  }
-}


### PR DESCRIPTION
- these files should not be longer tracked

The problem is the files have been already tracked by git, so I ran `git rm --cached` over them