### PR TITLE
fix(pf4 select): Added prop that enables select menu portaling

### DIFF
--- a/packages/pf4-component-mapper/src/form-fields/select/select-styles.scss
+++ b/packages/pf4-component-mapper/src/form-fields/select/select-styles.scss
@@ -59,115 +59,121 @@
           }
       }
   }
+}
 
-   .ddorg__pf4-component-mapper__select__menu {
-      cursor: pointer;
-      border-radius: 0;
-      z-index: 2;
+/**
+* Move menu styles out of select scope to enable using it while using portaling for context menu
+* !important is used to override global styles comming from react-select
+* z-index of menu has to be > 400 to show over pf4-modal
+*/
+
+.ddorg__pf4-component-mapper__select__menu {
+  cursor: pointer;
+  border-radius: 0 !important;
+  z-index: 1000 !important;
+}
+
+.ddorg__pf4-component-mapper__select__menu--option {
+  display: flex;
+  align-items: center;
+
+   &.focused {
+      background-color: var(--pf-global--Color--light-200);
   }
 
-   .ddorg__pf4-component-mapper__select__menu--option {
-      display: flex;
-      align-items: center;
-
-       &.focused {
-          background-color: var(--pf-global--Color--light-200);
-      }
-
-       svg {
-          width: 0.6em;
-          margin-right: 10px;
-          fill: var(--pf-global--active-color--100);
-      }
-
-       div.pf-c-check {
-          padding-left: 1rem;
-          & + .ddorg__pf4-component-mapper__select__option {
-              padding-left: 0;
-          }
-      }
+   svg {
+      width: 0.6em;
+      margin-right: 10px;
+      fill: var(--pf-global--active-color--100);
   }
 
-  .ddorg__pf4-component-mapper__select__menu--option div {
-      background: transparent;
-      cursor: pointer;
-      color: var(--pf-global--Color--300);
+   div.pf-c-check {
+      padding-left: 1rem;
+      & + .ddorg__pf4-component-mapper__select__option {
+          padding-left: 0;
+      }
+  }
+}
+
+.ddorg__pf4-component-mapper__select__menu--option div {
+  background: transparent;
+  cursor: pointer;
+  color: var(--pf-global--Color--300);
+}
+
+.ddorg__pf4-component-mapper__select__single-value {
+padding-left: 8px;
+}
+
+.ddorg__pf4-component-mapper__select__multivalue--container {
+display: flex;
+flex-direction: row;
+flex-wrap: nowrap;
+align-items: center;
+box-sizing: border-box;
+line-height: 24px;
+position: relative;
+margin-right: 4px;
+font-size: 12px;
+max-height: 26px;
+
+> .ddorg__pf4-component-mapper__select__multivalue--remove {
+  display: flex;
+
+  svg {
+    fill: var(--pf-global--Color--400);
   }
 
-  .ddorg__pf4-component-mapper__select__single-value {
-    padding-left: 8px;
-  }
-
-  .ddorg__pf4-component-mapper__select__multivalue--container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: center;
-    box-sizing: border-box;
-    line-height: 24px;
-    position: relative;
-    margin-right: 4px;
-    font-size: 12px;
-    max-height: 26px;
-
-    > .ddorg__pf4-component-mapper__select__multivalue--remove {
-      display: flex;
-
-      svg {
-        fill: var(--pf-global--Color--400);
-      }
-
-      > :hover {
-        background: transparent;
-        svg {
-            fill: var(--pf-global--Color--dark-100);
-        }
-      }
-    }
-
-    &::before {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      content: "";
-      border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--Color--dark-200);
-      border-radius: 3px;
-      pointer-events: none;
+  > :hover {
+    background: transparent;
+    svg {
+        fill: var(--pf-global--Color--dark-100);
     }
   }
+}
 
-   .ddorg__pf4-component-mapper__select__value--container {
-      display: flex;
-      padding-left: 8px;
-      align-items: center;
-      flex-wrap: wrap;
-      max-width: calc(100% - 70px);
+&::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  content: "";
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--Color--dark-200);
+  border-radius: 3px;
+  pointer-events: none;
+}
+}
 
-       .ddorg__pf4-component-mapper__select__multivalue--container {
-          align-items: initial;
-          .ddorg__pf4-component-mapper__select__multi-value__label {
-            max-width: 240px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            display: inline-block;
+.ddorg__pf4-component-mapper__select__value--container {
+  display: flex;
+  padding-left: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  max-width: calc(100% - 70px);
+
+   .ddorg__pf4-component-mapper__select__multivalue--container {
+      align-items: initial;
+      .ddorg__pf4-component-mapper__select__multi-value__label {
+        max-width: 240px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
+      }
+  }
+
+   .ddorg__pf4-component-mapper__select__value--container-chipgroup {
+      padding: 4px 6px;
+      font-size: 12px;
+      background-color: var(--pf-global--BorderColor--300);
+      border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
+      margin: 0;
+      max-height: 26px;
+          &:hover{
+              border-color: var(--pf-global--Color--dark-100);
+          }
+          > span {
+              color: var(--pf-global--Color--dark-100);
           }
       }
-
-       .ddorg__pf4-component-mapper__select__value--container-chipgroup {
-          padding: 4px 6px;
-          font-size: 12px;
-          background-color: var(--pf-global--BorderColor--300);
-          border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
-          margin: 0;
-          max-height: 26px;
-              &:hover{
-                  border-color: var(--pf-global--Color--dark-100);
-              }
-              > span {
-                  color: var(--pf-global--Color--dark-100);
-              }
-          }
-  }
 }

--- a/packages/pf4-component-mapper/src/form-fields/select/select.js
+++ b/packages/pf4-component-mapper/src/form-fields/select/select.js
@@ -68,7 +68,7 @@ export class Select extends React.Component {
     : () => this.props.noOptionsMessage;
 
   render() {
-    const { selectVariant, loadOptions, loadingMessage, noOptionsMessage, ... props } = this.props;
+    const { selectVariant, loadOptions, loadingMessage, noOptionsMessage, menuIsPortal, ... props } = this.props;
     const { isLoading, allOptions } = this.state;
     const Select = selectProvider(selectVariant);
     const isSearchable = selectVariant === 'createable' || props.isSearchable;
@@ -82,6 +82,8 @@ export class Select extends React.Component {
         options={ allOptions }
       />);
     }
+
+    const menuPortalTarget = menuIsPortal ? document.body : undefined;
 
     return (
       <Select
@@ -97,9 +99,16 @@ export class Select extends React.Component {
         isFetching={ Object.values(this.state.promises).some(value => value) }
         noOptionsMessage={ this.renderNoOptionsMessage() }
         onInputChange={ this.onInputChange }
+        menuPortalTarget={ menuPortalTarget }
         { ...props }
         className={ `ddorg__pf4-component-mapper__select${props.isMulti ? ' multi-select' : ' single-select'}` }
         classNamePrefix="ddorg__pf4-component-mapper__select"
+        styles={{
+          menuPortal: provided => ({
+            ...provided,
+            'z-index': 'initial',
+          }),
+        }}
         onChange={ (option) => {
           const o =  !option && props.isMulti ? [] : option;
           return simpleValue
@@ -132,6 +141,7 @@ Select.propTypes = {
   loadingMessage: PropTypes.node,
   updatingMessage: PropTypes.node,
   noOptionsMessage: PropTypes.func,
+  menuIsPortal: PropTypes.bool,
 };
 
 Select.defaultProps = {
@@ -142,6 +152,7 @@ Select.defaultProps = {
   loadingMessage: 'Loading...',
   updatingMessage: 'Loading data...',
   options: [],
+  menuIsPortal: false,
 };
 
 const DataDrivenSelect = ({ multi, ...props }) => (

--- a/packages/pf4-component-mapper/src/tests/select/select.test.js
+++ b/packages/pf4-component-mapper/src/tests/select/select.test.js
@@ -130,6 +130,7 @@ describe('<Select />', () => {
       showMoreLabel: 'more',
       simpleValue: true,
       updatingMessage: 'Loading data...',
+      menuIsPortal: false,
       value: [ 1, 2  ],
       loadingMessage: 'Loading...',
     });

--- a/packages/react-renderer-demo/src/app/src/doc-components/pf4-select.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/pf4-select.md
@@ -1,3 +1,11 @@
+# Menu portaling
+
+In order to show menu properly in dialogs like modals, you can use `menuIsPortal`. This will append menu as portal to body.
+
+|prop name|type|description|
+|---------|----|-----------|
+|menuIsPortal|`bool`|Append menu to body instead of to select wrapper.See more [here](https://react-select.com/advanced#portaling)|
+
 # PF4 Async Select
 
 PF4 Select allows to load the options asynchronously.


### PR DESCRIPTION
Use `menuIsPortal` prop to enable it. portal is appended to body element.

### Before
![Screenshot from 2019-12-10 13-12-29](https://user-images.githubusercontent.com/22619452/70528655-fe88d200-1b4e-11ea-8b10-af5627c4bb25.png)

### After
![screenshot-localhost_8080-2019 12 10-13_00_50](https://user-images.githubusercontent.com/22619452/70528671-08aad080-1b4f-11ea-8372-976f3118aaab.png)
