### PR TITLE
fix(pf3): datetimepickers buttons do not show texts

### DIFF
--- a/packages/pf3-component-mapper/src/form-fields/date-time-picker/intervals.js
+++ b/packages/pf3-component-mapper/src/form-fields/date-time-picker/intervals.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Icon } from 'patternfly-react';
+
+export const PrevInterval = (props) => <td { ...props } >
+  <Icon name="angle-left" aria-label="Prev interval" />
+</td>;
+
+export const NextInterval = (props) => <td { ...props } >
+  <Icon name="angle-right" aria-label="Next interval" />
+</td>;

--- a/packages/pf3-component-mapper/src/form-fields/date-time-picker/navbar.js
+++ b/packages/pf3-component-mapper/src/form-fields/date-time-picker/navbar.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from 'patternfly-react';
 import MomentLocaleUtils from 'react-day-picker/moment';
 import './date-picker-styles.scss';
+import { NextInterval, PrevInterval } from './intervals';
 
 const Navbar = ({ onNextClick, onPreviousClick, month, onMonthClick, isYear, toggleSelectingYear, locale, disablePrev, disableNext }) => (
   <table className="year-interval-header">
     <tbody>
       <tr>
-        <td className={ disablePrev ? 'disabled' : '' } onMouseDown={ () => !disablePrev && onPreviousClick() }>
-          <Icon name="angle-left"><span>Prev interval</span></Icon>
-        </td>
+        <PrevInterval className={ disablePrev ? 'disabled' : '' } onMouseDown={ () => !disablePrev && onPreviousClick() }/>
         <td>
           { isYear
             ? <button className="navbar-center-button" type="button" onClick={ () => toggleSelectingYear(true) }>{ month.getFullYear() }</button>
@@ -24,9 +22,7 @@ const Navbar = ({ onNextClick, onPreviousClick, month, onMonthClick, isYear, tog
               </button>
             ) }
         </td>
-        <td className={ disableNext ? 'disabled' : '' } onMouseDown={ () =>!disableNext &&  onNextClick() }>
-          <Icon name="angle-right" ><span>Next interval</span></Icon>
-        </td>
+        <NextInterval className={ disableNext ? 'disabled' : '' } onMouseDown={ () =>!disableNext &&  onNextClick() }/>
       </tr>
     </tbody>
   </table>

--- a/packages/pf3-component-mapper/src/form-fields/date-time-picker/year-selector.js
+++ b/packages/pf3-component-mapper/src/form-fields/date-time-picker/year-selector.js
@@ -1,21 +1,17 @@
 import React from 'react';
-import { Icon } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import './date-picker-styles.scss';
+import { PrevInterval, NextInterval } from './intervals';
 
 const YearIntervalSelector = ({ currentInterval, prevInterval, nextInterval }) => (
   <table className="year-interval-header">
     <tbody>
       <tr>
-        <td  onClick={ prevInterval }>
-          <Icon name="angle-left"><span>Prev interval</span></Icon>
-        </td>
+        <PrevInterval onClick={ prevInterval }/>
         <td>
           <button className="year-interval-button" disabled>{ `${currentInterval[0]} - ${currentInterval[1]}` }</button>
         </td>
-        <td onClick={ nextInterval }>
-          <Icon name="angle-right" ><span>Next interval</span></Icon>
-        </td>
+        <NextInterval onClick={ nextInterval }/>
       </tr>
     </tbody>
   </table>

--- a/packages/pf3-component-mapper/src/tests/form-fields/date-time-picker/__snapshots__/year-selector.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/form-fields/date-time-picker/__snapshots__/year-selector.test.js.snap
@@ -29,27 +29,30 @@ exports[`<YearSelector /> should render correctly 1`] = `
           >
             <tbody>
               <tr>
-                <td
+                <PrevInterval
                   onClick={[Function]}
                 >
-                  <Icon
-                    name="angle-left"
-                    type="fa"
+                  <td
+                    onClick={[Function]}
                   >
-                    <FontAwesome
+                    <Icon
+                      aria-label="Prev interval"
                       name="angle-left"
+                      type="fa"
                     >
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-angle-left"
+                      <FontAwesome
+                        aria-label="Prev interval"
+                        name="angle-left"
                       >
-                        <span>
-                          Prev interval
-                        </span>
-                      </span>
-                    </FontAwesome>
-                  </Icon>
-                </td>
+                        <span
+                          aria-hidden={true}
+                          aria-label="Prev interval"
+                          className="fa fa-angle-left"
+                        />
+                      </FontAwesome>
+                    </Icon>
+                  </td>
+                </PrevInterval>
                 <td>
                   <button
                     className="year-interval-button"
@@ -58,27 +61,30 @@ exports[`<YearSelector /> should render correctly 1`] = `
                     2000 - 2019
                   </button>
                 </td>
-                <td
+                <NextInterval
                   onClick={[Function]}
                 >
-                  <Icon
-                    name="angle-right"
-                    type="fa"
+                  <td
+                    onClick={[Function]}
                   >
-                    <FontAwesome
+                    <Icon
+                      aria-label="Next interval"
                       name="angle-right"
+                      type="fa"
                     >
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-angle-right"
+                      <FontAwesome
+                        aria-label="Next interval"
+                        name="angle-right"
                       >
-                        <span>
-                          Next interval
-                        </span>
-                      </span>
-                    </FontAwesome>
-                  </Icon>
-                </td>
+                        <span
+                          aria-hidden={true}
+                          aria-label="Next interval"
+                          className="fa fa-angle-right"
+                        />
+                      </FontAwesome>
+                    </Icon>
+                  </td>
+                </NextInterval>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
closes #254

I tried to integrate the official PF3 datetimepicker to DDF, but it looks like a lot more work than I expected... so here is a fix for the buttons issue.

**Before**

![image](https://user-images.githubusercontent.com/32869456/70542571-37ce3b80-1b69-11ea-9afc-3e2584910d45.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/70542534-284ef280-1b69-11ea-96cb-7dc23473b99d.png)
