### PR TITLE
ComponentExample cleanup

### DIFF
--- a/packages/react-renderer-demo/src/app/pages/_app.js
+++ b/packages/react-renderer-demo/src/app/pages/_app.js
@@ -19,6 +19,15 @@ export default class MyApp extends App {
     }
   }
 
+  static async getInitialProps ({ Component, router, ctx }) {
+    let page = {};
+    if (Component.getInitialProps) {
+      page = await Component.getInitialProps(ctx);
+    }
+
+    return { page };
+  }
+
   render() {
     const { Component, pageProps } = this.props;
 

--- a/packages/react-renderer-demo/src/app/pages/component-example/checkbox-multiple.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/checkbox-multiple.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Checkbox multiple
 
-<ComponentExample component="checkbox-multiple" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/checkbox.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/checkbox.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Checkbox
 
-<ComponentExample component="checkbox" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/date-picker.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/date-picker.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Date picker
 
-<ComponentExample component="date-picker" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/plain-text.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/plain-text.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Plain text
 
-<ComponentExample component="plain-text" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/radio.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/radio.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Radio
 
-<ComponentExample component="radio" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/select-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/select-field.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Select
 
-<ComponentExample component="select-field" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/sub-form.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/sub-form.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Subform
 
-<ComponentExample component="sub-form" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/switch-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/switch-field.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Switch
 
-<ComponentExample component="switch-field" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/tabs.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/tabs.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Tabs
 
-<ComponentExample component="tabs" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/text-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/text-field.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Text field
 
-<ComponentExample component="text-field" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/textarea-field.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/textarea-field.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Text area
 
-<ComponentExample component="textarea-field" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/time-picker.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/time-picker.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Time picker
 
-<ComponentExample component="time-picker" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/pages/component-example/wizard.md
+++ b/packages/react-renderer-demo/src/app/pages/component-example/wizard.md
@@ -1,5 +1,5 @@
-import ComponentExample from '../../src/components/component-example';
+import ComponentText from '@docs/components/component-example-text';
 
 # Wizard
 
-<ComponentExample component="wizard" />
+<ComponentText />

--- a/packages/react-renderer-demo/src/app/src/common/examples-texts/select.js
+++ b/packages/react-renderer-demo/src/app/src/common/examples-texts/select.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import GenericComponentText from './generic-mui-component';
-import Pf3Select from 'docs/components/pf3-select.md';
-import Pf4Select from 'docs/components/pf4-select.md';
-
-export default ({ activeMapper }) => activeMapper === 'pf3' ? <Pf3Select /> : activeMapper === 'pf4' ? <Pf4Select /> : <GenericComponentText />;

--- a/packages/react-renderer-demo/src/app/src/components/component-example-text.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example-text.js
@@ -13,10 +13,10 @@ const ComponentExampleText = (props) => {
 
   const baseStructure = baseExamples.find(item => item.component === component);
 
-  return <React.Fragment>
+  return (<React.Fragment>
     <ComponentExample activeMapper={ activeMapper } component={ component }/>
-    <baseStructure.ContentText activeMapper={ activeMapper } component={ component }/>;
-  </React.Fragment>;
+    <baseStructure.ContentText activeMapper={ activeMapper } component={ component }/>
+  </React.Fragment>);
 };
 
 export default ComponentExampleText;

--- a/packages/react-renderer-demo/src/app/src/components/component-example-text.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example-text.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import { baseExamples } from '@docs/components/navigation/examples-definitions';
+import ComponentExample from '@docs/components/component-example';
+
+const ComponentExampleText = (props) => {
+  const router = useRouter();
+
+  const activeMapper = router.query.mapper || 'mui';
+
+  const pathname = router.pathname;
+  let component = pathname.split('/').pop();
+
+  const baseStructure = baseExamples.find(item => item.component === component);
+
+  return <React.Fragment>
+    <ComponentExample activeMapper={ activeMapper } component={ component }/>
+    <baseStructure.ContentText activeMapper={ activeMapper } component={ component }/>;
+  </React.Fragment>;
+};
+
+export default ComponentExampleText;

--- a/packages/react-renderer-demo/src/app/src/components/component-example-text.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example-text.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { baseExamples } from '@docs/components/navigation/examples-definitions';
 import ComponentExample from '@docs/components/component-example';
 
-const ComponentExampleText = (props) => {
+const ComponentExampleText = () => {
   const router = useRouter();
 
   const activeMapper = router.query.mapper || 'mui';

--- a/packages/react-renderer-demo/src/app/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example.js
@@ -291,22 +291,12 @@ class ComponentExample extends Component {
         direction="row"
         spacing={ 4 }
       >
-        <Grid item xs={ 4 } >
-          <Typography variant="h5" gutterBottom>
+        <Grid item xs={ 12 } md={ 4 } >
+          <Grid item xs={ 12 }>
+            <Typography variant="h5" gutterBottom>
               Schema
-          </Typography>
-        </Grid>
-        <Grid item xs={ 3 } >
-          <Typography variant="h5" gutterBottom>
-              Props
-          </Typography>
-        </Grid>
-        <Grid item xs={ 5 } >
-          <Typography variant="h5" gutterBottom>
-              Preview
-          </Typography>
-        </Grid>
-        <Grid item xs={ 4 } >
+            </Typography>
+          </Grid>
           <div style={{ background: '#1d1f21', position: 'relative' }}>
             <Grid item xs={ 12 } container={ true } justify='flex-end' style={{ position: 'absolute', zIndex: 100 }}>
               <CopyToClipboard text={ editedValue } onCopy={ this.handleTooltipOpen }>
@@ -334,14 +324,24 @@ class ComponentExample extends Component {
             />
           </div>
         </Grid>
-        <Grid item xs={ 3 }>
+        <Grid item xs={ 12 } md={ 3 }>
+          <Grid item xs={ 12 }>
+            <Typography variant="h5" gutterBottom>
+              Props
+            </Typography>
+          </Grid>
           <Card square>
             <CardContent>
               { this.renderActions(variants) }
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={ 5 } >
+        <Grid item xs={ 12 } md={ 5 } >
+          <Grid item xs={ 12 }>
+            <Typography variant="h5" gutterBottom>
+              Preview
+            </Typography>
+          </Grid>
           <Card square style={{ overflow: 'initial' }}>
             <div style={{ padding: 8 }}>
               <FormControl component="fieldset">

--- a/packages/react-renderer-demo/src/app/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example.js
@@ -62,6 +62,12 @@ const useStyles = makeStyles(theme => ({
   close: {
     padding: theme.spacing(0.5),
   },
+  radioLink: {
+    color: 'rgba(0, 0, 0, 0.87)',
+    '&:hover': {
+      textDecoration: 'none',
+    },
+  },
 }));
 
 const CopySnackbar = ({ open, handleClose }) => {
@@ -277,7 +283,7 @@ class ComponentExample extends Component {
   }
   render () {
     const { value, parsedSchema, component, openTooltip, variants } = this.state;
-    const { activeMapper } = this.props;
+    const { activeMapper, classes } = this.props;
 
     const editedValue = value.replace(/^{\n {2}"fields": \[\n/, '')
     .replace(/ {2}\]\n}$/, '')
@@ -353,9 +359,21 @@ class ComponentExample extends Component {
                   onChange={ this.handleMapperChange }
                   style={{ flexDirection: 'row' }}
                 >
-                  <RouterLink href={ `${this.props.router.pathname}?mapper=mui` }><Link href={ `${this.props.router.pathname}?mapper=mui` }><FormControlLabel value="mui" control={ <Radio /> } label="MUI" /></Link></RouterLink>
-                  <RouterLink href={ `${this.props.router.pathname}?mapper=pf3` }><Link href={ `${this.props.router.pathname}?mapper=pf3` }><FormControlLabel value="pf3" control={ <Radio /> } label="PF3" /></Link></RouterLink>
-                  <RouterLink href={ `${this.props.router.pathname}?mapper=pf4` }><Link href={ `${this.props.router.pathname}?mapper=pf4` }><FormControlLabel value="pf4" control={ <Radio /> } label="PF4" /></Link></RouterLink>
+                  <RouterLink href={ `${this.props.router.pathname}?mapper=mui` }>
+                    <Link href={ `${this.props.router.pathname}?mapper=mui` } className={ classes.radioLink }>
+                      <FormControlLabel value="mui" control={ <Radio /> } label="MUI"/>
+                    </Link>
+                  </RouterLink>
+                  <RouterLink href={ `${this.props.router.pathname}?mapper=pf3` }>
+                    <Link href={ `${this.props.router.pathname}?mapper=pf3` } className={ classes.radioLink }>
+                      <FormControlLabel value="pf3" control={ <Radio /> } label="PF3"/>
+                    </Link>
+                  </RouterLink>
+                  <RouterLink href={ `${this.props.router.pathname}?mapper=pf4` }>
+                    <Link href={ `${this.props.router.pathname}?mapper=pf4` } className={ classes.radioLink }>
+                      <FormControlLabel value="pf4" control={ <Radio /> } label="PF4"/>
+                    </Link>
+                  </RouterLink>
                 </RadioGroup>
               </FormControl>
             </div>
@@ -395,14 +413,21 @@ ComponentExample.propTypes = {
   }),
   mappers: PropTypes.object,
   activeMapper: PropTypes.string.isRequired,
+  classes: PropTypes.shape({
+    radioLink: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default (props) => {
   const router = useRouter();
+  const classes = useStyles();
+
+  console.log(classes);
+
   return (
     <MapperContext.Consumer>
       { ({ loaded, mappers }) =>
-        loaded && <ComponentExample { ...props } router={ router } mappers={ mappers } /> }
+        loaded && <ComponentExample { ...props } router={ router } mappers={ mappers } classes={ classes }/> }
     </MapperContext.Consumer>
   );
 };

--- a/packages/react-renderer-demo/src/app/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example.js
@@ -28,6 +28,7 @@ import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import RouterLink from 'next/link';
 import Link from '@material-ui/core/Link';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 import dynamic from 'next/dynamic';
 
@@ -279,8 +280,8 @@ class ComponentExample extends Component {
     } finally {
       this.setState({ value });
     }
-
   }
+
   render () {
     const { value, parsedSchema, component, openTooltip, variants } = this.state;
     const { activeMapper, classes } = this.props;
@@ -422,12 +423,19 @@ export default (props) => {
   const router = useRouter();
   const classes = useStyles();
 
-  console.log(classes);
-
   return (
     <MapperContext.Consumer>
       { ({ loaded, mappers }) =>
-        loaded && <ComponentExample { ...props } router={ router } mappers={ mappers } classes={ classes }/> }
+        loaded ?
+          <ComponentExample { ...props } router={ router } mappers={ mappers } classes={ classes }/> :
+          <Grid
+            container
+            direction="row"
+            justify="center"
+            alignItems="center"
+          >
+            <CircularProgress disableShrink />
+          </Grid> }
     </MapperContext.Consumer>
   );
 };

--- a/packages/react-renderer-demo/src/app/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/app/src/components/component-example.js
@@ -26,6 +26,8 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import MuiWizard from '@docs/components/missing-demo-fields/mui-wizard/mui-wizard';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import RouterLink from 'next/link';
+import Link from '@material-ui/core/Link';
 
 import dynamic from 'next/dynamic';
 
@@ -97,7 +99,10 @@ CopySnackbar.propTypes = {
 class ComponentExample extends Component {
   constructor(props) {
     super(props);
-    const baseStructure = baseExamples.find(item => item.component === props.component);
+
+    const { component } = this.props;
+
+    const baseStructure = baseExamples.find(item => item.component === component);
     if (!baseStructure) {
       this.state = {
         notFound: true,
@@ -119,7 +124,6 @@ class ComponentExample extends Component {
         ],
         value: JSON.stringify(baseStructure.value, null, 2),
         parsedSchema: baseStructure.value,
-        activeMapper: 'mui',
         frameHeight: 360,
         openTooltip: false,
       };
@@ -149,10 +153,6 @@ class ComponentExample extends Component {
         layoutMapper: props.mappers.pf4.layoutMapper,
       },
     };
-  }
-
-  handleMapperChange = (_event, value) => {
-    this.setState({ activeMapper: value });
   }
 
   handleTooltipClose = () => {
@@ -276,7 +276,8 @@ class ComponentExample extends Component {
 
   }
   render () {
-    const { value, parsedSchema, linkText, ContentText, activeMapper, component, openTooltip, variants } = this.state;
+    const { value, parsedSchema, component, openTooltip, variants } = this.state;
+    const { activeMapper } = this.props;
 
     const editedValue = value.replace(/^{\n {2}"fields": \[\n/, '')
     .replace(/ {2}\]\n}$/, '')
@@ -352,9 +353,9 @@ class ComponentExample extends Component {
                   onChange={ this.handleMapperChange }
                   style={{ flexDirection: 'row' }}
                 >
-                  <FormControlLabel value="mui" control={ <Radio /> } label="MUI" />
-                  <FormControlLabel value="pf3" control={ <Radio /> } label="PF3" />
-                  <FormControlLabel value="pf4" control={ <Radio /> } label="PF4" />
+                  <RouterLink href={ `${this.props.router.pathname}?mapper=mui` }><Link href={ `${this.props.router.pathname}?mapper=mui` }><FormControlLabel value="mui" control={ <Radio /> } label="MUI" /></Link></RouterLink>
+                  <RouterLink href={ `${this.props.router.pathname}?mapper=pf3` }><Link href={ `${this.props.router.pathname}?mapper=pf3` }><FormControlLabel value="pf3" control={ <Radio /> } label="PF3" /></Link></RouterLink>
+                  <RouterLink href={ `${this.props.router.pathname}?mapper=pf4` }><Link href={ `${this.props.router.pathname}?mapper=pf4` }><FormControlLabel value="pf4" control={ <Radio /> } label="PF4" /></Link></RouterLink>
                 </RadioGroup>
               </FormControl>
             </div>
@@ -377,9 +378,6 @@ class ComponentExample extends Component {
               Notes
           </Typography>
         </Grid>
-        <Grid item xs={ 12 } >
-          <ContentText activeMapper={ activeMapper } component={ component } />
-        </Grid>
       </Grid>
     );
   }
@@ -390,10 +388,13 @@ ComponentExample.propTypes = {
   router: PropTypes.shape({
     query: PropTypes.shape({
       component: PropTypes.string,
+      mapper: PropTypes.string,
     }),
     push: PropTypes.func.isRequired,
+    pathname: PropTypes.string,
   }),
   mappers: PropTypes.object,
+  activeMapper: PropTypes.string.isRequired,
 };
 
 export default (props) => {


### PR DESCRIPTION
- is possible to use query param to switch the active mapper (you can share the link!)
- specific text for each mapper is rendered on first render => better algolia support
- reworked grids - on smaller screens each of the three boxes takes all 12 columns
- add spinner when editor is being loaded