### PR TITLE
fix(renderer): prevent double submitting by button

### DIFF
--- a/__mocks__/mock-layout-mapper.js
+++ b/__mocks__/mock-layout-mapper.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { layoutComponents } from "../packages/react-form-renderer/src/constants";
 
 export const layoutMapper = {
-  [layoutComponents.FORM_WRAPPER]: ({ children }) => <div>{ children }</div>,
+  [layoutComponents.FORM_WRAPPER]: ({ children, ...rest }) => <form {...rest}>{ children }</form>,
   [layoutComponents.BUTTON]: ({ label, ...rest }) =>  <button { ...rest }>{ label }</button>,
   [layoutComponents.BUTTON_GROUP]: ({ children }) => <div>{ children }</div>,
   [layoutComponents.TITLE]: ({ children }) => <div>{ children }</div>,

--- a/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
@@ -666,12 +666,10 @@ exports[`FieldArray should render array field correctly 1`] = `
                         <ButtonLayout
                           key="form-submit"
                           label="Submit"
-                          onClick={[Function]}
                           type="submit"
                           variant="primary"
                         >
                           <Component
-                            onClick={[Function]}
                             type="submit"
                             variant="primary"
                           >
@@ -684,7 +682,6 @@ exports[`FieldArray should render array field correctly 1`] = `
                                     undefined,
                                   ],
                                   "isDisabled": undefined,
-                                  "onClick": [Function],
                                   "type": "submit",
                                   "variant": "primary",
                                 }
@@ -692,7 +689,6 @@ exports[`FieldArray should render array field correctly 1`] = `
                               consumerContext={null}
                             >
                               <Button
-                                onClick={[Function]}
                                 ouiaContext={
                                   Object {
                                     "isOuia": false,
@@ -707,7 +703,6 @@ exports[`FieldArray should render array field correctly 1`] = `
                                   aria-label={null}
                                   className="pf-c-button pf-m-primary"
                                   disabled={false}
-                                  onClick={[Function]}
                                   tabIndex={null}
                                   type="submit"
                                 >

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -16,7 +16,7 @@ const submitTest = (...args) => new Promise(resolve => {
 const FormButtons = props => {
     return (
         <div>
-            <button disabled={props.submitting} type="button" onClick={props.form.submit}>Submit</button>
+            <button disabled={props.submitting} type="submit">Submit</button>
         </div>
     )
 }
@@ -31,7 +31,7 @@ const App = () => (
             clearedValue={'bla'}
             layoutMapper={layoutMapper}
             formFieldsMapper={formFieldsMapper}
-            onSubmit={console.log}
+            onSubmit={() => console.log(554)}
             onCancel={console.log}
             canReset
             onReset={() => console.log('i am resseting')}

--- a/packages/react-form-renderer/src/form-renderer/form-controls.js
+++ b/packages/react-form-renderer/src/form-renderer/form-controls.js
@@ -38,7 +38,7 @@ const FormControls = ({
       : (
         <RendererContext.Consumer>
           { ({ layoutMapper: { Button, ButtonGroup }}) => {
-            const { submitting, pristine, validating, form: { submit, reset }, values } = formSpyProps;
+            const { submitting, pristine, validating, form: { reset }, values } = formSpyProps;
             const buttons = {
               submit: (
                 <Button
@@ -46,7 +46,6 @@ const FormControls = ({
                   type="submit"
                   variant="primary"
                   disabled={ submitting || validating || disableSubmit }
-                  onClick={ submit }
                   label={ submitLabel }
                 />
               ),

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-controls.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-controls.test.js.snap
@@ -48,12 +48,10 @@ exports[`<FormControls /> should add missing buttons if not defined in button or
               <Component
                 key="form-submit"
                 label="Submit"
-                onClick={[Function]}
                 type="submit"
                 variant="primary"
               >
                 <button
-                  onClick={[Function]}
                   type="submit"
                   variant="primary"
                 >
@@ -153,13 +151,11 @@ exports[`<FormControls /> should render all controls and with default labels 1`]
                 disabled={true}
                 key="form-submit"
                 label="Submit"
-                onClick={[Function]}
                 type="submit"
                 variant="primary"
               >
                 <button
                   disabled={true}
-                  onClick={[Function]}
                   type="submit"
                   variant="primary"
                 >
@@ -270,12 +266,10 @@ exports[`<FormControls /> should render buttons in correct order 1`] = `
               <Component
                 key="form-submit"
                 label="Submit"
-                onClick={[Function]}
                 type="submit"
                 variant="primary"
               >
                 <button
-                  onClick={[Function]}
                   type="submit"
                   variant="primary"
                 >
@@ -359,12 +353,10 @@ exports[`<FormControls /> should render only submit button 1`] = `
               <Component
                 key="form-submit"
                 label="Submit"
-                onClick={[Function]}
                 type="submit"
                 variant="primary"
               >
                 <button
-                  onClick={[Function]}
                   type="submit"
                   variant="primary"
                 >

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
@@ -131,12 +131,10 @@ exports[`<FormControls /> should render with description 1`] = `
                     <Component
                       key="form-submit"
                       label="Submit"
-                      onClick={[Function]}
                       type="submit"
                       variant="primary"
                     >
                       <button
-                        onClick={[Function]}
                         type="submit"
                         variant="primary"
                       >
@@ -292,12 +290,10 @@ exports[`<FormControls /> should render with title and description 1`] = `
                     <Component
                       key="form-submit"
                       label="Submit"
-                      onClick={[Function]}
                       type="submit"
                       variant="primary"
                     >
                       <button
-                        onClick={[Function]}
                         type="submit"
                         variant="primary"
                       >
@@ -441,12 +437,10 @@ exports[`<FormControls /> should render without title and description 1`] = `
                     <Component
                       key="form-submit"
                       label="Submit"
-                      onClick={[Function]}
                       type="submit"
                       variant="primary"
                     >
                       <button
-                        onClick={[Function]}
                         type="submit"
                         variant="primary"
                       >

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -787,12 +787,10 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   <Component
                     key="form-submit"
                     label="Submit"
-                    onClick={[Function]}
                     type="submit"
                     variant="primary"
                   >
                     <button
-                      onClick={[Function]}
                       type="submit"
                       variant="primary"
                     >

--- a/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
@@ -28,7 +28,6 @@ describe('data types', () => {
   let initialProps;
   beforeEach(() => {
     initialProps = {
-      onSubmit: jest.fn(),
       layoutMapper,
       formFieldsMapper: {
         [componentTypes.TEXT_FIELD]: DataTypeInput,
@@ -62,7 +61,10 @@ describe('data types', () => {
     expect(onSubmit).not.toHaveBeenCalled();
 
     input.simulate('change', { target: { value: '123' }});
-    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+
+    wrapper.find('form').first().simulate('submit');
+
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
       'data-type-text': 123,
     }), expect.anything(), expect.anything());
@@ -82,7 +84,7 @@ describe('data types', () => {
     const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } schema={ propSchema } />);
     const input = wrapper.find('input');
     input.simulate('change', { target: { value: '123' }});
-    wrapper.find('button').first().simulate('click');
+    wrapper.find('form').first().simulate('submit');
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
       'data-type-text': 123,
     }), expect.anything(), expect.anything());
@@ -102,7 +104,7 @@ describe('data types', () => {
     const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } schema={ renderSchema } />);
     const input = wrapper.find('input');
     input.simulate('change', { target: { value: '123' }});
-    wrapper.find('button').first().simulate('click');
+    wrapper.find('form').first().simulate('submit');
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
       'data-type-text': 123,
     }), expect.anything(), expect.anything());
@@ -122,7 +124,7 @@ describe('data types', () => {
     const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } schema={ childSchema } />);
     const input = wrapper.find('input');
     input.simulate('change', { target: { value: '123' }});
-    wrapper.find('button').first().simulate('click');
+    wrapper.find('form').first().simulate('submit');
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
       'data-type-text': 123,
     }), expect.anything(), expect.anything());


### PR DESCRIPTION
fixes https://github.com/data-driven-forms/react-forms/issues/292

OnClick is removed from the submit button, as the submit event is already included in form.

This breaks some tests as jest cannot call parents' events.
