### PR TITLE
Convert component examples to mdx

### DIFF
--- a/packages/react-renderer-demo/src/app/pages/component-example/checkbox-multiple.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/checkbox-multiple.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const CheckboxMultiple = () => <ComponentExample component="checkbox-multiple" />;
-
-export default CheckboxMultiple;

--- a/packages/react-renderer-demo/src/app/pages/component-example/checkbox-multiple.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/checkbox-multiple.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Checkbox multiple
+
+<ComponentExample component="checkbox-multiple" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/checkbox.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/checkbox.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Checkbox = () => <ComponentExample component="checkbox" />;
-
-export default Checkbox;

--- a/packages/react-renderer-demo/src/app/pages/component-example/checkbox.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/checkbox.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Checkbox
+
+<ComponentExample component="checkbox" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/date-picker.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/date-picker.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const DatePicker = () => <ComponentExample component="date-picker" />;
-
-export default DatePicker;

--- a/packages/react-renderer-demo/src/app/pages/component-example/date-picker.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/date-picker.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Date picker
+
+<ComponentExample component="date-picker" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/plain-text.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/plain-text.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const PlainText = () => <ComponentExample component="plain-text" />;
-
-export default PlainText;

--- a/packages/react-renderer-demo/src/app/pages/component-example/plain-text.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/plain-text.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Plain text
+
+<ComponentExample component="plain-text" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/radio.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/radio.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Radio = () => <ComponentExample component="radio" />;
-
-export default Radio;

--- a/packages/react-renderer-demo/src/app/pages/component-example/radio.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/radio.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Radio
+
+<ComponentExample component="radio" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/select-field.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/select-field.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Select = () => <ComponentExample component="select-field" />;
-
-export default Select;

--- a/packages/react-renderer-demo/src/app/pages/component-example/select-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/select-field.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Select
+
+<ComponentExample component="select-field" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/sub-form.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/sub-form.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const SubForm = () => <ComponentExample component="sub-form" />;
-
-export default SubForm;

--- a/packages/react-renderer-demo/src/app/pages/component-example/sub-form.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/sub-form.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Subform
+
+<ComponentExample component="sub-form" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/switch-field.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/switch-field.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Switch = () => <ComponentExample component="switch-field" />;
-
-export default Switch;

--- a/packages/react-renderer-demo/src/app/pages/component-example/switch-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/switch-field.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Switch
+
+<ComponentExample component="switch-field" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/tabs.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/tabs.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Tabs = () => <ComponentExample component="tabs" />;
-
-export default Tabs;

--- a/packages/react-renderer-demo/src/app/pages/component-example/tabs.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/tabs.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Tabs
+
+<ComponentExample component="tabs" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/text-field.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/text-field.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Textfield = () => <ComponentExample component="text-field" />;
-
-export default Textfield;

--- a/packages/react-renderer-demo/src/app/pages/component-example/text-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/text-field.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Text field
+
+<ComponentExample component="text-field" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/textarea-field.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/textarea-field.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Textarea = () => <ComponentExample component="textarea-field" />;
-
-export default Textarea;

--- a/packages/react-renderer-demo/src/app/pages/component-example/textarea-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/textarea-field.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Text area
+
+<ComponentExample component="textarea-field" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/time-picker.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/time-picker.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Timepicker = () => <ComponentExample component="time-picker" />;
-
-export default Timepicker;

--- a/packages/react-renderer-demo/src/app/pages/component-example/time-picker.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/time-picker.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Time picker
+
+<ComponentExample component="time-picker" />

--- a/packages/react-renderer-demo/src/app/pages/component-example/wizard.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/wizard.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import ComponentExample from '../../src/components/component-example';
-
-const Wizard = () => <ComponentExample component="wizard" />;
-
-export default Wizard;

--- a/packages/react-renderer-demo/src/app/pages/component-example/wizard.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/wizard.md
@@ -1,0 +1,5 @@
+import ComponentExample from '../../src/components/component-example';
+
+# Wizard
+
+<ComponentExample component="wizard" />

--- a/packages/react-renderer-demo/src/app/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example.js
@@ -290,12 +290,6 @@ class ComponentExample extends Component {
         direction="row"
         spacing={ 4 }
       >
-        <Grid item xs={ 12 } >
-          <Typography variant="h4" gutterBottom>
-            { linkText }
-          </Typography>
-
-        </Grid>
         <Grid item xs={ 4 } >
           <Typography variant="h5" gutterBottom>
               Schema


### PR DESCRIPTION
- Component pages are converted into MDX
- Header is set in the MDX, not in the component itself

Should help Algolia to crawl these pages
