### PR TITLE
Add releases page to demo

### DIFF
--- a/packages/react-renderer-demo/package.json
+++ b/packages/react-renderer-demo/package.json
@@ -38,6 +38,7 @@
         "firebase-admin": "^8.5.0",
         "firebase-functions": "^2.1.0",
         "grpc": "^1.22.2",
+        "markdown-to-jsx": "^6.10.3",
         "next": "9.1.2",
         "patternfly-react": "^2.25.1",
         "prop-types": "^15.6.2",

--- a/packages/react-renderer-demo/src/app/pages/releases.js
+++ b/packages/react-renderer-demo/src/app/pages/releases.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Markdown from 'markdown-to-jsx';
+import { Heading } from '../src/components/mdx/mdx-components';
+
+const parseData = data => data.map((release) => {
+  return (
+    <React.Fragment key={ release.name }>
+      <Markdown>{ release.body }</Markdown>
+    </React.Fragment>
+  );
+});
+
+const ReleasesPage = () => {
+  const [ data, setData ] = useState(undefined);
+
+  useEffect(() => {
+    fetch('https://api.github.com/repos/data-driven-forms/react-forms/releases?page=1')
+    .then(res => res.json())
+    .then((data) => {
+      setData(parseData(data));
+    })
+    .catch(() => {
+      setData('Something wrong happened :(');
+    });
+  }, []);
+
+  return (<div>
+    <Heading level="4" component="h1">Releases</Heading>
+    { !data ? (<Grid
+      container
+      direction="row"
+      justify="center"
+      alignItems="center"
+    >
+      <CircularProgress disableShrink />
+    </Grid>) : data }
+  </div>);
+};
+
+export default ReleasesPage;

--- a/packages/react-renderer-demo/src/app/pages/releases.js
+++ b/packages/react-renderer-demo/src/app/pages/releases.js
@@ -3,14 +3,17 @@ import Grid from '@material-ui/core/Grid';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Markdown from 'markdown-to-jsx';
 import { Heading } from '../src/components/mdx/mdx-components';
+import mdxComponents from '@docs/components/mdx/mdx-components';
 
-const parseData = data => data.map((release) => {
-  return (
-    <React.Fragment key={ release.name }>
-      <Markdown>{ release.body }</Markdown>
-    </React.Fragment>
-  );
-});
+const options = {
+  overrides: { a: mdxComponents.link },
+};
+
+const parseData = data => data.map((release) => (
+  <React.Fragment key={ release.name }>
+    <Markdown options={ options }>{ release.body }</Markdown>
+  </React.Fragment>
+));
 
 const ReleasesPage = () => {
   const [ data, setData ] = useState(undefined);

--- a/packages/react-renderer-demo/src/app/src/components/navigation/schema.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/schema.js
@@ -8,9 +8,6 @@ const schema =  [
     linkText: 'Live Form Editor',
     link: 'live-editor',
   }, {
-    linkText: 'Releases',
-    link: 'releases',
-  }, {
     title: 'React form renderer',
     link: 'renderer',
     noRoute: true,
@@ -33,6 +30,9 @@ const schema =  [
     fields: [
       ...otherExamples,
     ],
+  }, {
+    linkText: 'Releases',
+    link: 'releases',
   },
 ];
 

--- a/packages/react-renderer-demo/src/app/src/components/navigation/schema.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/schema.js
@@ -7,8 +7,10 @@ const schema =  [
   {
     linkText: 'Live Form Editor',
     link: 'live-editor',
-  },
-  {
+  }, {
+    linkText: 'Releases',
+    link: 'releases',
+  }, {
     title: 'React form renderer',
     link: 'renderer',
     noRoute: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11586,6 +11586,14 @@ markdown-escapes@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.3.tgz#6155e10416efaafab665d466ce598216375195f5"
 
+markdown-to-jsx@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz#7f0946684acd321125ff2de7fd258a9b9c7c40b7"
+  integrity sha512-PSoUyLnW/xoW6RsxZrquSSz5eGEOTwa15H5eqp3enmrp8esmgDJmhzd6zmQ9tgAA9TxJzx1Hmf3incYU/IamoQ==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
+
 marked-terminal@^3.0.0, marked-terminal@^3.2.0, marked-terminal@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-3.3.0.tgz#25ce0c0299285998c7636beaefc87055341ba1bd"
@@ -17507,7 +17515,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
-unquote@~1.1.1:
+unquote@^1.1.0, unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
 


### PR DESCRIPTION
Adds `Releases` page with data obtained by the GitHub's API

![image](https://user-images.githubusercontent.com/32869456/72610257-3392fc00-3927-11ea-846f-db95ea999e47.png)
