### PR TITLE
Clean obsolete props in formRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Data Driven Forms is a React library used for rendering and managing forms with 
 - Cross-field validation!
 - Asynchronous validation supported!
 - Supporting Wizard forms!
-- Supporting Mozzila form schema!
 - Supporting [Final Form Field Array](https://github.com/final-form/react-final-form-arrays)!
 - ... and a lot more!
 

--- a/packages/pf3-component-mapper/demo/index.js
+++ b/packages/pf3-component-mapper/demo/index.js
@@ -111,7 +111,6 @@ class App extends React.Component {
           <FormRenderer
             initialValues={{}}
             onSubmit={console.log}
-            schemaType="default"
             formFieldsMapper={formFieldsMapper}
             layoutMapper={layoutMapper}
             schema={sandbox}

--- a/packages/pf3-component-mapper/src/tests/wizard.test.js
+++ b/packages/pf3-component-mapper/src/tests/wizard.test.js
@@ -224,7 +224,6 @@ describe('<Wizard />', () => {
         onCancel={ () => {} }
         showFormControls={ false }
         onSubmit={ jest.fn() }
-        schemaType="default"
         initialValues={{ 'source-type': 'google' }}
       />
     );

--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -11,7 +11,7 @@ import sandboxSchema from './demo-schemas/sandbox';
 
 const Summary = props => <div>Custom summary component.</div>;
 
-const fieldArrayState = { schema: arraySchemaDDF, schemaString: 'default', ui: uiArraySchema, additionalOptions: {
+const fieldArrayState = { schema: arraySchemaDDF, additionalOptions: {
     initialValues: {
         number: [1,2,3,4],
         minMax: [null, null, null, null]
@@ -30,27 +30,17 @@ class App extends React.Component {
             <Title size="4xl">Pf4 component mapper</Title>
             <Toolbar style={{ marginBottom: 20, marginTop: 20 }}>
                 <ToolbarGroup>
-                    <Button onClick={() => this.setState(state => ({ schema: wizardSchema, schemaString: 'default', additionalOptions: { showFormControls: false, wizard: true } }))}>Wizard</Button>
+                    <Button onClick={() => this.setState(state => ({ schema: wizardSchema, additionalOptions: { showFormControls: false, wizard: true } }))}>Wizard</Button>
                 </ToolbarGroup>
                 <ToolbarGroup>
                     <Button onClick={() => this.setState(state => fieldArrayState)}>arraySchema</Button>
                 </ToolbarGroup>
                 <ToolbarGroup>
-                    <Button onClick={() => this.setState(state => ({ schema: schema, schemaString: 'mozilla', ui: uiSchema, additionalOptions: {}}))}>schema</Button>
-                </ToolbarGroup>
-                <ToolbarGroup>
-                    <Button onClick={() => this.setState(state => ({ schema: miqSchema, schemaString: 'miq', additionalOptions: {}}))}>miq</Button>
-                </ToolbarGroup>
-                <ToolbarGroup>
-                    <Button onClick={() => this.setState(state => ({ schema: conditionalSchema, schemaString: 'mozilla', ui: uiSchema, additionalOptions: {}}))}>conditional</Button>
-                </ToolbarGroup>
-                <ToolbarGroup>
-                    <Button onClick={() => this.setState(state => ({ schema: sandboxSchema, schemaString: 'default', additionalOptions: {}}))}>Sandbox</Button>
+                    <Button onClick={() => this.setState(state => ({ schema: sandboxSchema, additionalOptions: {}}))}>Sandbox</Button>
                 </ToolbarGroup>
             </Toolbar>
             <FormRenderer
                 onSubmit={console.log}
-                schemaType={this.state.schemaString}
                 formFieldsMapper={{
                     ...formFieldsMapper,
                     summary: Summary

--- a/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
@@ -42,7 +42,6 @@ exports[`FieldArray should render array field correctly 1`] = `
         "wizard": [Function],
       }
     }
-    formType="pf3"
     initialValues={Object {}}
     layoutMapper={
       Object {
@@ -54,7 +53,6 @@ exports[`FieldArray should render array field correctly 1`] = `
       }
     }
     onSubmit={[MockFunction]}
-    resetAble={false}
     schema={
       Object {
         "fields": Array [
@@ -72,9 +70,7 @@ exports[`FieldArray should render array field correctly 1`] = `
         ],
       }
     }
-    schemaType="default"
     showFormControls={true}
-    uiSchema={Object {}}
   >
     <ReactFinalForm
       decorators={

--- a/packages/react-form-renderer/README.md
+++ b/packages/react-form-renderer/README.md
@@ -21,7 +21,6 @@ Data Driven Forms is a React library used for rendering and managing forms with 
 - Cross-field validation!
 - Asynchronous validation supported!
 - Supporting Wizard forms!
-- Supporting Mozzila form schema!
 - Supporting [Final Form Field Array](https://github.com/final-form/react-final-form-arrays)!
 - ... and a lot more!
 

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -35,7 +35,6 @@ const App = () => (
             onCancel={console.log}
             canReset
             onReset={() => console.log('i am resseting')}
-            schemaType="default"
             schema={sandboxSchema}
             buttonOrder={['cancel', 'reset', 'submit']}
             buttonClassName="Foo"

--- a/packages/react-form-renderer/src/form-renderer/index.js
+++ b/packages/react-form-renderer/src/form-renderer/index.js
@@ -122,7 +122,6 @@ const FormRenderer = ({
 export default FormRenderer;
 
 FormRenderer.propTypes = {
-  formType: PropTypes.oneOf([ 'pf3', 'pf4' ]),
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
   onReset: PropTypes.func,
@@ -145,7 +144,6 @@ FormRenderer.propTypes = {
 };
 
 FormRenderer.defaultProps = {
-  formType: 'pf3',
   resetAble: false,
   schemaType: 'default',
   buttonsLabels: {},

--- a/packages/react-form-renderer/src/form-renderer/index.js
+++ b/packages/react-form-renderer/src/form-renderer/index.js
@@ -128,7 +128,6 @@ FormRenderer.propTypes = {
 };
 
 FormRenderer.defaultProps = {
-  resetAble: false,
   buttonsLabels: {},
   disableSubmit: [],
   initialValues: {},

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
@@ -19,7 +19,6 @@ exports[`<FormControls /> should render with description 1`] = `
       }
     }
     onSubmit={[MockFunction]}
-    resetAble={false}
     schema={
       Object {
         "description": "Description",
@@ -175,7 +174,6 @@ exports[`<FormControls /> should render with title and description 1`] = `
       }
     }
     onSubmit={[MockFunction]}
-    resetAble={false}
     schema={
       Object {
         "description": "Description",
@@ -337,7 +335,6 @@ exports[`<FormControls /> should render without title and description 1`] = `
       }
     }
     onSubmit={[MockFunction]}
-    resetAble={false}
     schema={
       Object {
         "fields": Array [],

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
@@ -26,9 +26,7 @@ exports[`<FormControls /> should render with description 1`] = `
         "fields": Array [],
       }
     }
-    schemaType="default"
     showFormControls={true}
-    uiSchema={Object {}}
   >
     <ReactFinalForm
       decorators={
@@ -185,9 +183,7 @@ exports[`<FormControls /> should render with title and description 1`] = `
         "title": "Title",
       }
     }
-    schemaType="default"
     showFormControls={true}
-    uiSchema={Object {}}
   >
     <ReactFinalForm
       decorators={
@@ -347,9 +343,7 @@ exports[`<FormControls /> should render without title and description 1`] = `
         "fields": Array [],
       }
     }
-    schemaType="default"
     showFormControls={true}
-    uiSchema={Object {}}
   >
     <ReactFinalForm
       decorators={

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
@@ -8,7 +8,6 @@ exports[`<FormControls /> should render with description 1`] = `
     clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
-    formType="pf3"
     initialValues={Object {}}
     layoutMapper={
       Object {
@@ -167,7 +166,6 @@ exports[`<FormControls /> should render with title and description 1`] = `
     clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
-    formType="pf3"
     initialValues={Object {}}
     layoutMapper={
       Object {
@@ -332,7 +330,6 @@ exports[`<FormControls /> should render without title and description 1`] = `
     clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
-    formType="pf3"
     initialValues={Object {}}
     layoutMapper={
       Object {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -19,7 +19,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
       "time-picker": [Function],
     }
   }
-  formType="pf3"
   initialValues={Object {}}
   layoutMapper={
     Object {
@@ -2779,7 +2778,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
       "time-picker": [Function],
     }
   }
-  formType="pf3"
   initialValues={Object {}}
   layoutMapper={
     Object {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -30,7 +30,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
     }
   }
   onSubmit={[MockFunction]}
-  resetAble={false}
   schema={
     Object {
       "fields": Array [
@@ -842,7 +841,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
   }
   onSubmit={[MockFunction]}
   renderFormButtons={[Function]}
-  resetAble={false}
   schema={
     Object {
       "fields": Array [

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -33,142 +33,19 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
   resetAble={false}
   schema={
     Object {
-      "properties": Object {
-        "boolean": Object {
-          "properties": Object {
-            "defaultCheckbox": Object {
-              "description": "This is the checkbox-description",
-              "title": "checkbox (default)",
-              "type": "boolean",
-            },
-            "radio": Object {
-              "description": "This is the radio-description",
-              "title": "radio buttons",
-              "type": "boolean",
-            },
-            "select": Object {
-              "description": "This is the select-description",
-              "title": "select box",
-              "type": "boolean",
-            },
-          },
-          "title": "Boolean field",
-          "type": "object",
+      "fields": Array [
+        Object {
+          "component": "text-field",
+          "name": "component1",
         },
-        "disabled": Object {
-          "default": "I am disabled.",
-          "title": "A disabled field",
-          "type": "string",
+        Object {
+          "component": "select-field",
+          "name": "secret",
         },
-        "readonly": Object {
-          "default": "I am read-only.",
-          "title": "A readonly field",
-          "type": "string",
-        },
-        "secret": Object {
-          "default": "I'm a hidden string.",
-          "type": "string",
-        },
-        "selectWidgetOptions": Object {
-          "enum": Array [
-            "foo",
-            "bar",
-          ],
-          "enumNames": Array [
-            "Foo",
-            "Bar",
-          ],
-          "title": "Custom select widget with options",
-          "type": "string",
-        },
-        "string": Object {
-          "properties": Object {
-            "color": Object {
-              "default": "#151ce6",
-              "title": "color picker",
-              "type": "string",
-            },
-            "defaultInput": Object {
-              "title": "text input (default)",
-              "type": "string",
-            },
-            "textarea": Object {
-              "title": "textarea",
-              "type": "string",
-            },
-          },
-          "title": "String field",
-          "type": "object",
-        },
-        "stringFormats": Object {
-          "properties": Object {
-            "email": Object {
-              "format": "email",
-              "type": "string",
-            },
-            "uri": Object {
-              "format": "uri",
-              "type": "string",
-            },
-          },
-          "title": "String formats",
-          "type": "object",
-        },
-        "widgetOptions": Object {
-          "default": "I am yellow",
-          "title": "Custom widget with options",
-          "type": "string",
-        },
-      },
-      "title": "Widgets",
-      "type": "object",
+      ],
     }
   }
-  schemaType="mozilla"
   showFormControls={true}
-  uiSchema={Object {}}
-  uischema={
-    Object {
-      "boolean": Object {
-        "radio": Object {
-          "ui:widget": "radio",
-        },
-        "select": Object {
-          "ui:widget": "select",
-        },
-      },
-      "disabled": Object {
-        "ui:disabled": true,
-      },
-      "readonly": Object {
-        "ui:readonly": true,
-      },
-      "secret": Object {
-        "ui:widget": "hidden",
-      },
-      "selectWidgetOptions": Object {
-        "ui:options": Object {
-          "backgroundColor": "pink",
-        },
-      },
-      "string": Object {
-        "color": Object {
-          "ui:widget": "color",
-        },
-        "textarea": Object {
-          "ui:options": Object {
-            "rows": 5,
-          },
-          "ui:widget": "textarea",
-        },
-      },
-      "widgetOptions": Object {
-        "ui:options": Object {
-          "backgroundColor": "yellow",
-        },
-      },
-    }
-  }
 >
   <ReactFinalForm
     decorators={
@@ -176,17 +53,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
         [Function],
       ]
     }
-    initialValues={
-      Object {
-        "disabled": "I am disabled.",
-        "readonly": "I am read-only.",
-        "secret": "I'm a hidden string.",
-        "string": Object {
-          "color": "#151ce6",
-        },
-        "widgetOptions": "I am yellow",
-      }
-    }
+    initialValues={Object {}}
     mutators={
       Object {
         "concat": [Function],
@@ -216,660 +83,13 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
       onSubmit={[Function]}
     >
       <form>
-        <Component>
-          <div>
-            Widgets
-          </div>
-        </Component>
         <FormConditionWrapper>
           <FormFieldHideWrapper
             hideField={false}
           >
             <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="sub-form"
-              fields={
-                Array [
-                  Object {
-                    "autoFocus": false,
-                    "component": "text-field",
-                    "dataType": "string",
-                    "description": undefined,
-                    "helperText": undefined,
-                    "initialKey": "email",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "email",
-                    "name": "stringFormats.email",
-                    "rows": undefined,
-                    "type": "email",
-                    "validate": Array [],
-                  },
-                  Object {
-                    "autoFocus": false,
-                    "component": "text-field",
-                    "dataType": "string",
-                    "description": undefined,
-                    "helperText": undefined,
-                    "initialKey": "uri",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "uri",
-                    "name": "stringFormats.uri",
-                    "rows": undefined,
-                    "type": "uri",
-                    "validate": Array [],
-                  },
-                ]
-              }
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              key="stringFormats"
-              name="stringFormats"
-              title="String formats"
-              validate={
-                Array [
-                  undefined,
-                ]
-              }
-            >
-              <Component
-                FieldProvider={[Function]}
-                autoFocus={false}
-                fields={
-                  Array [
-                    Object {
-                      "autoFocus": false,
-                      "component": "text-field",
-                      "dataType": "string",
-                      "description": undefined,
-                      "helperText": undefined,
-                      "initialKey": "email",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "email",
-                      "name": "stringFormats.email",
-                      "rows": undefined,
-                      "type": "email",
-                      "validate": Array [],
-                    },
-                    Object {
-                      "autoFocus": false,
-                      "component": "text-field",
-                      "dataType": "string",
-                      "description": undefined,
-                      "helperText": undefined,
-                      "initialKey": "uri",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "uri",
-                      "name": "stringFormats.uri",
-                      "rows": undefined,
-                      "type": "uri",
-                      "validate": Array [],
-                    },
-                  ]
-                }
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                name="stringFormats"
-                title="String formats"
-                validate={[Function]}
-              >
-                <div
-                  className="nested-item"
-                >
-                  sub form
-                </div>
-              </Component>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="sub-form"
-              fields={
-                Array [
-                  Object {
-                    "autoFocus": false,
-                    "component": "checkbox",
-                    "dataType": "boolean",
-                    "description": "This is the checkbox-description",
-                    "helperText": undefined,
-                    "initialKey": "defaultCheckbox",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "checkbox (default)",
-                    "name": "boolean.defaultCheckbox",
-                    "rows": undefined,
-                    "title": "checkbox (default)",
-                    "type": "checkbox",
-                    "validate": Array [],
-                  },
-                  Object {
-                    "autoFocus": false,
-                    "component": "checkbox",
-                    "dataType": "boolean",
-                    "description": "This is the radio-description",
-                    "helperText": undefined,
-                    "initialKey": "radio",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "radio buttons",
-                    "name": "boolean.radio",
-                    "rows": undefined,
-                    "title": "radio buttons",
-                    "type": "checkbox",
-                    "validate": Array [],
-                  },
-                  Object {
-                    "autoFocus": false,
-                    "component": "checkbox",
-                    "dataType": "boolean",
-                    "description": "This is the select-description",
-                    "helperText": undefined,
-                    "initialKey": "select",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "select box",
-                    "name": "boolean.select",
-                    "rows": undefined,
-                    "title": "select box",
-                    "type": "checkbox",
-                    "validate": Array [],
-                  },
-                ]
-              }
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              key="boolean"
-              name="boolean"
-              title="Boolean field"
-              validate={
-                Array [
-                  undefined,
-                ]
-              }
-            >
-              <Component
-                FieldProvider={[Function]}
-                autoFocus={false}
-                fields={
-                  Array [
-                    Object {
-                      "autoFocus": false,
-                      "component": "checkbox",
-                      "dataType": "boolean",
-                      "description": "This is the checkbox-description",
-                      "helperText": undefined,
-                      "initialKey": "defaultCheckbox",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "checkbox (default)",
-                      "name": "boolean.defaultCheckbox",
-                      "rows": undefined,
-                      "title": "checkbox (default)",
-                      "type": "checkbox",
-                      "validate": Array [],
-                    },
-                    Object {
-                      "autoFocus": false,
-                      "component": "checkbox",
-                      "dataType": "boolean",
-                      "description": "This is the radio-description",
-                      "helperText": undefined,
-                      "initialKey": "radio",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "radio buttons",
-                      "name": "boolean.radio",
-                      "rows": undefined,
-                      "title": "radio buttons",
-                      "type": "checkbox",
-                      "validate": Array [],
-                    },
-                    Object {
-                      "autoFocus": false,
-                      "component": "checkbox",
-                      "dataType": "boolean",
-                      "description": "This is the select-description",
-                      "helperText": undefined,
-                      "initialKey": "select",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "select box",
-                      "name": "boolean.select",
-                      "rows": undefined,
-                      "title": "select box",
-                      "type": "checkbox",
-                      "validate": Array [],
-                    },
-                  ]
-                }
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                name="boolean"
-                title="Boolean field"
-                validate={[Function]}
-              >
-                <div
-                  className="nested-item"
-                >
-                  sub form
-                </div>
-              </Component>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="sub-form"
-              fields={
-                Array [
-                  Object {
-                    "autoFocus": false,
-                    "component": "text-field",
-                    "dataType": "string",
-                    "description": undefined,
-                    "helperText": undefined,
-                    "initialKey": "defaultInput",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "text input (default)",
-                    "name": "string.defaultInput",
-                    "rows": undefined,
-                    "title": "text input (default)",
-                    "type": "text",
-                    "validate": Array [],
-                  },
-                  Object {
-                    "autoFocus": false,
-                    "component": "text-field",
-                    "dataType": "string",
-                    "description": undefined,
-                    "helperText": undefined,
-                    "initialKey": "textarea",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "textarea",
-                    "name": "string.textarea",
-                    "rows": undefined,
-                    "title": "textarea",
-                    "type": "text",
-                    "validate": Array [],
-                  },
-                  Object {
-                    "autoFocus": false,
-                    "component": "text-field",
-                    "dataType": "string",
-                    "default": "#151ce6",
-                    "description": undefined,
-                    "helperText": undefined,
-                    "initialKey": "color",
-                    "inline": undefined,
-                    "isDisabled": undefined,
-                    "isReadOnly": undefined,
-                    "label": "color picker",
-                    "name": "string.color",
-                    "rows": undefined,
-                    "title": "color picker",
-                    "type": "text",
-                    "validate": Array [],
-                  },
-                ]
-              }
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              key="string"
-              name="string"
-              title="String field"
-              validate={
-                Array [
-                  undefined,
-                ]
-              }
-            >
-              <Component
-                FieldProvider={[Function]}
-                autoFocus={false}
-                fields={
-                  Array [
-                    Object {
-                      "autoFocus": false,
-                      "component": "text-field",
-                      "dataType": "string",
-                      "description": undefined,
-                      "helperText": undefined,
-                      "initialKey": "defaultInput",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "text input (default)",
-                      "name": "string.defaultInput",
-                      "rows": undefined,
-                      "title": "text input (default)",
-                      "type": "text",
-                      "validate": Array [],
-                    },
-                    Object {
-                      "autoFocus": false,
-                      "component": "text-field",
-                      "dataType": "string",
-                      "description": undefined,
-                      "helperText": undefined,
-                      "initialKey": "textarea",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "textarea",
-                      "name": "string.textarea",
-                      "rows": undefined,
-                      "title": "textarea",
-                      "type": "text",
-                      "validate": Array [],
-                    },
-                    Object {
-                      "autoFocus": false,
-                      "component": "text-field",
-                      "dataType": "string",
-                      "default": "#151ce6",
-                      "description": undefined,
-                      "helperText": undefined,
-                      "initialKey": "color",
-                      "inline": undefined,
-                      "isDisabled": undefined,
-                      "isReadOnly": undefined,
-                      "label": "color picker",
-                      "name": "string.color",
-                      "rows": undefined,
-                      "title": "color picker",
-                      "type": "text",
-                      "validate": Array [],
-                    },
-                  ]
-                }
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                name="string"
-                title="String field"
-                validate={[Function]}
-              >
-                <div
-                  className="nested-item"
-                >
-                  sub form
-                </div>
-              </Component>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
               component={[Function]}
               componentType="text-field"
-              dataType="string"
-              default="I'm a hidden string."
               formOptions={
                 Object {
                   "batch": [Function],
@@ -911,22 +131,17 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "valid": true,
                 }
               }
-              label="secret"
-              name="secret"
-              type="text"
+              name="component1"
               validate={
                 Array [
-                  [Function],
+                  undefined,
                 ]
               }
             >
               <FieldProvider
                 FieldArrayProvider={[Function]}
                 FieldProvider={[Function]}
-                autoFocus={false}
                 component={[Function]}
-                dataType="string"
-                default="I'm a hidden string."
                 formOptions={
                   Object {
                     "batch": [Function],
@@ -968,16 +183,12 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "valid": true,
                   }
                 }
-                label="secret"
-                name="secret"
-                type="text"
+                name="component1"
                 validate={[Function]}
               >
                 <ReactFinalForm(Field)
                   FieldArrayProvider={[Function]}
                   FieldProvider={[Function]}
-                  autoFocus={false}
-                  default="I'm a hidden string."
                   formOptions={
                     Object {
                       "batch": [Function],
@@ -1019,17 +230,13 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "valid": true,
                     }
                   }
-                  label="secret"
-                  name="secret"
+                  name="component1"
                   render={[Function]}
-                  type="text"
                   validate={[Function]}
                 >
                   <Field
                     FieldArrayProvider={[Function]}
                     FieldProvider={[Function]}
-                    autoFocus={false}
-                    default="I'm a hidden string."
                     formOptions={
                       Object {
                         "batch": [Function],
@@ -1072,7 +279,328 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       }
                     }
                     format={[Function]}
-                    label="secret"
+                    name="component1"
+                    parse={[Function]}
+                    reactFinalForm={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "destroyOnUnregister": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "mutators": Object {
+                          "concat": [Function],
+                          "insert": [Function],
+                          "move": [Function],
+                          "pop": [Function],
+                          "push": [Function],
+                          "remove": [Function],
+                          "removeBatch": [Function],
+                          "shift": [Function],
+                          "swap": [Function],
+                          "unshift": [Function],
+                          "update": [Function],
+                        },
+                        "pauseValidation": [Function],
+                        "registerField": [Function],
+                        "reset": [Function],
+                        "resetFieldState": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                      }
+                    }
+                    render={[Function]}
+                    validate={[Function]}
+                  >
+                    <Component
+                      FieldArrayProvider={[Function]}
+                      FieldProvider={[Function]}
+                      formOptions={
+                        Object {
+                          "batch": [Function],
+                          "blur": [Function],
+                          "change": [Function],
+                          "clearOnUnmount": false,
+                          "clearedValue": undefined,
+                          "concat": [Function],
+                          "destroyOnUnregister": false,
+                          "focus": [Function],
+                          "getFieldState": [Function],
+                          "getRegisteredFields": [Function],
+                          "getState": [Function],
+                          "handleSubmit": [Function],
+                          "initialize": [Function],
+                          "insert": [Function],
+                          "isValidationPaused": [Function],
+                          "move": [Function],
+                          "onCancel": undefined,
+                          "onSubmit": [MockFunction],
+                          "pauseValidation": [Function],
+                          "pop": [Function],
+                          "pristine": true,
+                          "push": [Function],
+                          "registerField": [Function],
+                          "remove": [Function],
+                          "removeBatch": [Function],
+                          "renderForm": [Function],
+                          "reset": [Function],
+                          "resetFieldState": [Function],
+                          "resumeValidation": [Function],
+                          "setConfig": [Function],
+                          "shift": [Function],
+                          "submit": [Function],
+                          "subscribe": [Function],
+                          "swap": [Function],
+                          "unshift": [Function],
+                          "update": [Function],
+                          "valid": true,
+                        }
+                      }
+                      input={
+                        Object {
+                          "name": "component1",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": undefined,
+                          "invalid": false,
+                          "modified": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "submitting": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                    >
+                      <div
+                        className="nested-item"
+                      >
+                        Text field
+                      </div>
+                    </Component>
+                  </Field>
+                </ReactFinalForm(Field)>
+              </FieldProvider>
+            </FieldWrapper>
+          </FormFieldHideWrapper>
+        </FormConditionWrapper>
+        <FormConditionWrapper>
+          <FormFieldHideWrapper
+            hideField={false}
+          >
+            <FieldWrapper
+              component={[Function]}
+              componentType="select-field"
+              formOptions={
+                Object {
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "clearOnUnmount": false,
+                  "clearedValue": undefined,
+                  "concat": [Function],
+                  "destroyOnUnregister": false,
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
+                  "getState": [Function],
+                  "handleSubmit": [Function],
+                  "initialize": [Function],
+                  "insert": [Function],
+                  "isValidationPaused": [Function],
+                  "move": [Function],
+                  "onCancel": undefined,
+                  "onSubmit": [MockFunction],
+                  "pauseValidation": [Function],
+                  "pop": [Function],
+                  "pristine": true,
+                  "push": [Function],
+                  "registerField": [Function],
+                  "remove": [Function],
+                  "removeBatch": [Function],
+                  "renderForm": [Function],
+                  "reset": [Function],
+                  "resetFieldState": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "shift": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
+                  "swap": [Function],
+                  "unshift": [Function],
+                  "update": [Function],
+                  "valid": true,
+                }
+              }
+              name="secret"
+              validate={
+                Array [
+                  undefined,
+                ]
+              }
+            >
+              <FieldProvider
+                FieldArrayProvider={[Function]}
+                FieldProvider={[Function]}
+                component={[Function]}
+                formOptions={
+                  Object {
+                    "batch": [Function],
+                    "blur": [Function],
+                    "change": [Function],
+                    "clearOnUnmount": false,
+                    "clearedValue": undefined,
+                    "concat": [Function],
+                    "destroyOnUnregister": false,
+                    "focus": [Function],
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "handleSubmit": [Function],
+                    "initialize": [Function],
+                    "insert": [Function],
+                    "isValidationPaused": [Function],
+                    "move": [Function],
+                    "onCancel": undefined,
+                    "onSubmit": [MockFunction],
+                    "pauseValidation": [Function],
+                    "pop": [Function],
+                    "pristine": true,
+                    "push": [Function],
+                    "registerField": [Function],
+                    "remove": [Function],
+                    "removeBatch": [Function],
+                    "renderForm": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "shift": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                    "valid": true,
+                  }
+                }
+                name="secret"
+                validate={[Function]}
+              >
+                <ReactFinalForm(Field)
+                  FieldArrayProvider={[Function]}
+                  FieldProvider={[Function]}
+                  formOptions={
+                    Object {
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "clearOnUnmount": false,
+                      "clearedValue": undefined,
+                      "concat": [Function],
+                      "destroyOnUnregister": false,
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "handleSubmit": [Function],
+                      "initialize": [Function],
+                      "insert": [Function],
+                      "isValidationPaused": [Function],
+                      "move": [Function],
+                      "onCancel": undefined,
+                      "onSubmit": [MockFunction],
+                      "pauseValidation": [Function],
+                      "pop": [Function],
+                      "pristine": true,
+                      "push": [Function],
+                      "registerField": [Function],
+                      "remove": [Function],
+                      "removeBatch": [Function],
+                      "renderForm": [Function],
+                      "reset": [Function],
+                      "resetFieldState": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "shift": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
+                      "swap": [Function],
+                      "unshift": [Function],
+                      "update": [Function],
+                      "valid": true,
+                    }
+                  }
+                  name="secret"
+                  render={[Function]}
+                  validate={[Function]}
+                >
+                  <Field
+                    FieldArrayProvider={[Function]}
+                    FieldProvider={[Function]}
+                    formOptions={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "clearOnUnmount": false,
+                        "clearedValue": undefined,
+                        "concat": [Function],
+                        "destroyOnUnregister": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "handleSubmit": [Function],
+                        "initialize": [Function],
+                        "insert": [Function],
+                        "isValidationPaused": [Function],
+                        "move": [Function],
+                        "onCancel": undefined,
+                        "onSubmit": [MockFunction],
+                        "pauseValidation": [Function],
+                        "pop": [Function],
+                        "pristine": true,
+                        "push": [Function],
+                        "registerField": [Function],
+                        "remove": [Function],
+                        "removeBatch": [Function],
+                        "renderForm": [Function],
+                        "reset": [Function],
+                        "resetFieldState": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "shift": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                        "valid": true,
+                      }
+                    }
+                    format={[Function]}
                     name="secret"
                     parse={[Function]}
                     reactFinalForm={
@@ -1111,14 +639,11 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       }
                     }
                     render={[Function]}
-                    type="text"
                     validate={[Function]}
                   >
                     <Component
                       FieldArrayProvider={[Function]}
                       FieldProvider={[Function]}
-                      autoFocus={false}
-                      default="I'm a hidden string."
                       formOptions={
                         Object {
                           "batch": [Function],
@@ -1166,1464 +691,9 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                           "onBlur": [Function],
                           "onChange": [Function],
                           "onFocus": [Function],
-                          "value": "I'm a hidden string.",
-                        }
-                      }
-                      label="secret"
-                      meta={
-                        Object {
-                          "active": false,
-                          "data": Object {},
-                          "dirty": false,
-                          "dirtySinceLastSubmit": false,
-                          "error": undefined,
-                          "initial": "I'm a hidden string.",
-                          "invalid": false,
-                          "modified": false,
-                          "pristine": true,
-                          "submitError": undefined,
-                          "submitFailed": false,
-                          "submitSucceeded": false,
-                          "submitting": false,
-                          "touched": false,
-                          "valid": true,
-                          "visited": false,
-                        }
-                      }
-                      type="text"
-                    >
-                      <div
-                        className="nested-item"
-                      >
-                        Text field
-                      </div>
-                    </Component>
-                  </Field>
-                </ReactFinalForm(Field)>
-              </FieldProvider>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="text-field"
-              dataType="string"
-              default="I am disabled."
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              label="A disabled field"
-              name="disabled"
-              title="A disabled field"
-              type="text"
-              validate={
-                Array [
-                  [Function],
-                ]
-              }
-            >
-              <FieldProvider
-                FieldArrayProvider={[Function]}
-                FieldProvider={[Function]}
-                autoFocus={false}
-                component={[Function]}
-                dataType="string"
-                default="I am disabled."
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                label="A disabled field"
-                name="disabled"
-                title="A disabled field"
-                type="text"
-                validate={[Function]}
-              >
-                <ReactFinalForm(Field)
-                  FieldArrayProvider={[Function]}
-                  FieldProvider={[Function]}
-                  autoFocus={false}
-                  default="I am disabled."
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
-                  }
-                  label="A disabled field"
-                  name="disabled"
-                  render={[Function]}
-                  title="A disabled field"
-                  type="text"
-                  validate={[Function]}
-                >
-                  <Field
-                    FieldArrayProvider={[Function]}
-                    FieldProvider={[Function]}
-                    autoFocus={false}
-                    default="I am disabled."
-                    formOptions={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "clearOnUnmount": false,
-                        "clearedValue": undefined,
-                        "concat": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "handleSubmit": [Function],
-                        "initialize": [Function],
-                        "insert": [Function],
-                        "isValidationPaused": [Function],
-                        "move": [Function],
-                        "onCancel": undefined,
-                        "onSubmit": [MockFunction],
-                        "pauseValidation": [Function],
-                        "pop": [Function],
-                        "pristine": true,
-                        "push": [Function],
-                        "registerField": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "renderForm": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "shift": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                        "valid": true,
-                      }
-                    }
-                    format={[Function]}
-                    label="A disabled field"
-                    name="disabled"
-                    parse={[Function]}
-                    reactFinalForm={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "initialize": [Function],
-                        "isValidationPaused": [Function],
-                        "mutators": Object {
-                          "concat": [Function],
-                          "insert": [Function],
-                          "move": [Function],
-                          "pop": [Function],
-                          "push": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "shift": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                        },
-                        "pauseValidation": [Function],
-                        "registerField": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                      }
-                    }
-                    render={[Function]}
-                    title="A disabled field"
-                    type="text"
-                    validate={[Function]}
-                  >
-                    <Component
-                      FieldArrayProvider={[Function]}
-                      FieldProvider={[Function]}
-                      autoFocus={false}
-                      default="I am disabled."
-                      formOptions={
-                        Object {
-                          "batch": [Function],
-                          "blur": [Function],
-                          "change": [Function],
-                          "clearOnUnmount": false,
-                          "clearedValue": undefined,
-                          "concat": [Function],
-                          "destroyOnUnregister": false,
-                          "focus": [Function],
-                          "getFieldState": [Function],
-                          "getRegisteredFields": [Function],
-                          "getState": [Function],
-                          "handleSubmit": [Function],
-                          "initialize": [Function],
-                          "insert": [Function],
-                          "isValidationPaused": [Function],
-                          "move": [Function],
-                          "onCancel": undefined,
-                          "onSubmit": [MockFunction],
-                          "pauseValidation": [Function],
-                          "pop": [Function],
-                          "pristine": true,
-                          "push": [Function],
-                          "registerField": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "renderForm": [Function],
-                          "reset": [Function],
-                          "resetFieldState": [Function],
-                          "resumeValidation": [Function],
-                          "setConfig": [Function],
-                          "shift": [Function],
-                          "submit": [Function],
-                          "subscribe": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                          "valid": true,
-                        }
-                      }
-                      input={
-                        Object {
-                          "name": "disabled",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onFocus": [Function],
-                          "value": "I am disabled.",
-                        }
-                      }
-                      label="A disabled field"
-                      meta={
-                        Object {
-                          "active": false,
-                          "data": Object {},
-                          "dirty": false,
-                          "dirtySinceLastSubmit": false,
-                          "error": undefined,
-                          "initial": "I am disabled.",
-                          "invalid": false,
-                          "modified": false,
-                          "pristine": true,
-                          "submitError": undefined,
-                          "submitFailed": false,
-                          "submitSucceeded": false,
-                          "submitting": false,
-                          "touched": false,
-                          "valid": true,
-                          "visited": false,
-                        }
-                      }
-                      title="A disabled field"
-                      type="text"
-                    >
-                      <div
-                        className="nested-item"
-                      >
-                        Text field
-                      </div>
-                    </Component>
-                  </Field>
-                </ReactFinalForm(Field)>
-              </FieldProvider>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="text-field"
-              dataType="string"
-              default="I am read-only."
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              label="A readonly field"
-              name="readonly"
-              title="A readonly field"
-              type="text"
-              validate={
-                Array [
-                  [Function],
-                ]
-              }
-            >
-              <FieldProvider
-                FieldArrayProvider={[Function]}
-                FieldProvider={[Function]}
-                autoFocus={false}
-                component={[Function]}
-                dataType="string"
-                default="I am read-only."
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                label="A readonly field"
-                name="readonly"
-                title="A readonly field"
-                type="text"
-                validate={[Function]}
-              >
-                <ReactFinalForm(Field)
-                  FieldArrayProvider={[Function]}
-                  FieldProvider={[Function]}
-                  autoFocus={false}
-                  default="I am read-only."
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
-                  }
-                  label="A readonly field"
-                  name="readonly"
-                  render={[Function]}
-                  title="A readonly field"
-                  type="text"
-                  validate={[Function]}
-                >
-                  <Field
-                    FieldArrayProvider={[Function]}
-                    FieldProvider={[Function]}
-                    autoFocus={false}
-                    default="I am read-only."
-                    formOptions={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "clearOnUnmount": false,
-                        "clearedValue": undefined,
-                        "concat": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "handleSubmit": [Function],
-                        "initialize": [Function],
-                        "insert": [Function],
-                        "isValidationPaused": [Function],
-                        "move": [Function],
-                        "onCancel": undefined,
-                        "onSubmit": [MockFunction],
-                        "pauseValidation": [Function],
-                        "pop": [Function],
-                        "pristine": true,
-                        "push": [Function],
-                        "registerField": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "renderForm": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "shift": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                        "valid": true,
-                      }
-                    }
-                    format={[Function]}
-                    label="A readonly field"
-                    name="readonly"
-                    parse={[Function]}
-                    reactFinalForm={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "initialize": [Function],
-                        "isValidationPaused": [Function],
-                        "mutators": Object {
-                          "concat": [Function],
-                          "insert": [Function],
-                          "move": [Function],
-                          "pop": [Function],
-                          "push": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "shift": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                        },
-                        "pauseValidation": [Function],
-                        "registerField": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                      }
-                    }
-                    render={[Function]}
-                    title="A readonly field"
-                    type="text"
-                    validate={[Function]}
-                  >
-                    <Component
-                      FieldArrayProvider={[Function]}
-                      FieldProvider={[Function]}
-                      autoFocus={false}
-                      default="I am read-only."
-                      formOptions={
-                        Object {
-                          "batch": [Function],
-                          "blur": [Function],
-                          "change": [Function],
-                          "clearOnUnmount": false,
-                          "clearedValue": undefined,
-                          "concat": [Function],
-                          "destroyOnUnregister": false,
-                          "focus": [Function],
-                          "getFieldState": [Function],
-                          "getRegisteredFields": [Function],
-                          "getState": [Function],
-                          "handleSubmit": [Function],
-                          "initialize": [Function],
-                          "insert": [Function],
-                          "isValidationPaused": [Function],
-                          "move": [Function],
-                          "onCancel": undefined,
-                          "onSubmit": [MockFunction],
-                          "pauseValidation": [Function],
-                          "pop": [Function],
-                          "pristine": true,
-                          "push": [Function],
-                          "registerField": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "renderForm": [Function],
-                          "reset": [Function],
-                          "resetFieldState": [Function],
-                          "resumeValidation": [Function],
-                          "setConfig": [Function],
-                          "shift": [Function],
-                          "submit": [Function],
-                          "subscribe": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                          "valid": true,
-                        }
-                      }
-                      input={
-                        Object {
-                          "name": "readonly",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onFocus": [Function],
-                          "value": "I am read-only.",
-                        }
-                      }
-                      label="A readonly field"
-                      meta={
-                        Object {
-                          "active": false,
-                          "data": Object {},
-                          "dirty": false,
-                          "dirtySinceLastSubmit": false,
-                          "error": undefined,
-                          "initial": "I am read-only.",
-                          "invalid": false,
-                          "modified": false,
-                          "pristine": true,
-                          "submitError": undefined,
-                          "submitFailed": false,
-                          "submitSucceeded": false,
-                          "submitting": false,
-                          "touched": false,
-                          "valid": true,
-                          "visited": false,
-                        }
-                      }
-                      title="A readonly field"
-                      type="text"
-                    >
-                      <div
-                        className="nested-item"
-                      >
-                        Text field
-                      </div>
-                    </Component>
-                  </Field>
-                </ReactFinalForm(Field)>
-              </FieldProvider>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="text-field"
-              dataType="string"
-              default="I am yellow"
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              label="Custom widget with options"
-              name="widgetOptions"
-              title="Custom widget with options"
-              type="text"
-              validate={
-                Array [
-                  [Function],
-                ]
-              }
-            >
-              <FieldProvider
-                FieldArrayProvider={[Function]}
-                FieldProvider={[Function]}
-                autoFocus={false}
-                component={[Function]}
-                dataType="string"
-                default="I am yellow"
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                label="Custom widget with options"
-                name="widgetOptions"
-                title="Custom widget with options"
-                type="text"
-                validate={[Function]}
-              >
-                <ReactFinalForm(Field)
-                  FieldArrayProvider={[Function]}
-                  FieldProvider={[Function]}
-                  autoFocus={false}
-                  default="I am yellow"
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
-                  }
-                  label="Custom widget with options"
-                  name="widgetOptions"
-                  render={[Function]}
-                  title="Custom widget with options"
-                  type="text"
-                  validate={[Function]}
-                >
-                  <Field
-                    FieldArrayProvider={[Function]}
-                    FieldProvider={[Function]}
-                    autoFocus={false}
-                    default="I am yellow"
-                    formOptions={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "clearOnUnmount": false,
-                        "clearedValue": undefined,
-                        "concat": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "handleSubmit": [Function],
-                        "initialize": [Function],
-                        "insert": [Function],
-                        "isValidationPaused": [Function],
-                        "move": [Function],
-                        "onCancel": undefined,
-                        "onSubmit": [MockFunction],
-                        "pauseValidation": [Function],
-                        "pop": [Function],
-                        "pristine": true,
-                        "push": [Function],
-                        "registerField": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "renderForm": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "shift": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                        "valid": true,
-                      }
-                    }
-                    format={[Function]}
-                    label="Custom widget with options"
-                    name="widgetOptions"
-                    parse={[Function]}
-                    reactFinalForm={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "initialize": [Function],
-                        "isValidationPaused": [Function],
-                        "mutators": Object {
-                          "concat": [Function],
-                          "insert": [Function],
-                          "move": [Function],
-                          "pop": [Function],
-                          "push": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "shift": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                        },
-                        "pauseValidation": [Function],
-                        "registerField": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                      }
-                    }
-                    render={[Function]}
-                    title="Custom widget with options"
-                    type="text"
-                    validate={[Function]}
-                  >
-                    <Component
-                      FieldArrayProvider={[Function]}
-                      FieldProvider={[Function]}
-                      autoFocus={false}
-                      default="I am yellow"
-                      formOptions={
-                        Object {
-                          "batch": [Function],
-                          "blur": [Function],
-                          "change": [Function],
-                          "clearOnUnmount": false,
-                          "clearedValue": undefined,
-                          "concat": [Function],
-                          "destroyOnUnregister": false,
-                          "focus": [Function],
-                          "getFieldState": [Function],
-                          "getRegisteredFields": [Function],
-                          "getState": [Function],
-                          "handleSubmit": [Function],
-                          "initialize": [Function],
-                          "insert": [Function],
-                          "isValidationPaused": [Function],
-                          "move": [Function],
-                          "onCancel": undefined,
-                          "onSubmit": [MockFunction],
-                          "pauseValidation": [Function],
-                          "pop": [Function],
-                          "pristine": true,
-                          "push": [Function],
-                          "registerField": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "renderForm": [Function],
-                          "reset": [Function],
-                          "resetFieldState": [Function],
-                          "resumeValidation": [Function],
-                          "setConfig": [Function],
-                          "shift": [Function],
-                          "submit": [Function],
-                          "subscribe": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                          "valid": true,
-                        }
-                      }
-                      input={
-                        Object {
-                          "name": "widgetOptions",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onFocus": [Function],
-                          "value": "I am yellow",
-                        }
-                      }
-                      label="Custom widget with options"
-                      meta={
-                        Object {
-                          "active": false,
-                          "data": Object {},
-                          "dirty": false,
-                          "dirtySinceLastSubmit": false,
-                          "error": undefined,
-                          "initial": "I am yellow",
-                          "invalid": false,
-                          "modified": false,
-                          "pristine": true,
-                          "submitError": undefined,
-                          "submitFailed": false,
-                          "submitSucceeded": false,
-                          "submitting": false,
-                          "touched": false,
-                          "valid": true,
-                          "visited": false,
-                        }
-                      }
-                      title="Custom widget with options"
-                      type="text"
-                    >
-                      <div
-                        className="nested-item"
-                      >
-                        Text field
-                      </div>
-                    </Component>
-                  </Field>
-                </ReactFinalForm(Field)>
-              </FieldProvider>
-            </FieldWrapper>
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-        <FormConditionWrapper>
-          <FormFieldHideWrapper
-            hideField={false}
-          >
-            <FieldWrapper
-              autoFocus={false}
-              component={[Function]}
-              componentType="select-field"
-              dataType="string"
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
-              label="Custom select widget with options"
-              name="selectWidgetOptions"
-              options={
-                Array [
-                  Object {
-                    "disabled": undefined,
-                    "label": "Please Choose",
-                  },
-                  Object {
-                    "label": "Foo",
-                    "value": "foo",
-                  },
-                  Object {
-                    "label": "Bar",
-                    "value": "bar",
-                  },
-                ]
-              }
-              title="Custom select widget with options"
-              type="string"
-              validate={
-                Array [
-                  [Function],
-                ]
-              }
-            >
-              <FieldProvider
-                FieldArrayProvider={[Function]}
-                FieldProvider={[Function]}
-                autoFocus={false}
-                component={[Function]}
-                dataType="string"
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
-                label="Custom select widget with options"
-                name="selectWidgetOptions"
-                options={
-                  Array [
-                    Object {
-                      "disabled": undefined,
-                      "label": "Please Choose",
-                    },
-                    Object {
-                      "label": "Foo",
-                      "value": "foo",
-                    },
-                    Object {
-                      "label": "Bar",
-                      "value": "bar",
-                    },
-                  ]
-                }
-                title="Custom select widget with options"
-                type="string"
-                validate={[Function]}
-              >
-                <ReactFinalForm(Field)
-                  FieldArrayProvider={[Function]}
-                  FieldProvider={[Function]}
-                  autoFocus={false}
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
-                  }
-                  label="Custom select widget with options"
-                  name="selectWidgetOptions"
-                  options={
-                    Array [
-                      Object {
-                        "disabled": undefined,
-                        "label": "Please Choose",
-                      },
-                      Object {
-                        "label": "Foo",
-                        "value": "foo",
-                      },
-                      Object {
-                        "label": "Bar",
-                        "value": "bar",
-                      },
-                    ]
-                  }
-                  render={[Function]}
-                  title="Custom select widget with options"
-                  type="string"
-                  validate={[Function]}
-                >
-                  <Field
-                    FieldArrayProvider={[Function]}
-                    FieldProvider={[Function]}
-                    autoFocus={false}
-                    formOptions={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "clearOnUnmount": false,
-                        "clearedValue": undefined,
-                        "concat": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "handleSubmit": [Function],
-                        "initialize": [Function],
-                        "insert": [Function],
-                        "isValidationPaused": [Function],
-                        "move": [Function],
-                        "onCancel": undefined,
-                        "onSubmit": [MockFunction],
-                        "pauseValidation": [Function],
-                        "pop": [Function],
-                        "pristine": true,
-                        "push": [Function],
-                        "registerField": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "renderForm": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "shift": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                        "valid": true,
-                      }
-                    }
-                    format={[Function]}
-                    label="Custom select widget with options"
-                    name="selectWidgetOptions"
-                    options={
-                      Array [
-                        Object {
-                          "disabled": undefined,
-                          "label": "Please Choose",
-                        },
-                        Object {
-                          "label": "Foo",
-                          "value": "foo",
-                        },
-                        Object {
-                          "label": "Bar",
-                          "value": "bar",
-                        },
-                      ]
-                    }
-                    parse={[Function]}
-                    reactFinalForm={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "initialize": [Function],
-                        "isValidationPaused": [Function],
-                        "mutators": Object {
-                          "concat": [Function],
-                          "insert": [Function],
-                          "move": [Function],
-                          "pop": [Function],
-                          "push": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "shift": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                        },
-                        "pauseValidation": [Function],
-                        "registerField": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                      }
-                    }
-                    render={[Function]}
-                    title="Custom select widget with options"
-                    type="string"
-                    validate={[Function]}
-                  >
-                    <Component
-                      FieldArrayProvider={[Function]}
-                      FieldProvider={[Function]}
-                      autoFocus={false}
-                      formOptions={
-                        Object {
-                          "batch": [Function],
-                          "blur": [Function],
-                          "change": [Function],
-                          "clearOnUnmount": false,
-                          "clearedValue": undefined,
-                          "concat": [Function],
-                          "destroyOnUnregister": false,
-                          "focus": [Function],
-                          "getFieldState": [Function],
-                          "getRegisteredFields": [Function],
-                          "getState": [Function],
-                          "handleSubmit": [Function],
-                          "initialize": [Function],
-                          "insert": [Function],
-                          "isValidationPaused": [Function],
-                          "move": [Function],
-                          "onCancel": undefined,
-                          "onSubmit": [MockFunction],
-                          "pauseValidation": [Function],
-                          "pop": [Function],
-                          "pristine": true,
-                          "push": [Function],
-                          "registerField": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "renderForm": [Function],
-                          "reset": [Function],
-                          "resetFieldState": [Function],
-                          "resumeValidation": [Function],
-                          "setConfig": [Function],
-                          "shift": [Function],
-                          "submit": [Function],
-                          "subscribe": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                          "valid": true,
-                        }
-                      }
-                      input={
-                        Object {
-                          "name": "selectWidgetOptions",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onFocus": [Function],
                           "value": "",
                         }
                       }
-                      label="Custom select widget with options"
                       meta={
                         Object {
                           "active": false,
@@ -2644,24 +714,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                           "visited": false,
                         }
                       }
-                      options={
-                        Array [
-                          Object {
-                            "disabled": undefined,
-                            "label": "Please Choose",
-                          },
-                          Object {
-                            "label": "Foo",
-                            "value": "foo",
-                          },
-                          Object {
-                            "label": "Bar",
-                            "value": "bar",
-                          },
-                        ]
-                      }
-                      title="Custom select widget with options"
-                      type="string"
                     >
                       <div
                         className="nested-item"
@@ -2812,51 +864,7 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
       ],
     }
   }
-  schemaType="default"
   showFormControls={true}
-  uiSchema={Object {}}
-  uischema={
-    Object {
-      "boolean": Object {
-        "radio": Object {
-          "ui:widget": "radio",
-        },
-        "select": Object {
-          "ui:widget": "select",
-        },
-      },
-      "disabled": Object {
-        "ui:disabled": true,
-      },
-      "readonly": Object {
-        "ui:readonly": true,
-      },
-      "secret": Object {
-        "ui:widget": "hidden",
-      },
-      "selectWidgetOptions": Object {
-        "ui:options": Object {
-          "backgroundColor": "pink",
-        },
-      },
-      "string": Object {
-        "color": Object {
-          "ui:widget": "color",
-        },
-        "textarea": Object {
-          "ui:options": Object {
-            "rows": 5,
-          },
-          "ui:widget": "textarea",
-        },
-      },
-      "widgetOptions": Object {
-        "ui:options": Object {
-          "backgroundColor": "yellow",
-        },
-      },
-    }
-  }
 >
   <ReactFinalForm
     decorators={

--- a/packages/react-form-renderer/src/tests/form-renderer/form-renderer.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/form-renderer.test.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { Form } from 'react-final-form';
 import FormRenderer from '../../form-renderer';
-import { widgets, uiWidgets } from '../../demo-schemas/mozilla-schemas';
 import { components, layoutComponents } from '../../constants';
 import FormControls from '../../form-renderer/form-controls';
 import SchemaErrorComponent from '../../form-renderer/schema-error-component';
@@ -12,6 +11,8 @@ describe('<FormRenderer />', () => {
   let layoutMapper;
   let formFieldsMapper;
   let initialProps;
+  let schema;
+
   beforeEach(() => {
     formFieldsMapper = {
       [components.TEXT_FIELD]: () => <div className="nested-item">Text field</div>,
@@ -35,15 +36,22 @@ describe('<FormRenderer />', () => {
       [layoutComponents.DESCRIPTION]: ({ children }) => <div>{ children }</div>,
     };
 
+    schema = {
+      fields: [{
+        component: components.TEXT_FIELD,
+        name: 'component1',
+      }, {
+        component: components.SELECT,
+        name: 'secret',
+      }],
+    };
+
     initialProps = {
       formFieldsMapper,
       layoutMapper,
       onSubmit: jest.fn(),
-      schemaType: 'mozilla',
-      schema: widgets,
-      uischema: uiWidgets,
+      schema,
     };
-
   });
 
   it('should render form from schema', () => {
@@ -67,7 +75,7 @@ describe('<FormRenderer />', () => {
       }],
     };
 
-    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schemaWithError } schemaType={ undefined }/>);
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schemaWithError } />);
 
     expect(wrapper.find(SchemaErrorComponent));
     expect(spy).toHaveBeenCalled();
@@ -123,18 +131,23 @@ describe('<FormRenderer />', () => {
         <button id="custom-submit-button" onClick={ submit } type="button">Handle submit</button>
       </div>
     );
-    const wrapper = mount(<FormRenderer { ...initialProps } schemaType="default" schema={{
-      fields: [{
-        component: [ components.TEXT_FIELD ],
-        name: 'visible',
-        label: 'Visible',
-      }, {
-        component: [ components.TEXT_FIELD ],
-        name: 'hidden',
-        label: 'Hidden',
-        hideField: true,
-      }],
-    }} onSubmit={ onSubmit } renderFormButtons={ FormControls }/>);
+    const wrapper = mount(<FormRenderer
+      { ...initialProps }
+      schema={{
+        fields: [{
+          component: [ components.TEXT_FIELD ],
+          name: 'visible',
+          label: 'Visible',
+        }, {
+          component: [ components.TEXT_FIELD ],
+          name: 'hidden',
+          label: 'Hidden',
+          hideField: true,
+        }],
+      }}
+      onSubmit={ onSubmit }
+      renderFormButtons={ FormControls }
+    />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/packages/react-renderer-demo/src/app/pages/renderer/renderer-api.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/renderer-api.md
@@ -37,10 +37,8 @@ Form Renderer provides a lot of customization via props.
 |onStateUpdate|func|A function which will be called with every form update, i.e. `({ values }) => setValues(values)`||
 |disableSubmit|array of strings|You can specify a form attributes (see [here](https://final-form.org/docs/final-form/types/FormState)) which will make the submit button disabled. |[ ]|
 |initialValues|object|An object of fields names as keys and values as their values.||
-|schemaType|one of `['mozilla', 'miq', 'default']`|Data driven forms includes two basic parsers: mozilla and manageiq service dialogs.|'default'|
 |showFormControls|bool|You can disable showing form buttons. Use it with wizard component which has its own buttons.|true|
 |subscription|object|You can pass your own [subscription](https://final-form.org/docs/react-final-form/types/FormProps#subscription), which will be added to default settings.|`{ pristine: true, submitting: true, valid: true }`|
-|uiSchema|object|Use when you need to use mozilla schema.|{ }|
 |<RouterLink href="/renderer/validators"><Link href="/renderer/validators">validate</Link></RouterLink>|func|A function which receives all form values and returns an object with errors.||
 
 # Schema

--- a/packages/react-renderer-demo/src/app/src/components/navigation/schema.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/schema.js
@@ -5,10 +5,6 @@ import flatMap from 'lodash/flatMap';
 
 const schema =  [
   {
-    linkText: 'Demo',
-    link: 'show-case',
-  },
-  {
     linkText: 'Live Form Editor',
     link: 'live-editor',
   },


### PR DESCRIPTION
- removes `formType`
- removes ability to parse different schemas (parsers could be exported separately)
- removes `resetAble` formType
