### PR TITLE
fix(pf4wizard): onCancel button receives formValues

### DIFF
--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -55,7 +55,7 @@ class App extends React.Component {
                     ...formFieldsMapper,
                     summary: Summary
                 }}
-                onCancel={() => console.log('Cancel action')}
+                onCancel={console.log}
                 layoutMapper={layoutMapper}
                 schema={this.state.schema}
                 uiSchema={this.state.ui}

--- a/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/step-buttons.js
@@ -99,7 +99,7 @@ const WizardStepButtons = ({
           submitLabel: submit,
         }) }
         <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
-        <Button type="button" variant="link" onClick={ formOptions.onCancel }>{ cancel }</Button>
+        <Button type="button" variant="link" onClick={ () => formOptions.onCancel(formOptions.getState().values) }>{ cancel }</Button>
       </React.Fragment> }
   </footer>;
 
@@ -107,6 +107,7 @@ WizardStepButtons.propTypes = {
   formOptions: PropTypes.shape({
     onCancel: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
+    getState: PropTypes.func.isRequired,
   }).isRequired,
   disableBack: PropTypes.bool,
   handlePrev: PropTypes.func.isRequired,

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/step-buttons.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/step-buttons.test.js.snap
@@ -16,7 +16,7 @@ exports[`<WizardSTepButtons should add custom className to toolbar 1`] = `
     Back
   </Component>
   <Component
-    onClick={[MockFunction]}
+    onClick={[Function]}
     type="button"
     variant="link"
   >
@@ -41,7 +41,7 @@ exports[`<WizardSTepButtons should render correctly 1`] = `
     Back
   </Component>
   <Component
-    onClick={[MockFunction]}
+    onClick={[Function]}
     type="button"
     variant="link"
   >

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard-step.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard-step.test.js.snap
@@ -27,6 +27,7 @@ exports[`<WizardStep /> should render correctly 1`] = `
     }
     formOptions={
       Object {
+        "getState": [MockFunction],
         "handleSubmit": [MockFunction],
         "onCancel": [MockFunction],
         "renderForm": [Function],
@@ -65,6 +66,7 @@ exports[`<WizardStep /> should render custom description 1`] = `
     }
     formOptions={
       Object {
+        "getState": [MockFunction],
         "handleSubmit": [MockFunction],
         "onCancel": [MockFunction],
         "renderForm": [Function],
@@ -110,6 +112,7 @@ exports[`<WizardStep /> should render title with showTitle 1`] = `
     }
     formOptions={
       Object {
+        "getState": [MockFunction],
         "handleSubmit": [MockFunction],
         "onCancel": [MockFunction],
         "renderForm": [Function],

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -365,7 +365,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                   </ComponentWithOuia>
                 </Component>
                 <Component
-                  onClick={[MockFunction]}
+                  onClick={[Function]}
                   type="button"
                   variant="link"
                 >
@@ -374,7 +374,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                     componentProps={
                       Object {
                         "children": "Cancel",
-                        "onClick": [MockFunction],
+                        "onClick": [Function],
                         "type": "button",
                         "variant": "link",
                       }
@@ -382,7 +382,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                     consumerContext={null}
                   >
                     <Button
-                      onClick={[MockFunction]}
+                      onClick={[Function]}
                       ouiaContext={
                         Object {
                           "isOuia": false,
@@ -397,7 +397,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                         aria-label={null}
                         className="pf-c-button pf-m-link"
                         disabled={false}
-                        onClick={[MockFunction]}
+                        onClick={[Function]}
                         tabIndex={null}
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                             </ComponentWithOuia>
                           </Component>
                           <Component
-                            onClick={[MockFunction]}
+                            onClick={[Function]}
                             type="button"
                             variant="link"
                           >
@@ -1021,7 +1021,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                               componentProps={
                                 Object {
                                   "children": "Cancel",
-                                  "onClick": [MockFunction],
+                                  "onClick": [Function],
                                   "type": "button",
                                   "variant": "link",
                                 }
@@ -1029,7 +1029,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                               consumerContext={null}
                             >
                               <Button
-                                onClick={[MockFunction]}
+                                onClick={[Function]}
                                 ouiaContext={
                                   Object {
                                     "isOuia": false,
@@ -1044,7 +1044,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                   aria-label={null}
                                   className="pf-c-button pf-m-link"
                                   disabled={false}
-                                  onClick={[MockFunction]}
+                                  onClick={[Function]}
                                   tabIndex={null}
                                   type="button"
                                 >
@@ -1471,7 +1471,7 @@ exports[`<Wizard /> should render correctly with custom title and description 1`
                   </ComponentWithOuia>
                 </Component>
                 <Component
-                  onClick={[MockFunction]}
+                  onClick={[Function]}
                   type="button"
                   variant="link"
                 >
@@ -1480,7 +1480,7 @@ exports[`<Wizard /> should render correctly with custom title and description 1`
                     componentProps={
                       Object {
                         "children": "Cancel",
-                        "onClick": [MockFunction],
+                        "onClick": [Function],
                         "type": "button",
                         "variant": "link",
                       }
@@ -1488,7 +1488,7 @@ exports[`<Wizard /> should render correctly with custom title and description 1`
                     consumerContext={null}
                   >
                     <Button
-                      onClick={[MockFunction]}
+                      onClick={[Function]}
                       ouiaContext={
                         Object {
                           "isOuia": false,
@@ -1503,7 +1503,7 @@ exports[`<Wizard /> should render correctly with custom title and description 1`
                         aria-label={null}
                         className="pf-c-button pf-m-link"
                         disabled={false}
-                        onClick={[MockFunction]}
+                        onClick={[Function]}
                         tabIndex={null}
                         type="button"
                       >

--- a/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
@@ -19,6 +19,7 @@ describe('<WizardSTepButtons', () => {
         handleSubmit: jest.fn(),
         submit: jest.fn(),
         valid: true,
+        getState: jest.fn(),
       },
       handlePrev: jest.fn(),
       handleNext: jest.fn(),
@@ -74,11 +75,15 @@ describe('<WizardSTepButtons', () => {
     expect(handleSubmit).toHaveBeenCalled();
   });
 
-  it('should call cancel function', () => {
+  it('should call cancel function with values', () => {
+    const VALUES = { aws: 'yes', password: '123456643' };
     const onCancel = jest.fn();
-    const wrapper = mount(<WizardStepButtons { ...initialProps } formOptions={{ ...initialProps.formOptions, onCancel }} />);
+    const wrapper = mount(<WizardStepButtons
+      { ...initialProps }
+      formOptions={{ ...initialProps.formOptions, onCancel, getState: () => ({ values: VALUES }) }}
+    />);
     wrapper.find('button').last().simulate('click');
-    expect(onCancel).toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledWith(VALUES);
   });
 
   it('should call prev function', () => {

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard-step.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard-step.test.js
@@ -14,6 +14,7 @@ describe('<WizardStep />', () => {
         renderForm: item => <div key={ item }>{ item }</div>,
         onCancel: jest.fn(),
         handleSubmit: jest.fn(),
+        getState: jest.fn(),
       },
       FieldProvider,
       handlePrev: jest.fn(),

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -15,6 +15,7 @@ describe('<Wizard />', () => {
   let getRegisteredFieldsSchemaMock;
   let getRegisteredFieldsNestedSchemaMock;
   let getValuesNestedSchema;
+  let initialValues;
 
   const nextButtonClick = (wrapper) =>  {
     wrapper.find('button').at(0).simulate('click');
@@ -36,6 +37,11 @@ describe('<Wizard />', () => {
     wrapper.update();
   };
 
+  const cancelButtonClickWithHeader = (wrapper) =>  {
+    wrapper.find('button').at(3).simulate('click');
+    wrapper.update();
+  };
+
   const changeValue = (wrapper, value) => {
     wrapper.find('input').instance().value = value;
     wrapper.find('input').simulate('change');
@@ -43,6 +49,11 @@ describe('<Wizard />', () => {
   };
 
   beforeEach(() => {
+    initialValues = {
+      'foo-field': 'foo-field-value',
+      'bar-field': 'bar-field-value',
+      'not-visited-field': 'not-visted-field-value',
+    };
     initialProps = {
       FieldProvider,
       title: 'Wizard',
@@ -50,11 +61,7 @@ describe('<Wizard />', () => {
       formOptions: {
         renderForm: ([{ name }]) => <div key={ name }>{ name }</div>,
         getState: () => ({
-          values: {
-            'foo-field': 'foo-field-value',
-            'bar-field': 'bar-field-value',
-            'not-visited-field': 'not-visted-field-value',
-          },
+          values: initialValues,
         }),
         onCancel: jest.fn(),
         onSubmit: jest.fn(),
@@ -192,6 +199,19 @@ describe('<Wizard />', () => {
       'foo-field': 'foo-field-value',
       'bar-field': 'bar-field-value',
     });
+  });
+
+  it('should pass values to cancel', () => {
+    const onCancel = jest.fn();
+    const wrapper = mount(<Wizard
+      { ...initialProps }
+      fields={ schema }
+      formOptions={{ ...initialProps.formOptions, onCancel }}
+    />);
+
+    cancelButtonClickWithHeader(wrapper);
+
+    expect(onCancel).toHaveBeenCalledWith(initialValues);
   });
 
   it('should submit data when nested schema', () => {


### PR DESCRIPTION
**Description**

Follow-up of https://github.com/data-driven-forms/react-forms/pull/202

pF4 wizard cancel button now pass formValues

