### PR TITLE
Set TRAVIS_REPO_SLUG in Circle_CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
       - attach_workspace:
           at: ~/react-forms
       - run:
+          name: 'Setup environment variables'
+          command: 'export TRAVIS_REPO_SLUG=data-driven-forms/react-forms'
+      - run:
           name: Release new version
           command: |
             echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/react-forms/.npmrc


### PR DESCRIPTION
commit-analyzer supports only TRAVIS

https://github.com/karelhala/commit-analyzer-wildcard/blob/00e93203765c9956b8f7efa718c8d3e32cd42db9/packages/release-notes/analyzer.js#L46

So, we need to add this environment variable to CircleCI to properly create links in release notes