### PR TITLE
feat(pf4): wizard predicts nextSteps in realtime

### DIFF
--- a/packages/mui-component-mapper/src/form-fields/form-fields.js
+++ b/packages/mui-component-mapper/src/form-fields/form-fields.js
@@ -208,6 +208,7 @@ const FieldInterface = ({
   componentType,
   initialKey,
   FieldArrayProvider, // eslint-disable-line react/prop-types
+  FormSpyProvider, // eslint-disable-line react/prop-types
   ...props
 }) => (
   <Grid xs={ 12 } item style={{ marginBottom: 16, padding: 0 }}>

--- a/packages/mui-component-mapper/src/form-fields/sub-form.js
+++ b/packages/mui-component-mapper/src/form-fields/sub-form.js
@@ -9,6 +9,7 @@ const SubForm = ({
   title,
   description,
   FieldProvider: _FieldProvider,
+  FormSpyProvider: _FormSpyProvider,
   validate: _validate,
   ...rest
 }) => (
@@ -30,6 +31,7 @@ SubForm.propTypes = {
   title: PropTypes.string,
   description: PropTypes.string,
   FieldProvider: PropTypes.any,
+  FormSpyProvider: PropTypes.any,
   validate: PropTypes.any,
 };
 

--- a/packages/pf3-component-mapper/src/form-fields/form-fields.js
+++ b/packages/pf3-component-mapper/src/form-fields/form-fields.js
@@ -139,6 +139,7 @@ const FieldInterface = ({
   componentType,
   initialKey,
   FieldArrayProvider, // eslint-disable-line
+  FormSpyProvider, // eslint-disable-line react/prop-types
   ...props
 }) => (
   fieldMapper(componentType)({

--- a/packages/pf3-component-mapper/src/form-fields/sub-form.js
+++ b/packages/pf3-component-mapper/src/form-fields/sub-form.js
@@ -7,6 +7,7 @@ const SubForm = ({
   title,
   description,
   FieldProvider: _FieldProvider,
+  FormSpyProvider: _FormSpyProvider,
   validate: _validate,
   ...rest
 }) => (
@@ -26,6 +27,7 @@ SubForm.propTypes = {
   title: PropTypes.string,
   description: PropTypes.string,
   FieldProvider: PropTypes.any,
+  FormSpyProvider: PropTypes.any,
   validate: PropTypes.any,
 };
 

--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -32,6 +32,7 @@ export const wizardSchema = {
   fields: [{
     component: componentTypes.WIZARD,
     name: 'wizzard',
+    crossroads: ['source.source-type'],
     predictSteps: true,
     //inModal: true,
     title: 'Title',

--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -21,7 +21,7 @@ const fieldArrayState = { schema: arraySchemaDDF, additionalOptions: {
 class App extends React.Component {
     constructor(props) {
         super(props);
-        this.state = fieldArrayState
+        this.state = { schema: wizardSchema, additionalOptions: { showFormControls: false, wizard: true } }
     }
 
     render() {

--- a/packages/pf4-component-mapper/src/form-fields/fieldArray/index.js
+++ b/packages/pf4-component-mapper/src/form-fields/fieldArray/index.js
@@ -83,6 +83,7 @@ const DynamicArray = ({
   formOptions,
   meta,
   FieldArrayProvider,
+  FormSpyProvider, // eslint-disable-line react/prop-types
   minItems,
   maxItems,
   noItemsMessage,

--- a/packages/pf4-component-mapper/src/form-fields/form-fields.js
+++ b/packages/pf4-component-mapper/src/form-fields/form-fields.js
@@ -136,6 +136,7 @@ const FieldInterface = ({
   componentType,
   initialKey,
   FieldArrayProvider, // catch it and don't send it to components
+  FormSpyProvider, // eslint-disable-line react/prop-types
   ...props
 }) => (
   fieldMapper(componentType)({

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-nav.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { WizardNavItem, WizardNav } from '@patternfly/react-core';
 import isEqual from 'lodash/isEqual';
 import get from 'lodash/get';
+import { PropTypes } from 'prop-types';
 
 const memoValues = (initialValue) => {
   let valueCache = initialValue;
@@ -51,6 +52,16 @@ const WizardNavigationInternal = React.memo(({
     </WizardNavItem>;
   }));
 }, isEqual);
+
+WizardNavigationInternal.propTypes = {
+  activeStepIndex: PropTypes.number.isRequired,
+  formOptions: PropTypes.shape({
+    valid: PropTypes.bool.isRequired,
+  }).isRequired,
+  maxStepIndex: PropTypes.number.isRequired,
+  jumpToStep: PropTypes.func.isRequired,
+  navSchema: PropTypes.array.isRequired,
+};
 
 class WizardNavigationClass extends React.Component {
   constructor(props) {
@@ -111,5 +122,16 @@ class WizardNavigationClass extends React.Component {
     );
   }
 }
+
+WizardNavigationClass.propTypes = {
+  activeStepIndex: PropTypes.number.isRequired,
+  formOptions: PropTypes.object.isRequired,
+  maxStepIndex: PropTypes.number.isRequired,
+  jumpToStep: PropTypes.func.isRequired,
+  setPrevSteps: PropTypes.func.isRequired,
+  navSchema: PropTypes.array.isRequired,
+  values: PropTypes.object.isRequired,
+  crossroads: PropTypes.arrayOf(PropTypes.string),
+};
 
 export default WizardNavigationClass;

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-nav.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import { WizardNavItem, WizardNav } from '@patternfly/react-core';
+import isEqual from 'lodash/isEqual';
+import get from 'lodash/get';
+
+const memoValues = (initialValue) => {
+  let valueCache = initialValue;
+
+  return (value) => {
+    if (!isEqual(value, valueCache)){
+      valueCache = value;
+      return true;
+    }
+
+    return false;
+  };
+};
+
+const WizardNavigationInternal = React.memo(({
+  navSchema,
+  activeStepIndex,
+  formOptions,
+  maxStepIndex,
+  jumpToStep,
+}) => {
+  return (navSchema
+  .filter(field => field.primary)
+  .map(step => {
+    const substeps = step.substepOf && navSchema.filter(field => field.substepOf === step.substepOf);
+
+    return <WizardNavItem
+      key={ step.substepOf || step.title }
+      text={ step.substepOf || step.title }
+      isCurrent={ substeps ? activeStepIndex >= step.index && activeStepIndex < step.index + substeps.length : activeStepIndex === step.index }
+      isDisabled={ formOptions.valid ? maxStepIndex < step.index : step.index > activeStepIndex }
+      onNavItemClick={ (ind) => jumpToStep(ind, formOptions.valid) }
+      step={ step.index }
+    >
+      { substeps && <WizardNav returnList>
+        { substeps.map(substep => <WizardNavItem
+          key={ substep.title }
+          text={ substep.title }
+          isCurrent={ activeStepIndex === substep.index }
+          isDisabled={ formOptions.valid ?
+            maxStepIndex < substep.index
+            : substep.index > activeStepIndex }
+          onNavItemClick={ (ind) => jumpToStep(ind, formOptions.valid) }
+          step={ substep.index }
+        />) }
+      </WizardNav> }
+    </WizardNavItem>;
+  }));
+}, isEqual);
+
+class WizardNavigationClass extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const { crossroads, values } = this.props;
+
+    this.state = {
+      memoValue: memoValues(crossroads ? crossroads.reduce((acc, curr) => ({
+        ...acc,
+        [curr]: get(values, curr),
+      }), {}) : {}),
+      maxStepIndex: undefined,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.crossroads) {
+      const modifiedRoad = this.props.crossroads.reduce((acc, curr) => ({
+        ...acc,
+        [curr]: get(this.props.values, curr),
+      }), {});
+
+      if (this.state.memoValue(modifiedRoad)) {
+        this.setState({
+          maxStepIndex: this.props.activeStepIndex,
+        });
+        this.props.setPrevSteps();
+      } else {
+        if (prevProps.activeStepIndex !== this.props.activeStepIndex) {
+          this.setState({ maxStepIndex: undefined });
+        }
+      }
+    }
+  }
+
+  render() {
+    const {
+      activeStepIndex,
+      formOptions,
+      maxStepIndex,
+      jumpToStep,
+      navSchema,
+    } = this.props;
+
+    const { maxStepIndex: maxStepIndexState } = this.state;
+
+    const maxIndex = typeof maxStepIndexState === 'number' ? maxStepIndexState : maxStepIndex;
+
+    return (
+      <WizardNavigationInternal
+        navSchema={ navSchema }
+        activeStepIndex={ activeStepIndex }
+        formOptions={ formOptions }
+        maxStepIndex={ maxIndex }
+        jumpToStep={ jumpToStep }
+      />
+    );
+  }
+}
+
+export default WizardNavigationClass;

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard-nav.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { WizardNavItem, WizardNav } from '@patternfly/react-core';
 import isEqual from 'lodash/isEqual';
 import get from 'lodash/get';
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 
 const memoValues = (initialValue) => {
   let valueCache = initialValue;

--- a/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/form-fields/wizard/wizard.js
@@ -183,6 +183,21 @@ class Wizard extends React.Component {
     return schema;
   };
 
+  handleSubmitFinal = () => this.props.formOptions.onSubmit(
+    this.handleSubmit(
+      this.props.formOptions.getState().values,
+      [ ...this.state.prevSteps, this.state.activeStep ],
+      this.props.formOptions.getRegisteredFields,
+    ),
+    this.props.formOptions
+  );
+
+  setPrevSteps = () => this.setState((prevState) => ({
+    navSchema: this.createSchema({ currentIndex: this.state.activeStepIndex }),
+    prevSteps: prevState.prevSteps.slice(0, this.state.activeStepIndex),
+    maxStepIndex: this.state.activeStepIndex,
+  }))
+
   render() {
     if (this.state.loading) {
       return null;
@@ -205,22 +220,12 @@ class Wizard extends React.Component {
     } = this.props;
     const { activeStepIndex, navSchema, maxStepIndex, isDynamic } = this.state;
 
-    const handleSubmit = () =>
-      formOptions.onSubmit(
-        this.handleSubmit(
-          formOptions.getState().values,
-          [ ...this.state.prevSteps, this.state.activeStep ],
-          formOptions.getRegisteredFields,
-        ),
-        formOptions
-      );
-
     const currentStep = (
       <WizardStep
         { ...this.findCurrentStep(this.state.activeStep) }
         formOptions={{
           ...formOptions,
-          handleSubmit,
+          handleSubmit: this.handleSubmitFinal,
         }}
         buttonLabels={ buttonLabels }
         FieldProvider={ FieldProvider }
@@ -233,7 +238,7 @@ class Wizard extends React.Component {
         <div className={ `pf-c-wizard ${inModal ? '' : 'no-shadow'} ${isCompactNav ? 'pf-m-compact-nav' : ''} ${setFullWidth ? 'pf-m-full-width' : ''} ${setFullHeight ? 'pf-m-full-height' : ''}` }
           role="dialog"
           aria-modal={ inModal ? 'true' : undefined }
-          onKeyDown={ e => handleEnter(e, formOptions, this.state.activeStep, this.findCurrentStep, this.handleNext, handleSubmit) }
+          onKeyDown={ e => handleEnter(e, formOptions, this.state.activeStep, this.findCurrentStep, this.handleNext,  this.handleSubmitFinal) }
         >
           { title && <WizardHeader
             title={ title }
@@ -253,11 +258,7 @@ class Wizard extends React.Component {
                     crossroads={ crossroads }
                     isDynamic={ isDynamic }
                     values={ values }
-                    setPrevSteps={ () => this.setState((prevState) => ({
-                      navSchema: this.createSchema({ currentIndex: activeStepIndex }),
-                      prevSteps: prevState.prevSteps.slice(0, activeStepIndex),
-                      maxStepIndex: activeStepIndex,
-                    })) }
+                    setPrevSteps={ this.setPrevSteps }
                   />
                 ) }
               </FormSpyProvider>

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -1,1526 +1,2927 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Wizard /> should render correctly and unmount 1`] = `
-<WizardFunction
-  FieldProvider={[Function]}
-  buttonLabels={Object {}}
-  description="wizard description"
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "foo",
-        "stepKey": "1",
-      },
-    ]
-  }
-  formOptions={
+<FormRenderer
+  buttonClassName=""
+  buttonsLabels={Object {}}
+  clearOnUnmount={false}
+  disableSubmit={Array []}
+  formFieldsMapper={
     Object {
-      "getRegisteredFields": [MockFunction],
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "renderForm": [Function],
-      "submit": [MockFunction],
-      "valid": true,
+      "checkbox": [Function],
+      "date-picker": [Function],
+      "field-array": [Function],
+      "plain-text": [Function],
+      "radio": [Function],
+      "select-field": [Function],
+      "sub-form": [Function],
+      "switch-field": [Function],
+      "tabs": [Function],
+      "text-field": [Function],
+      "textarea-field": [Function],
+      "time-picker": [Function],
+      "wizard": [Function],
     }
   }
-  title="Wizard"
->
-  <Wizard
-    FieldProvider={[Function]}
-    buttonLabels={
-      Object {
-        "back": "Back",
-        "cancel": "Cancel",
-        "next": "Next",
-        "submit": "Submit",
-      }
+  initialValues={Object {}}
+  layoutMapper={
+    Object {
+      "Button": [Function],
+      "ButtonGroup": [Function],
+      "Description": [Function],
+      "FormWrapper": [Function],
+      "Title": [Function],
     }
-    description="wizard description"
-    fields={
-      Array [
+  }
+  onCancel={[MockFunction]}
+  onSubmit={[MockFunction]}
+  schema={
+    Object {
+      "fields": Array [
         Object {
-          "fields": Array [],
-          "name": "foo",
-          "stepKey": "1",
+          "component": "wizard",
+          "fields": Array [
+            Object {
+              "fields": Array [
+                Object {
+                  "component": "text-field",
+                  "name": "foo-field",
+                },
+              ],
+              "name": "foo",
+              "nextStep": "2",
+              "stepKey": "1",
+              "title": "foo-step",
+            },
+            Object {
+              "fields": Array [
+                Object {
+                  "component": "text-field",
+                  "name": "bar-field",
+                },
+              ],
+              "name": "bar",
+              "stepKey": "2",
+              "title": "bar-step",
+            },
+          ],
+          "name": "wizard",
         },
+      ],
+    }
+  }
+  showFormControls={false}
+>
+  <ReactFinalForm
+    decorators={
+      Array [
+        [Function],
       ]
     }
-    formOptions={
+    initialValues={Object {}}
+    mutators={
       Object {
-        "getRegisteredFields": [MockFunction],
-        "getState": [Function],
-        "onCancel": [MockFunction],
-        "onSubmit": [MockFunction],
-        "renderForm": [Function],
-        "submit": [MockFunction],
+        "concat": [Function],
+        "insert": [Function],
+        "move": [Function],
+        "pop": [Function],
+        "push": [Function],
+        "remove": [Function],
+        "removeBatch": [Function],
+        "shift": [Function],
+        "swap": [Function],
+        "unshift": [Function],
+        "update": [Function],
+      }
+    }
+    onSubmit={[MockFunction]}
+    render={[Function]}
+    subscription={
+      Object {
+        "pristine": true,
+        "submitting": true,
         "valid": true,
       }
     }
-    title="Wizard"
   >
-    <Modal>
-      <div
-        className="pf-c-wizard no-shadow   "
-        onKeyDown={[Function]}
-        role="dialog"
+    <Form
+      onSubmit={[Function]}
+    >
+      <form
+        className="pf-c-form"
+        noValidate={true}
+        onSubmit={[Function]}
       >
-        <WizardHeader
-          description="wizard description"
-          onClose={[Function]}
-          title="Wizard"
-        >
-          <div
-            className="pf-c-wizard__header"
+        <FormConditionWrapper>
+          <FormFieldHideWrapper
+            hideField={false}
           >
-            <Component
-              className="pf-c-wizard__close"
-              onClick={[Function]}
-              variant="plain"
-            >
-              <ComponentWithOuia
-                component={[Function]}
-                componentProps={
+            <FieldWrapper
+              component={[Function]}
+              componentType="wizard"
+              fields={
+                Array [
                   Object {
-                    "aria-label": undefined,
-                    "children": <TimesIcon
-                      aria-hidden="true"
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                      title={null}
-                    />,
-                    "className": "pf-c-wizard__close",
-                    "onClick": [Function],
-                    "variant": "plain",
-                  }
-                }
-                consumerContext={null}
-              >
-                <Button
-                  className="pf-c-wizard__close"
-                  onClick={[Function]}
-                  ouiaContext={
-                    Object {
-                      "isOuia": false,
-                      "ouiaId": null,
-                    }
-                  }
-                  variant="plain"
-                >
-                  <button
-                    aria-disabled={null}
-                    aria-label={null}
-                    className="pf-c-button pf-m-plain pf-c-wizard__close"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={null}
-                    type="button"
-                  >
-                    <TimesIcon
-                      aria-hidden="true"
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                      title={null}
-                    >
-                      <svg
-                        aria-hidden="true"
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 352 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          transform=""
-                        />
-                      </svg>
-                    </TimesIcon>
-                  </button>
-                </Button>
-              </ComponentWithOuia>
-            </Component>
-            <Title
-              aria-label="Wizard"
-              className="pf-c-wizard__title"
-              size="3xl"
-            >
-              <h1
-                aria-label="Wizard"
-                className="pf-c-title pf-m-3xl pf-c-wizard__title"
-              >
-                Wizard
-              </h1>
-            </Title>
-            <p
-              className="pf-c-wizard__description"
-            >
-              wizard description
-            </p>
-          </div>
-        </WizardHeader>
-        <div
-          className="pf-c-wizard__outer-wrap"
-        >
-          <WizardNav>
-            <nav
-              className="pf-c-wizard__nav"
-            >
-              <ol
-                className="pf-c-wizard__nav-list"
-              >
-                <WizardNavItem
-                  isCurrent={true}
-                  isDisabled={false}
-                  onNavItemClick={[Function]}
-                  step={0}
-                >
-                  <li
-                    className="pf-c-wizard__nav-item"
-                  >
-                    <a
-                      aria-current="page"
-                      aria-disabled={false}
-                      className="pf-c-wizard__nav-link pf-m-current"
-                      onClick={[Function]}
-                    />
-                  </li>
-                </WizardNavItem>
-              </ol>
-            </nav>
-          </WizardNav>
-          <WizardStep
-            FieldProvider={[Function]}
-            buttonLabels={
-              Object {
-                "back": "Back",
-                "cancel": "Cancel",
-                "next": "Next",
-                "submit": "Submit",
+                    "fields": Array [
+                      Object {
+                        "component": "text-field",
+                        "name": "foo-field",
+                      },
+                    ],
+                    "name": "foo",
+                    "nextStep": "2",
+                    "stepKey": "1",
+                    "title": "foo-step",
+                  },
+                  Object {
+                    "fields": Array [
+                      Object {
+                        "component": "text-field",
+                        "name": "bar-field",
+                      },
+                    ],
+                    "name": "bar",
+                    "stepKey": "2",
+                    "title": "bar-step",
+                  },
+                ]
               }
-            }
-            disableBack={true}
-            fields={Array []}
-            formOptions={
-              Object {
-                "getRegisteredFields": [MockFunction],
-                "getState": [Function],
-                "handleSubmit": [Function],
-                "onCancel": [MockFunction],
-                "onSubmit": [MockFunction],
-                "renderForm": [Function],
-                "submit": [MockFunction],
-                "valid": true,
-              }
-            }
-            handleNext={[Function]}
-            handlePrev={[Function]}
-            name="foo"
-            stepKey="1"
-          >
-            <WizardBody
-              hasBodyPadding={true}
-            >
-              <main
-                className="pf-c-wizard__main"
-              >
-                <div
-                  className="pf-c-wizard__main-body"
-                >
-                  <div
-                    className="pf-c-form"
-                  />
-                </div>
-              </main>
-            </WizardBody>
-            <WizardStepButtons
-              FieldProvider={[Function]}
-              buttonLabels={
-                Object {
-                  "back": "Back",
-                  "cancel": "Cancel",
-                  "next": "Next",
-                  "submit": "Submit",
-                }
-              }
-              disableBack={true}
               formOptions={
                 Object {
-                  "getRegisteredFields": [MockFunction],
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "clearOnUnmount": false,
+                  "clearedValue": undefined,
+                  "concat": [Function],
+                  "destroyOnUnregister": false,
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
                   "getState": [Function],
                   "handleSubmit": [Function],
+                  "initialize": [Function],
+                  "insert": [Function],
+                  "isValidationPaused": [Function],
+                  "move": [Function],
                   "onCancel": [MockFunction],
                   "onSubmit": [MockFunction],
+                  "pauseValidation": [Function],
+                  "pop": [Function],
+                  "pristine": true,
+                  "push": [Function],
+                  "registerField": [Function],
+                  "remove": [Function],
+                  "removeBatch": [Function],
                   "renderForm": [Function],
-                  "submit": [MockFunction],
+                  "reset": [Function],
+                  "resetFieldState": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "shift": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
+                  "swap": [Function],
+                  "unshift": [Function],
+                  "update": [Function],
                   "valid": true,
                 }
               }
-              handleNext={[Function]}
-              handlePrev={[Function]}
-              name="foo"
-              stepKey="1"
+              name="wizard"
+              validate={
+                Array [
+                  undefined,
+                ]
+              }
             >
-              <footer
-                className="pf-c-wizard__footer "
+              <WizardFunction
+                FieldProvider={[Function]}
+                FormSpyProvider={[Function]}
+                buttonLabels={Object {}}
+                fields={
+                  Array [
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "foo-field",
+                        },
+                      ],
+                      "name": "foo",
+                      "nextStep": "2",
+                      "stepKey": "1",
+                      "title": "foo-step",
+                    },
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "bar-field",
+                        },
+                      ],
+                      "name": "bar",
+                      "stepKey": "2",
+                      "title": "bar-step",
+                    },
+                  ]
+                }
+                formOptions={
+                  Object {
+                    "batch": [Function],
+                    "blur": [Function],
+                    "change": [Function],
+                    "clearOnUnmount": false,
+                    "clearedValue": undefined,
+                    "concat": [Function],
+                    "destroyOnUnregister": false,
+                    "focus": [Function],
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "handleSubmit": [Function],
+                    "initialize": [Function],
+                    "insert": [Function],
+                    "isValidationPaused": [Function],
+                    "move": [Function],
+                    "onCancel": [MockFunction],
+                    "onSubmit": [MockFunction],
+                    "pauseValidation": [Function],
+                    "pop": [Function],
+                    "pristine": true,
+                    "push": [Function],
+                    "registerField": [Function],
+                    "remove": [Function],
+                    "removeBatch": [Function],
+                    "renderForm": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "shift": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                    "valid": true,
+                  }
+                }
+                name="wizard"
+                validate={[Function]}
               >
-                <SubmitButton
-                  handleSubmit={[Function]}
-                  submitLabel="Submit"
-                >
-                  <Component
-                    onClick={[Function]}
-                    type="button"
-                    variant="primary"
-                  >
-                    <ComponentWithOuia
-                      component={[Function]}
-                      componentProps={
-                        Object {
-                          "children": "Submit",
-                          "onClick": [Function],
-                          "type": "button",
-                          "variant": "primary",
-                        }
-                      }
-                      consumerContext={null}
-                    >
-                      <Button
-                        onClick={[Function]}
-                        ouiaContext={
+                <Wizard
+                  FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
+                  buttonLabels={
+                    Object {
+                      "back": "Back",
+                      "cancel": "Cancel",
+                      "next": "Next",
+                      "submit": "Submit",
+                    }
+                  }
+                  fields={
+                    Array [
+                      Object {
+                        "fields": Array [
                           Object {
-                            "isOuia": false,
-                            "ouiaId": null,
+                            "component": "text-field",
+                            "name": "foo-field",
+                          },
+                        ],
+                        "name": "foo",
+                        "nextStep": "2",
+                        "stepKey": "1",
+                        "title": "foo-step",
+                      },
+                      Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "bar-field",
+                          },
+                        ],
+                        "name": "bar",
+                        "stepKey": "2",
+                        "title": "bar-step",
+                      },
+                    ]
+                  }
+                  formOptions={
+                    Object {
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "clearOnUnmount": false,
+                      "clearedValue": undefined,
+                      "concat": [Function],
+                      "destroyOnUnregister": false,
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "handleSubmit": [Function],
+                      "initialize": [Function],
+                      "insert": [Function],
+                      "isValidationPaused": [Function],
+                      "move": [Function],
+                      "onCancel": [MockFunction],
+                      "onSubmit": [MockFunction],
+                      "pauseValidation": [Function],
+                      "pop": [Function],
+                      "pristine": true,
+                      "push": [Function],
+                      "registerField": [Function],
+                      "remove": [Function],
+                      "removeBatch": [Function],
+                      "renderForm": [Function],
+                      "reset": [Function],
+                      "resetFieldState": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "shift": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
+                      "swap": [Function],
+                      "unshift": [Function],
+                      "update": [Function],
+                      "valid": true,
+                    }
+                  }
+                  name="wizard"
+                  validate={[Function]}
+                >
+                  <Modal>
+                    <div
+                      className="pf-c-wizard no-shadow   "
+                      onKeyDown={[Function]}
+                      role="dialog"
+                    >
+                      <div
+                        className="pf-c-wizard__outer-wrap"
+                      >
+                        <WizardNav>
+                          <nav
+                            className="pf-c-wizard__nav"
+                          >
+                            <ol
+                              className="pf-c-wizard__nav-list"
+                            >
+                              <ReactFinalForm(FormSpy)>
+                                <FormSpy
+                                  reactFinalForm={
+                                    Object {
+                                      "batch": [Function],
+                                      "blur": [Function],
+                                      "change": [Function],
+                                      "destroyOnUnregister": false,
+                                      "focus": [Function],
+                                      "getFieldState": [Function],
+                                      "getRegisteredFields": [Function],
+                                      "getState": [Function],
+                                      "initialize": [Function],
+                                      "isValidationPaused": [Function],
+                                      "mutators": Object {
+                                        "concat": [Function],
+                                        "insert": [Function],
+                                        "move": [Function],
+                                        "pop": [Function],
+                                        "push": [Function],
+                                        "remove": [Function],
+                                        "removeBatch": [Function],
+                                        "shift": [Function],
+                                        "swap": [Function],
+                                        "unshift": [Function],
+                                        "update": [Function],
+                                      },
+                                      "pauseValidation": [Function],
+                                      "registerField": [Function],
+                                      "reset": [Function],
+                                      "resetFieldState": [Function],
+                                      "resumeValidation": [Function],
+                                      "setConfig": [Function],
+                                      "submit": [Function],
+                                      "subscribe": [Function],
+                                    }
+                                  }
+                                >
+                                  <WizardNavigationClass
+                                    activeStepIndex={0}
+                                    formOptions={
+                                      Object {
+                                        "batch": [Function],
+                                        "blur": [Function],
+                                        "change": [Function],
+                                        "clearOnUnmount": false,
+                                        "clearedValue": undefined,
+                                        "concat": [Function],
+                                        "destroyOnUnregister": false,
+                                        "focus": [Function],
+                                        "getFieldState": [Function],
+                                        "getRegisteredFields": [Function],
+                                        "getState": [Function],
+                                        "handleSubmit": [Function],
+                                        "initialize": [Function],
+                                        "insert": [Function],
+                                        "isValidationPaused": [Function],
+                                        "move": [Function],
+                                        "onCancel": [MockFunction],
+                                        "onSubmit": [MockFunction],
+                                        "pauseValidation": [Function],
+                                        "pop": [Function],
+                                        "pristine": true,
+                                        "push": [Function],
+                                        "registerField": [Function],
+                                        "remove": [Function],
+                                        "removeBatch": [Function],
+                                        "renderForm": [Function],
+                                        "reset": [Function],
+                                        "resetFieldState": [Function],
+                                        "resumeValidation": [Function],
+                                        "setConfig": [Function],
+                                        "shift": [Function],
+                                        "submit": [Function],
+                                        "subscribe": [Function],
+                                        "swap": [Function],
+                                        "unshift": [Function],
+                                        "update": [Function],
+                                        "valid": true,
+                                      }
+                                    }
+                                    isDynamic={false}
+                                    jumpToStep={[Function]}
+                                    maxStepIndex={0}
+                                    navSchema={
+                                      Array [
+                                        Object {
+                                          "index": 0,
+                                          "primary": true,
+                                          "substepOf": undefined,
+                                          "title": "foo-step",
+                                        },
+                                        Object {
+                                          "index": 1,
+                                          "primary": true,
+                                          "substepOf": undefined,
+                                          "title": "bar-step",
+                                        },
+                                      ]
+                                    }
+                                    setPrevSteps={[Function]}
+                                    values={Object {}}
+                                  >
+                                    <Component
+                                      activeStepIndex={0}
+                                      formOptions={
+                                        Object {
+                                          "batch": [Function],
+                                          "blur": [Function],
+                                          "change": [Function],
+                                          "clearOnUnmount": false,
+                                          "clearedValue": undefined,
+                                          "concat": [Function],
+                                          "destroyOnUnregister": false,
+                                          "focus": [Function],
+                                          "getFieldState": [Function],
+                                          "getRegisteredFields": [Function],
+                                          "getState": [Function],
+                                          "handleSubmit": [Function],
+                                          "initialize": [Function],
+                                          "insert": [Function],
+                                          "isValidationPaused": [Function],
+                                          "move": [Function],
+                                          "onCancel": [MockFunction],
+                                          "onSubmit": [MockFunction],
+                                          "pauseValidation": [Function],
+                                          "pop": [Function],
+                                          "pristine": true,
+                                          "push": [Function],
+                                          "registerField": [Function],
+                                          "remove": [Function],
+                                          "removeBatch": [Function],
+                                          "renderForm": [Function],
+                                          "reset": [Function],
+                                          "resetFieldState": [Function],
+                                          "resumeValidation": [Function],
+                                          "setConfig": [Function],
+                                          "shift": [Function],
+                                          "submit": [Function],
+                                          "subscribe": [Function],
+                                          "swap": [Function],
+                                          "unshift": [Function],
+                                          "update": [Function],
+                                          "valid": true,
+                                        }
+                                      }
+                                      jumpToStep={[Function]}
+                                      maxStepIndex={0}
+                                      navSchema={
+                                        Array [
+                                          Object {
+                                            "index": 0,
+                                            "primary": true,
+                                            "substepOf": undefined,
+                                            "title": "foo-step",
+                                          },
+                                          Object {
+                                            "index": 1,
+                                            "primary": true,
+                                            "substepOf": undefined,
+                                            "title": "bar-step",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <WizardNavItem
+                                        isCurrent={true}
+                                        isDisabled={false}
+                                        key="foo-step"
+                                        onNavItemClick={[Function]}
+                                        step={0}
+                                        text="foo-step"
+                                      >
+                                        <li
+                                          className="pf-c-wizard__nav-item"
+                                        >
+                                          <a
+                                            aria-current="page"
+                                            aria-disabled={false}
+                                            className="pf-c-wizard__nav-link pf-m-current"
+                                            onClick={[Function]}
+                                          >
+                                            foo-step
+                                          </a>
+                                        </li>
+                                      </WizardNavItem>
+                                      <WizardNavItem
+                                        isCurrent={false}
+                                        isDisabled={true}
+                                        key="bar-step"
+                                        onNavItemClick={[Function]}
+                                        step={1}
+                                        text="bar-step"
+                                      >
+                                        <li
+                                          className="pf-c-wizard__nav-item"
+                                        >
+                                          <a
+                                            aria-current={false}
+                                            aria-disabled={true}
+                                            className="pf-c-wizard__nav-link pf-m-disabled"
+                                            onClick={[Function]}
+                                            tabIndex={-1}
+                                          >
+                                            bar-step
+                                          </a>
+                                        </li>
+                                      </WizardNavItem>
+                                    </Component>
+                                  </WizardNavigationClass>
+                                </FormSpy>
+                              </ReactFinalForm(FormSpy)>
+                            </ol>
+                          </nav>
+                        </WizardNav>
+                        <WizardStep
+                          FieldProvider={[Function]}
+                          buttonLabels={
+                            Object {
+                              "back": "Back",
+                              "cancel": "Cancel",
+                              "next": "Next",
+                              "submit": "Submit",
+                            }
                           }
-                        }
-                        type="button"
-                        variant="primary"
-                      >
-                        <button
-                          aria-disabled={null}
-                          aria-label={null}
-                          className="pf-c-button pf-m-primary"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={null}
-                          type="button"
+                          disableBack={true}
+                          fields={
+                            Array [
+                              Object {
+                                "component": "text-field",
+                                "name": "foo-field",
+                              },
+                            ]
+                          }
+                          formOptions={
+                            Object {
+                              "batch": [Function],
+                              "blur": [Function],
+                              "change": [Function],
+                              "clearOnUnmount": false,
+                              "clearedValue": undefined,
+                              "concat": [Function],
+                              "destroyOnUnregister": false,
+                              "focus": [Function],
+                              "getFieldState": [Function],
+                              "getRegisteredFields": [Function],
+                              "getState": [Function],
+                              "handleSubmit": [Function],
+                              "initialize": [Function],
+                              "insert": [Function],
+                              "isValidationPaused": [Function],
+                              "move": [Function],
+                              "onCancel": [MockFunction],
+                              "onSubmit": [MockFunction],
+                              "pauseValidation": [Function],
+                              "pop": [Function],
+                              "pristine": true,
+                              "push": [Function],
+                              "registerField": [Function],
+                              "remove": [Function],
+                              "removeBatch": [Function],
+                              "renderForm": [Function],
+                              "reset": [Function],
+                              "resetFieldState": [Function],
+                              "resumeValidation": [Function],
+                              "setConfig": [Function],
+                              "shift": [Function],
+                              "submit": [Function],
+                              "subscribe": [Function],
+                              "swap": [Function],
+                              "unshift": [Function],
+                              "update": [Function],
+                              "valid": true,
+                            }
+                          }
+                          handleNext={[Function]}
+                          handlePrev={[Function]}
+                          name="foo"
+                          nextStep="2"
+                          stepKey="1"
+                          title="foo-step"
                         >
-                          Submit
-                        </button>
-                      </Button>
-                    </ComponentWithOuia>
-                  </Component>
-                </SubmitButton>
-                <Component
-                  isDisabled={true}
-                  onClick={[Function]}
-                  type="button"
-                  variant="secondary"
-                >
-                  <ComponentWithOuia
-                    component={[Function]}
-                    componentProps={
-                      Object {
-                        "children": "Back",
-                        "isDisabled": true,
-                        "onClick": [Function],
-                        "type": "button",
-                        "variant": "secondary",
-                      }
-                    }
-                    consumerContext={null}
-                  >
-                    <Button
-                      isDisabled={true}
-                      onClick={[Function]}
-                      ouiaContext={
-                        Object {
-                          "isOuia": false,
-                          "ouiaId": null,
-                        }
-                      }
-                      type="button"
-                      variant="secondary"
-                    >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-secondary"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Back
-                      </button>
-                    </Button>
-                  </ComponentWithOuia>
-                </Component>
-                <Component
-                  onClick={[Function]}
-                  type="button"
-                  variant="link"
-                >
-                  <ComponentWithOuia
-                    component={[Function]}
-                    componentProps={
-                      Object {
-                        "children": "Cancel",
-                        "onClick": [Function],
-                        "type": "button",
-                        "variant": "link",
-                      }
-                    }
-                    consumerContext={null}
-                  >
-                    <Button
-                      onClick={[Function]}
-                      ouiaContext={
-                        Object {
-                          "isOuia": false,
-                          "ouiaId": null,
-                        }
-                      }
-                      type="button"
-                      variant="link"
-                    >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-link"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                    </Button>
-                  </ComponentWithOuia>
-                </Component>
-              </footer>
-            </WizardStepButtons>
-          </WizardStep>
-        </div>
-      </div>
-    </Modal>
-  </Wizard>
-</WizardFunction>
+                          <WizardBody
+                            hasBodyPadding={true}
+                          >
+                            <main
+                              className="pf-c-wizard__main"
+                            >
+                              <div
+                                className="pf-c-wizard__main-body"
+                              >
+                                <div
+                                  className="pf-c-form"
+                                >
+                                  <FormConditionWrapper>
+                                    <FormFieldHideWrapper
+                                      hideField={false}
+                                    >
+                                      <FieldWrapper
+                                        component={[Function]}
+                                        componentType="text-field"
+                                        formOptions={
+                                          Object {
+                                            "batch": [Function],
+                                            "blur": [Function],
+                                            "change": [Function],
+                                            "clearOnUnmount": false,
+                                            "clearedValue": undefined,
+                                            "concat": [Function],
+                                            "destroyOnUnregister": false,
+                                            "focus": [Function],
+                                            "getFieldState": [Function],
+                                            "getRegisteredFields": [Function],
+                                            "getState": [Function],
+                                            "handleSubmit": [Function],
+                                            "initialize": [Function],
+                                            "insert": [Function],
+                                            "isValidationPaused": [Function],
+                                            "move": [Function],
+                                            "onCancel": [MockFunction],
+                                            "onSubmit": [MockFunction],
+                                            "pauseValidation": [Function],
+                                            "pop": [Function],
+                                            "pristine": true,
+                                            "push": [Function],
+                                            "registerField": [Function],
+                                            "remove": [Function],
+                                            "removeBatch": [Function],
+                                            "renderForm": [Function],
+                                            "reset": [Function],
+                                            "resetFieldState": [Function],
+                                            "resumeValidation": [Function],
+                                            "setConfig": [Function],
+                                            "shift": [Function],
+                                            "submit": [Function],
+                                            "subscribe": [Function],
+                                            "swap": [Function],
+                                            "unshift": [Function],
+                                            "update": [Function],
+                                            "valid": true,
+                                          }
+                                        }
+                                        name="foo-field"
+                                        validate={
+                                          Array [
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        <FieldProvider
+                                          FieldArrayProvider={[Function]}
+                                          FieldProvider={[Function]}
+                                          component={[Function]}
+                                          formOptions={
+                                            Object {
+                                              "batch": [Function],
+                                              "blur": [Function],
+                                              "change": [Function],
+                                              "clearOnUnmount": false,
+                                              "clearedValue": undefined,
+                                              "concat": [Function],
+                                              "destroyOnUnregister": false,
+                                              "focus": [Function],
+                                              "getFieldState": [Function],
+                                              "getRegisteredFields": [Function],
+                                              "getState": [Function],
+                                              "handleSubmit": [Function],
+                                              "initialize": [Function],
+                                              "insert": [Function],
+                                              "isValidationPaused": [Function],
+                                              "move": [Function],
+                                              "onCancel": [MockFunction],
+                                              "onSubmit": [MockFunction],
+                                              "pauseValidation": [Function],
+                                              "pop": [Function],
+                                              "pristine": true,
+                                              "push": [Function],
+                                              "registerField": [Function],
+                                              "remove": [Function],
+                                              "removeBatch": [Function],
+                                              "renderForm": [Function],
+                                              "reset": [Function],
+                                              "resetFieldState": [Function],
+                                              "resumeValidation": [Function],
+                                              "setConfig": [Function],
+                                              "shift": [Function],
+                                              "submit": [Function],
+                                              "subscribe": [Function],
+                                              "swap": [Function],
+                                              "unshift": [Function],
+                                              "update": [Function],
+                                              "valid": true,
+                                            }
+                                          }
+                                          name="foo-field"
+                                          validate={[Function]}
+                                        >
+                                          <ReactFinalForm(Field)
+                                            FieldArrayProvider={[Function]}
+                                            FieldProvider={[Function]}
+                                            formOptions={
+                                              Object {
+                                                "batch": [Function],
+                                                "blur": [Function],
+                                                "change": [Function],
+                                                "clearOnUnmount": false,
+                                                "clearedValue": undefined,
+                                                "concat": [Function],
+                                                "destroyOnUnregister": false,
+                                                "focus": [Function],
+                                                "getFieldState": [Function],
+                                                "getRegisteredFields": [Function],
+                                                "getState": [Function],
+                                                "handleSubmit": [Function],
+                                                "initialize": [Function],
+                                                "insert": [Function],
+                                                "isValidationPaused": [Function],
+                                                "move": [Function],
+                                                "onCancel": [MockFunction],
+                                                "onSubmit": [MockFunction],
+                                                "pauseValidation": [Function],
+                                                "pop": [Function],
+                                                "pristine": true,
+                                                "push": [Function],
+                                                "registerField": [Function],
+                                                "remove": [Function],
+                                                "removeBatch": [Function],
+                                                "renderForm": [Function],
+                                                "reset": [Function],
+                                                "resetFieldState": [Function],
+                                                "resumeValidation": [Function],
+                                                "setConfig": [Function],
+                                                "shift": [Function],
+                                                "submit": [Function],
+                                                "subscribe": [Function],
+                                                "swap": [Function],
+                                                "unshift": [Function],
+                                                "update": [Function],
+                                                "valid": true,
+                                              }
+                                            }
+                                            name="foo-field"
+                                            render={[Function]}
+                                            validate={[Function]}
+                                          >
+                                            <Field
+                                              FieldArrayProvider={[Function]}
+                                              FieldProvider={[Function]}
+                                              formOptions={
+                                                Object {
+                                                  "batch": [Function],
+                                                  "blur": [Function],
+                                                  "change": [Function],
+                                                  "clearOnUnmount": false,
+                                                  "clearedValue": undefined,
+                                                  "concat": [Function],
+                                                  "destroyOnUnregister": false,
+                                                  "focus": [Function],
+                                                  "getFieldState": [Function],
+                                                  "getRegisteredFields": [Function],
+                                                  "getState": [Function],
+                                                  "handleSubmit": [Function],
+                                                  "initialize": [Function],
+                                                  "insert": [Function],
+                                                  "isValidationPaused": [Function],
+                                                  "move": [Function],
+                                                  "onCancel": [MockFunction],
+                                                  "onSubmit": [MockFunction],
+                                                  "pauseValidation": [Function],
+                                                  "pop": [Function],
+                                                  "pristine": true,
+                                                  "push": [Function],
+                                                  "registerField": [Function],
+                                                  "remove": [Function],
+                                                  "removeBatch": [Function],
+                                                  "renderForm": [Function],
+                                                  "reset": [Function],
+                                                  "resetFieldState": [Function],
+                                                  "resumeValidation": [Function],
+                                                  "setConfig": [Function],
+                                                  "shift": [Function],
+                                                  "submit": [Function],
+                                                  "subscribe": [Function],
+                                                  "swap": [Function],
+                                                  "unshift": [Function],
+                                                  "update": [Function],
+                                                  "valid": true,
+                                                }
+                                              }
+                                              format={[Function]}
+                                              name="foo-field"
+                                              parse={[Function]}
+                                              reactFinalForm={
+                                                Object {
+                                                  "batch": [Function],
+                                                  "blur": [Function],
+                                                  "change": [Function],
+                                                  "destroyOnUnregister": false,
+                                                  "focus": [Function],
+                                                  "getFieldState": [Function],
+                                                  "getRegisteredFields": [Function],
+                                                  "getState": [Function],
+                                                  "initialize": [Function],
+                                                  "isValidationPaused": [Function],
+                                                  "mutators": Object {
+                                                    "concat": [Function],
+                                                    "insert": [Function],
+                                                    "move": [Function],
+                                                    "pop": [Function],
+                                                    "push": [Function],
+                                                    "remove": [Function],
+                                                    "removeBatch": [Function],
+                                                    "shift": [Function],
+                                                    "swap": [Function],
+                                                    "unshift": [Function],
+                                                    "update": [Function],
+                                                  },
+                                                  "pauseValidation": [Function],
+                                                  "registerField": [Function],
+                                                  "reset": [Function],
+                                                  "resetFieldState": [Function],
+                                                  "resumeValidation": [Function],
+                                                  "setConfig": [Function],
+                                                  "submit": [Function],
+                                                  "subscribe": [Function],
+                                                }
+                                              }
+                                              render={[Function]}
+                                              validate={[Function]}
+                                            >
+                                              <TextField
+                                                FieldArrayProvider={[Function]}
+                                                FieldProvider={[Function]}
+                                                formOptions={
+                                                  Object {
+                                                    "batch": [Function],
+                                                    "blur": [Function],
+                                                    "change": [Function],
+                                                    "clearOnUnmount": false,
+                                                    "clearedValue": undefined,
+                                                    "concat": [Function],
+                                                    "destroyOnUnregister": false,
+                                                    "focus": [Function],
+                                                    "getFieldState": [Function],
+                                                    "getRegisteredFields": [Function],
+                                                    "getState": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialize": [Function],
+                                                    "insert": [Function],
+                                                    "isValidationPaused": [Function],
+                                                    "move": [Function],
+                                                    "onCancel": [MockFunction],
+                                                    "onSubmit": [MockFunction],
+                                                    "pauseValidation": [Function],
+                                                    "pop": [Function],
+                                                    "pristine": true,
+                                                    "push": [Function],
+                                                    "registerField": [Function],
+                                                    "remove": [Function],
+                                                    "removeBatch": [Function],
+                                                    "renderForm": [Function],
+                                                    "reset": [Function],
+                                                    "resetFieldState": [Function],
+                                                    "resumeValidation": [Function],
+                                                    "setConfig": [Function],
+                                                    "shift": [Function],
+                                                    "submit": [Function],
+                                                    "subscribe": [Function],
+                                                    "swap": [Function],
+                                                    "unshift": [Function],
+                                                    "update": [Function],
+                                                    "valid": true,
+                                                  }
+                                                }
+                                                input={
+                                                  Object {
+                                                    "name": "foo-field",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "onFocus": [Function],
+                                                    "value": "",
+                                                  }
+                                                }
+                                                meta={
+                                                  Object {
+                                                    "active": false,
+                                                    "data": Object {},
+                                                    "dirty": false,
+                                                    "dirtySinceLastSubmit": false,
+                                                    "error": undefined,
+                                                    "initial": undefined,
+                                                    "invalid": false,
+                                                    "modified": false,
+                                                    "pristine": true,
+                                                    "submitError": undefined,
+                                                    "submitFailed": false,
+                                                    "submitSucceeded": false,
+                                                    "submitting": false,
+                                                    "touched": false,
+                                                    "valid": true,
+                                                    "visited": false,
+                                                  }
+                                                }
+                                              >
+                                                <FieldInterface
+                                                  FieldArrayProvider={[Function]}
+                                                  FieldProvider={[Function]}
+                                                  componentType="text-field"
+                                                  formOptions={
+                                                    Object {
+                                                      "batch": [Function],
+                                                      "blur": [Function],
+                                                      "change": [Function],
+                                                      "clearOnUnmount": false,
+                                                      "clearedValue": undefined,
+                                                      "concat": [Function],
+                                                      "destroyOnUnregister": false,
+                                                      "focus": [Function],
+                                                      "getFieldState": [Function],
+                                                      "getRegisteredFields": [Function],
+                                                      "getState": [Function],
+                                                      "handleSubmit": [Function],
+                                                      "initialize": [Function],
+                                                      "insert": [Function],
+                                                      "isValidationPaused": [Function],
+                                                      "move": [Function],
+                                                      "onCancel": [MockFunction],
+                                                      "onSubmit": [MockFunction],
+                                                      "pauseValidation": [Function],
+                                                      "pop": [Function],
+                                                      "pristine": true,
+                                                      "push": [Function],
+                                                      "registerField": [Function],
+                                                      "remove": [Function],
+                                                      "removeBatch": [Function],
+                                                      "renderForm": [Function],
+                                                      "reset": [Function],
+                                                      "resetFieldState": [Function],
+                                                      "resumeValidation": [Function],
+                                                      "setConfig": [Function],
+                                                      "shift": [Function],
+                                                      "submit": [Function],
+                                                      "subscribe": [Function],
+                                                      "swap": [Function],
+                                                      "unshift": [Function],
+                                                      "update": [Function],
+                                                      "valid": true,
+                                                    }
+                                                  }
+                                                  input={
+                                                    Object {
+                                                      "name": "foo-field",
+                                                      "onBlur": [Function],
+                                                      "onChange": [Function],
+                                                      "onFocus": [Function],
+                                                      "value": "",
+                                                    }
+                                                  }
+                                                  meta={
+                                                    Object {
+                                                      "active": false,
+                                                      "data": Object {},
+                                                      "dirty": false,
+                                                      "dirtySinceLastSubmit": false,
+                                                      "error": undefined,
+                                                      "initial": undefined,
+                                                      "invalid": false,
+                                                      "modified": false,
+                                                      "pristine": true,
+                                                      "submitError": undefined,
+                                                      "submitFailed": false,
+                                                      "submitSucceeded": false,
+                                                      "submitting": false,
+                                                      "touched": false,
+                                                      "valid": true,
+                                                      "visited": false,
+                                                    }
+                                                  }
+                                                  name="foo-field"
+                                                >
+                                                  <FormGroup
+                                                    fieldId="foo-field"
+                                                    isValid={true}
+                                                  >
+                                                    <div
+                                                      className="pf-c-form__group"
+                                                    >
+                                                      <TextInput
+                                                        aria-label={null}
+                                                        className=""
+                                                        id="foo-field"
+                                                        isDisabled={false}
+                                                        isReadOnly={false}
+                                                        isRequired={false}
+                                                        isValid={true}
+                                                        name="foo-field"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onFocus={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          aria-invalid={false}
+                                                          aria-label={null}
+                                                          className="pf-c-form-control"
+                                                          disabled={false}
+                                                          id="foo-field"
+                                                          name="foo-field"
+                                                          onBlur={[Function]}
+                                                          onChange={[Function]}
+                                                          onFocus={[Function]}
+                                                          readOnly={false}
+                                                          required={false}
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </TextInput>
+                                                    </div>
+                                                  </FormGroup>
+                                                </FieldInterface>
+                                              </TextField>
+                                            </Field>
+                                          </ReactFinalForm(Field)>
+                                        </FieldProvider>
+                                      </FieldWrapper>
+                                    </FormFieldHideWrapper>
+                                  </FormConditionWrapper>
+                                </div>
+                              </div>
+                            </main>
+                          </WizardBody>
+                          <WizardStepButtons
+                            FieldProvider={[Function]}
+                            buttonLabels={
+                              Object {
+                                "back": "Back",
+                                "cancel": "Cancel",
+                                "next": "Next",
+                                "submit": "Submit",
+                              }
+                            }
+                            disableBack={true}
+                            formOptions={
+                              Object {
+                                "batch": [Function],
+                                "blur": [Function],
+                                "change": [Function],
+                                "clearOnUnmount": false,
+                                "clearedValue": undefined,
+                                "concat": [Function],
+                                "destroyOnUnregister": false,
+                                "focus": [Function],
+                                "getFieldState": [Function],
+                                "getRegisteredFields": [Function],
+                                "getState": [Function],
+                                "handleSubmit": [Function],
+                                "initialize": [Function],
+                                "insert": [Function],
+                                "isValidationPaused": [Function],
+                                "move": [Function],
+                                "onCancel": [MockFunction],
+                                "onSubmit": [MockFunction],
+                                "pauseValidation": [Function],
+                                "pop": [Function],
+                                "pristine": true,
+                                "push": [Function],
+                                "registerField": [Function],
+                                "remove": [Function],
+                                "removeBatch": [Function],
+                                "renderForm": [Function],
+                                "reset": [Function],
+                                "resetFieldState": [Function],
+                                "resumeValidation": [Function],
+                                "setConfig": [Function],
+                                "shift": [Function],
+                                "submit": [Function],
+                                "subscribe": [Function],
+                                "swap": [Function],
+                                "unshift": [Function],
+                                "update": [Function],
+                                "valid": true,
+                              }
+                            }
+                            handleNext={[Function]}
+                            handlePrev={[Function]}
+                            name="foo"
+                            nextStep="2"
+                            stepKey="1"
+                          >
+                            <footer
+                              className="pf-c-wizard__footer "
+                            >
+                              <SimpleNext
+                                batch={[Function]}
+                                blur={[Function]}
+                                change={[Function]}
+                                clearOnUnmount={false}
+                                concat={[Function]}
+                                destroyOnUnregister={false}
+                                focus={[Function]}
+                                getFieldState={[Function]}
+                                getRegisteredFields={[Function]}
+                                getState={[Function]}
+                                handleNext={[Function]}
+                                initialize={[Function]}
+                                insert={[Function]}
+                                isValidationPaused={[Function]}
+                                move={[Function]}
+                                nextLabel="Next"
+                                nextStep="2"
+                                onCancel={[MockFunction]}
+                                onSubmit={[MockFunction]}
+                                pauseValidation={[Function]}
+                                pop={[Function]}
+                                pristine={true}
+                                push={[Function]}
+                                registerField={[Function]}
+                                remove={[Function]}
+                                removeBatch={[Function]}
+                                renderForm={[Function]}
+                                reset={[Function]}
+                                resetFieldState={[Function]}
+                                resumeValidation={[Function]}
+                                setConfig={[Function]}
+                                shift={[Function]}
+                                submit={[Function]}
+                                subscribe={[Function]}
+                                swap={[Function]}
+                                unshift={[Function]}
+                                update={[Function]}
+                                valid={true}
+                              >
+                                <Component
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                  variant="primary"
+                                >
+                                  <ComponentWithOuia
+                                    component={[Function]}
+                                    componentProps={
+                                      Object {
+                                        "children": "Next",
+                                        "isDisabled": false,
+                                        "onClick": [Function],
+                                        "type": "button",
+                                        "variant": "primary",
+                                      }
+                                    }
+                                    consumerContext={null}
+                                  >
+                                    <Button
+                                      isDisabled={false}
+                                      onClick={[Function]}
+                                      ouiaContext={
+                                        Object {
+                                          "isOuia": false,
+                                          "ouiaId": null,
+                                        }
+                                      }
+                                      type="button"
+                                      variant="primary"
+                                    >
+                                      <button
+                                        aria-disabled={null}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-primary"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        tabIndex={null}
+                                        type="button"
+                                      >
+                                        Next
+                                      </button>
+                                    </Button>
+                                  </ComponentWithOuia>
+                                </Component>
+                              </SimpleNext>
+                              <Component
+                                isDisabled={true}
+                                onClick={[Function]}
+                                type="button"
+                                variant="secondary"
+                              >
+                                <ComponentWithOuia
+                                  component={[Function]}
+                                  componentProps={
+                                    Object {
+                                      "children": "Back",
+                                      "isDisabled": true,
+                                      "onClick": [Function],
+                                      "type": "button",
+                                      "variant": "secondary",
+                                    }
+                                  }
+                                  consumerContext={null}
+                                >
+                                  <Button
+                                    isDisabled={true}
+                                    onClick={[Function]}
+                                    ouiaContext={
+                                      Object {
+                                        "isOuia": false,
+                                        "ouiaId": null,
+                                      }
+                                    }
+                                    type="button"
+                                    variant="secondary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-secondary"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Back
+                                    </button>
+                                  </Button>
+                                </ComponentWithOuia>
+                              </Component>
+                              <Component
+                                onClick={[Function]}
+                                type="button"
+                                variant="link"
+                              >
+                                <ComponentWithOuia
+                                  component={[Function]}
+                                  componentProps={
+                                    Object {
+                                      "children": "Cancel",
+                                      "onClick": [Function],
+                                      "type": "button",
+                                      "variant": "link",
+                                    }
+                                  }
+                                  consumerContext={null}
+                                >
+                                  <Button
+                                    onClick={[Function]}
+                                    ouiaContext={
+                                      Object {
+                                        "isOuia": false,
+                                        "ouiaId": null,
+                                      }
+                                    }
+                                    type="button"
+                                    variant="link"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-link"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Button>
+                                </ComponentWithOuia>
+                              </Component>
+                            </footer>
+                          </WizardStepButtons>
+                        </WizardStep>
+                      </div>
+                    </div>
+                  </Modal>
+                </Wizard>
+              </WizardFunction>
+            </FieldWrapper>
+          </FormFieldHideWrapper>
+        </FormConditionWrapper>
+      </form>
+    </Form>
+  </ReactFinalForm>
+</FormRenderer>
 `;
 
 exports[`<Wizard /> should render correctly and unmount 2`] = `null`;
 
 exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
-<WizardFunction
-  FieldProvider={[Function]}
-  buttonLabels={Object {}}
-  description="wizard description"
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "foo",
-        "stepKey": "1",
-      },
-    ]
-  }
-  formOptions={
+<FormRenderer
+  buttonClassName=""
+  buttonsLabels={Object {}}
+  clearOnUnmount={false}
+  disableSubmit={Array []}
+  formFieldsMapper={
     Object {
-      "getRegisteredFields": [MockFunction],
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "renderForm": [Function],
-      "submit": [MockFunction],
-      "valid": true,
+      "checkbox": [Function],
+      "date-picker": [Function],
+      "field-array": [Function],
+      "plain-text": [Function],
+      "radio": [Function],
+      "select-field": [Function],
+      "sub-form": [Function],
+      "switch-field": [Function],
+      "tabs": [Function],
+      "text-field": [Function],
+      "textarea-field": [Function],
+      "time-picker": [Function],
+      "wizard": [Function],
     }
   }
-  inModal={true}
-  title="Wizard"
->
-  <Wizard
-    FieldProvider={[Function]}
-    buttonLabels={
-      Object {
-        "back": "Back",
-        "cancel": "Cancel",
-        "next": "Next",
-        "submit": "Submit",
-      }
-    }
-    description="wizard description"
-    fields={
-      Array [
-        Object {
-          "fields": Array [],
-          "name": "foo",
-          "stepKey": "1",
-        },
-      ]
-    }
-    formOptions={
-      Object {
-        "getRegisteredFields": [MockFunction],
-        "getState": [Function],
-        "onCancel": [MockFunction],
-        "onSubmit": [MockFunction],
-        "renderForm": [Function],
-        "submit": [MockFunction],
-        "valid": true,
-      }
-    }
-    inModal={true}
-    title="Wizard"
-  >
-    <Modal
-      container={
-        <div>
-          <div
-            class="pf-c-backdrop"
-          >
-            <div
-              class="pf-l-bullseye"
-            >
-              <div
-                aria-modal="true"
-                class="pf-c-wizard    "
-                role="dialog"
-              >
-                <div
-                  class="pf-c-wizard__header"
-                >
-                  <button
-                    class="pf-c-button pf-m-plain pf-c-wizard__close"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 352 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                        transform=""
-                      />
-                    </svg>
-                  </button>
-                  <h1
-                    aria-label="Wizard"
-                    class="pf-c-title pf-m-3xl pf-c-wizard__title"
-                  >
-                    Wizard
-                  </h1>
-                  <p
-                    class="pf-c-wizard__description"
-                  >
-                    wizard description
-                  </p>
-                </div>
-                <div
-                  class="pf-c-wizard__outer-wrap"
-                >
-                  <nav
-                    class="pf-c-wizard__nav"
-                  >
-                    <ol
-                      class="pf-c-wizard__nav-list"
-                    >
-                      <li
-                        class="pf-c-wizard__nav-item"
-                      >
-                        <a
-                          aria-current="page"
-                          aria-disabled="false"
-                          class="pf-c-wizard__nav-link pf-m-current"
-                        />
-                      </li>
-                    </ol>
-                  </nav>
-                  <main
-                    class="pf-c-wizard__main"
-                  >
-                    <div
-                      class="pf-c-wizard__main-body"
-                    >
-                      <div
-                        class="pf-c-form"
-                      />
-                    </div>
-                  </main>
-                  <footer
-                    class="pf-c-wizard__footer "
-                  >
-                    <button
-                      class="pf-c-button pf-m-primary"
-                      type="button"
-                    >
-                      Submit
-                    </button>
-                    <button
-                      class="pf-c-button pf-m-secondary"
-                      disabled=""
-                      type="button"
-                    >
-                      Back
-                    </button>
-                    <button
-                      class="pf-c-button pf-m-link"
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                  </footer>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      }
-      inModal={true}
-    >
-      <Portal
-        containerInfo={
-          <div>
-            <div
-              class="pf-c-backdrop"
-            >
-              <div
-                class="pf-l-bullseye"
-              >
-                <div
-                  aria-modal="true"
-                  class="pf-c-wizard    "
-                  role="dialog"
-                >
-                  <div
-                    class="pf-c-wizard__header"
-                  >
-                    <button
-                      class="pf-c-button pf-m-plain pf-c-wizard__close"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 352 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          transform=""
-                        />
-                      </svg>
-                    </button>
-                    <h1
-                      aria-label="Wizard"
-                      class="pf-c-title pf-m-3xl pf-c-wizard__title"
-                    >
-                      Wizard
-                    </h1>
-                    <p
-                      class="pf-c-wizard__description"
-                    >
-                      wizard description
-                    </p>
-                  </div>
-                  <div
-                    class="pf-c-wizard__outer-wrap"
-                  >
-                    <nav
-                      class="pf-c-wizard__nav"
-                    >
-                      <ol
-                        class="pf-c-wizard__nav-list"
-                      >
-                        <li
-                          class="pf-c-wizard__nav-item"
-                        >
-                          <a
-                            aria-current="page"
-                            aria-disabled="false"
-                            class="pf-c-wizard__nav-link pf-m-current"
-                          />
-                        </li>
-                      </ol>
-                    </nav>
-                    <main
-                      class="pf-c-wizard__main"
-                    >
-                      <div
-                        class="pf-c-wizard__main-body"
-                      >
-                        <div
-                          class="pf-c-form"
-                        />
-                      </div>
-                    </main>
-                    <footer
-                      class="pf-c-wizard__footer "
-                    >
-                      <button
-                        class="pf-c-button pf-m-primary"
-                        type="button"
-                      >
-                        Submit
-                      </button>
-                      <button
-                        class="pf-c-button pf-m-secondary"
-                        disabled=""
-                        type="button"
-                      >
-                        Back
-                      </button>
-                      <button
-                        class="pf-c-button pf-m-link"
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                    </footer>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        }
-      >
-        <Backdrop>
-          <div
-            className="pf-c-backdrop"
-          >
-            <Bullseye>
-              <div
-                className="pf-l-bullseye"
-              >
-                <div
-                  aria-modal="true"
-                  className="pf-c-wizard    "
-                  onKeyDown={[Function]}
-                  role="dialog"
-                >
-                  <WizardHeader
-                    description="wizard description"
-                    onClose={[Function]}
-                    title="Wizard"
-                  >
-                    <div
-                      className="pf-c-wizard__header"
-                    >
-                      <Component
-                        className="pf-c-wizard__close"
-                        onClick={[Function]}
-                        variant="plain"
-                      >
-                        <ComponentWithOuia
-                          component={[Function]}
-                          componentProps={
-                            Object {
-                              "aria-label": undefined,
-                              "children": <TimesIcon
-                                aria-hidden="true"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
-                                title={null}
-                              />,
-                              "className": "pf-c-wizard__close",
-                              "onClick": [Function],
-                              "variant": "plain",
-                            }
-                          }
-                          consumerContext={null}
-                        >
-                          <Button
-                            className="pf-c-wizard__close"
-                            onClick={[Function]}
-                            ouiaContext={
-                              Object {
-                                "isOuia": false,
-                                "ouiaId": null,
-                              }
-                            }
-                            variant="plain"
-                          >
-                            <button
-                              aria-disabled={null}
-                              aria-label={null}
-                              className="pf-c-button pf-m-plain pf-c-wizard__close"
-                              disabled={false}
-                              onClick={[Function]}
-                              tabIndex={null}
-                              type="button"
-                            >
-                              <TimesIcon
-                                aria-hidden="true"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
-                                title={null}
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  aria-labelledby={null}
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  style={
-                                    Object {
-                                      "verticalAlign": "-0.125em",
-                                    }
-                                  }
-                                  viewBox="0 0 352 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                    transform=""
-                                  />
-                                </svg>
-                              </TimesIcon>
-                            </button>
-                          </Button>
-                        </ComponentWithOuia>
-                      </Component>
-                      <Title
-                        aria-label="Wizard"
-                        className="pf-c-wizard__title"
-                        size="3xl"
-                      >
-                        <h1
-                          aria-label="Wizard"
-                          className="pf-c-title pf-m-3xl pf-c-wizard__title"
-                        >
-                          Wizard
-                        </h1>
-                      </Title>
-                      <p
-                        className="pf-c-wizard__description"
-                      >
-                        wizard description
-                      </p>
-                    </div>
-                  </WizardHeader>
-                  <div
-                    className="pf-c-wizard__outer-wrap"
-                  >
-                    <WizardNav>
-                      <nav
-                        className="pf-c-wizard__nav"
-                      >
-                        <ol
-                          className="pf-c-wizard__nav-list"
-                        >
-                          <WizardNavItem
-                            isCurrent={true}
-                            isDisabled={false}
-                            onNavItemClick={[Function]}
-                            step={0}
-                          >
-                            <li
-                              className="pf-c-wizard__nav-item"
-                            >
-                              <a
-                                aria-current="page"
-                                aria-disabled={false}
-                                className="pf-c-wizard__nav-link pf-m-current"
-                                onClick={[Function]}
-                              />
-                            </li>
-                          </WizardNavItem>
-                        </ol>
-                      </nav>
-                    </WizardNav>
-                    <WizardStep
-                      FieldProvider={[Function]}
-                      buttonLabels={
-                        Object {
-                          "back": "Back",
-                          "cancel": "Cancel",
-                          "next": "Next",
-                          "submit": "Submit",
-                        }
-                      }
-                      disableBack={true}
-                      fields={Array []}
-                      formOptions={
-                        Object {
-                          "getRegisteredFields": [MockFunction],
-                          "getState": [Function],
-                          "handleSubmit": [Function],
-                          "onCancel": [MockFunction],
-                          "onSubmit": [MockFunction],
-                          "renderForm": [Function],
-                          "submit": [MockFunction],
-                          "valid": true,
-                        }
-                      }
-                      handleNext={[Function]}
-                      handlePrev={[Function]}
-                      name="foo"
-                      stepKey="1"
-                    >
-                      <WizardBody
-                        hasBodyPadding={true}
-                      >
-                        <main
-                          className="pf-c-wizard__main"
-                        >
-                          <div
-                            className="pf-c-wizard__main-body"
-                          >
-                            <div
-                              className="pf-c-form"
-                            />
-                          </div>
-                        </main>
-                      </WizardBody>
-                      <WizardStepButtons
-                        FieldProvider={[Function]}
-                        buttonLabels={
-                          Object {
-                            "back": "Back",
-                            "cancel": "Cancel",
-                            "next": "Next",
-                            "submit": "Submit",
-                          }
-                        }
-                        disableBack={true}
-                        formOptions={
-                          Object {
-                            "getRegisteredFields": [MockFunction],
-                            "getState": [Function],
-                            "handleSubmit": [Function],
-                            "onCancel": [MockFunction],
-                            "onSubmit": [MockFunction],
-                            "renderForm": [Function],
-                            "submit": [MockFunction],
-                            "valid": true,
-                          }
-                        }
-                        handleNext={[Function]}
-                        handlePrev={[Function]}
-                        name="foo"
-                        stepKey="1"
-                      >
-                        <footer
-                          className="pf-c-wizard__footer "
-                        >
-                          <SubmitButton
-                            handleSubmit={[Function]}
-                            submitLabel="Submit"
-                          >
-                            <Component
-                              onClick={[Function]}
-                              type="button"
-                              variant="primary"
-                            >
-                              <ComponentWithOuia
-                                component={[Function]}
-                                componentProps={
-                                  Object {
-                                    "children": "Submit",
-                                    "onClick": [Function],
-                                    "type": "button",
-                                    "variant": "primary",
-                                  }
-                                }
-                                consumerContext={null}
-                              >
-                                <Button
-                                  onClick={[Function]}
-                                  ouiaContext={
-                                    Object {
-                                      "isOuia": false,
-                                      "ouiaId": null,
-                                    }
-                                  }
-                                  type="button"
-                                  variant="primary"
-                                >
-                                  <button
-                                    aria-disabled={null}
-                                    aria-label={null}
-                                    className="pf-c-button pf-m-primary"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    tabIndex={null}
-                                    type="button"
-                                  >
-                                    Submit
-                                  </button>
-                                </Button>
-                              </ComponentWithOuia>
-                            </Component>
-                          </SubmitButton>
-                          <Component
-                            isDisabled={true}
-                            onClick={[Function]}
-                            type="button"
-                            variant="secondary"
-                          >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": "Back",
-                                  "isDisabled": true,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
-                            >
-                              <Button
-                                isDisabled={true}
-                                onClick={[Function]}
-                                ouiaContext={
-                                  Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
-                                  }
-                                }
-                                type="button"
-                                variant="secondary"
-                              >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={true}
-                                  onClick={[Function]}
-                                  tabIndex={null}
-                                  type="button"
-                                >
-                                  Back
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                          <Component
-                            onClick={[Function]}
-                            type="button"
-                            variant="link"
-                          >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": "Cancel",
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "link",
-                                }
-                              }
-                              consumerContext={null}
-                            >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
-                                  Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
-                                  }
-                                }
-                                type="button"
-                                variant="link"
-                              >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-link"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={null}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </footer>
-                      </WizardStepButtons>
-                    </WizardStep>
-                  </div>
-                </div>
-              </div>
-            </Bullseye>
-          </div>
-        </Backdrop>
-      </Portal>
-    </Modal>
-  </Wizard>
-</WizardFunction>
-`;
-
-exports[`<Wizard /> should render correctly in modal and unmount 2`] = `null`;
-
-exports[`<Wizard /> should render correctly with custom title and description 1`] = `
-<WizardFunction
-  FieldProvider={[Function]}
-  buttonLabels={Object {}}
-  description={
-    <div>
-      description
-    </div>
-  }
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "foo",
-        "stepKey": "1",
-      },
-    ]
-  }
-  formOptions={
+  initialValues={Object {}}
+  layoutMapper={
     Object {
-      "getRegisteredFields": [MockFunction],
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "renderForm": [Function],
-      "submit": [MockFunction],
-      "valid": true,
+      "Button": [Function],
+      "ButtonGroup": [Function],
+      "Description": [Function],
+      "FormWrapper": [Function],
+      "Title": [Function],
     }
   }
-  title={
-    <div>
-      Title
-    </div>
-  }
->
-  <Wizard
-    FieldProvider={[Function]}
-    buttonLabels={
-      Object {
-        "back": "Back",
-        "cancel": "Cancel",
-        "next": "Next",
-        "submit": "Submit",
-      }
-    }
-    description={
-      <div>
-        description
-      </div>
-    }
-    fields={
-      Array [
+  onCancel={[MockFunction]}
+  onSubmit={[MockFunction]}
+  schema={
+    Object {
+      "fields": Array [
         Object {
-          "fields": Array [],
-          "name": "foo",
-          "stepKey": "1",
-        },
-      ]
-    }
-    formOptions={
-      Object {
-        "getRegisteredFields": [MockFunction],
-        "getState": [Function],
-        "onCancel": [MockFunction],
-        "onSubmit": [MockFunction],
-        "renderForm": [Function],
-        "submit": [MockFunction],
-        "valid": true,
-      }
-    }
-    title={
-      <div>
-        Title
-      </div>
-    }
-  >
-    <Modal>
-      <div
-        className="pf-c-wizard no-shadow   "
-        onKeyDown={[Function]}
-        role="dialog"
-      >
-        <WizardHeader
-          description={
-            <div>
-              description
-            </div>
-          }
-          onClose={[Function]}
-          title={
-            <div>
-              Title
-            </div>
-          }
-        >
-          <div
-            className="pf-c-wizard__header"
-          >
-            <Component
-              className="pf-c-wizard__close"
-              onClick={[Function]}
-              variant="plain"
-            >
-              <ComponentWithOuia
-                component={[Function]}
-                componentProps={
-                  Object {
-                    "aria-label": undefined,
-                    "children": <TimesIcon
-                      aria-hidden="true"
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                      title={null}
-                    />,
-                    "className": "pf-c-wizard__close",
-                    "onClick": [Function],
-                    "variant": "plain",
-                  }
-                }
-                consumerContext={null}
-              >
-                <Button
-                  className="pf-c-wizard__close"
-                  onClick={[Function]}
-                  ouiaContext={
-                    Object {
-                      "isOuia": false,
-                      "ouiaId": null,
-                    }
-                  }
-                  variant="plain"
-                >
-                  <button
-                    aria-disabled={null}
-                    aria-label={null}
-                    className="pf-c-button pf-m-plain pf-c-wizard__close"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={null}
-                    type="button"
-                  >
-                    <TimesIcon
-                      aria-hidden="true"
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                      title={null}
-                    >
-                      <svg
-                        aria-hidden="true"
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 352 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          transform=""
-                        />
-                      </svg>
-                    </TimesIcon>
-                  </button>
-                </Button>
-              </ComponentWithOuia>
-            </Component>
-            <Title
-              aria-label={
-                <div>
-                  Title
-                </div>
-              }
-              className="pf-c-wizard__title"
-              size="3xl"
-            >
-              <h1
-                aria-label={
-                  <div>
-                    Title
-                  </div>
-                }
-                className="pf-c-title pf-m-3xl pf-c-wizard__title"
-              >
-                <div>
-                  Title
-                </div>
-              </h1>
-            </Title>
-            <p
-              className="pf-c-wizard__description"
-            >
-              <div>
-                description
-              </div>
-            </p>
-          </div>
-        </WizardHeader>
-        <div
-          className="pf-c-wizard__outer-wrap"
-        >
-          <WizardNav>
-            <nav
-              className="pf-c-wizard__nav"
-            >
-              <ol
-                className="pf-c-wizard__nav-list"
-              >
-                <WizardNavItem
-                  isCurrent={true}
-                  isDisabled={false}
-                  onNavItemClick={[Function]}
-                  step={0}
-                >
-                  <li
-                    className="pf-c-wizard__nav-item"
-                  >
-                    <a
-                      aria-current="page"
-                      aria-disabled={false}
-                      className="pf-c-wizard__nav-link pf-m-current"
-                      onClick={[Function]}
-                    />
-                  </li>
-                </WizardNavItem>
-              </ol>
-            </nav>
-          </WizardNav>
-          <WizardStep
-            FieldProvider={[Function]}
-            buttonLabels={
-              Object {
-                "back": "Back",
-                "cancel": "Cancel",
-                "next": "Next",
-                "submit": "Submit",
-              }
-            }
-            disableBack={true}
-            fields={Array []}
-            formOptions={
-              Object {
-                "getRegisteredFields": [MockFunction],
-                "getState": [Function],
-                "handleSubmit": [Function],
-                "onCancel": [MockFunction],
-                "onSubmit": [MockFunction],
-                "renderForm": [Function],
-                "submit": [MockFunction],
-                "valid": true,
-              }
-            }
-            handleNext={[Function]}
-            handlePrev={[Function]}
-            name="foo"
-            stepKey="1"
-          >
-            <WizardBody
-              hasBodyPadding={true}
-            >
-              <main
-                className="pf-c-wizard__main"
-              >
-                <div
-                  className="pf-c-wizard__main-body"
-                >
-                  <div
-                    className="pf-c-form"
-                  />
-                </div>
-              </main>
-            </WizardBody>
-            <WizardStepButtons
-              FieldProvider={[Function]}
-              buttonLabels={
+          "component": "wizard",
+          "fields": Array [
+            Object {
+              "fields": Array [
                 Object {
-                  "back": "Back",
-                  "cancel": "Cancel",
-                  "next": "Next",
-                  "submit": "Submit",
-                }
+                  "component": "text-field",
+                  "name": "foo-field",
+                },
+              ],
+              "name": "foo",
+              "nextStep": "2",
+              "stepKey": "1",
+              "title": "foo-step",
+            },
+            Object {
+              "fields": Array [
+                Object {
+                  "component": "text-field",
+                  "name": "bar-field",
+                },
+              ],
+              "name": "bar",
+              "stepKey": "2",
+              "title": "bar-step",
+            },
+          ],
+          "inModal": true,
+          "name": "wizard",
+        },
+      ],
+    }
+  }
+  showFormControls={false}
+>
+  <ReactFinalForm
+    decorators={
+      Array [
+        [Function],
+      ]
+    }
+    initialValues={Object {}}
+    mutators={
+      Object {
+        "concat": [Function],
+        "insert": [Function],
+        "move": [Function],
+        "pop": [Function],
+        "push": [Function],
+        "remove": [Function],
+        "removeBatch": [Function],
+        "shift": [Function],
+        "swap": [Function],
+        "unshift": [Function],
+        "update": [Function],
+      }
+    }
+    onSubmit={[MockFunction]}
+    render={[Function]}
+    subscription={
+      Object {
+        "pristine": true,
+        "submitting": true,
+        "valid": true,
+      }
+    }
+  >
+    <Form
+      onSubmit={[Function]}
+    >
+      <form
+        className="pf-c-form"
+        noValidate={true}
+        onSubmit={[Function]}
+      >
+        <FormConditionWrapper>
+          <FormFieldHideWrapper
+            hideField={false}
+          >
+            <FieldWrapper
+              component={[Function]}
+              componentType="wizard"
+              fields={
+                Array [
+                  Object {
+                    "fields": Array [
+                      Object {
+                        "component": "text-field",
+                        "name": "foo-field",
+                      },
+                    ],
+                    "name": "foo",
+                    "nextStep": "2",
+                    "stepKey": "1",
+                    "title": "foo-step",
+                  },
+                  Object {
+                    "fields": Array [
+                      Object {
+                        "component": "text-field",
+                        "name": "bar-field",
+                      },
+                    ],
+                    "name": "bar",
+                    "stepKey": "2",
+                    "title": "bar-step",
+                  },
+                ]
               }
-              disableBack={true}
               formOptions={
                 Object {
-                  "getRegisteredFields": [MockFunction],
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "clearOnUnmount": false,
+                  "clearedValue": undefined,
+                  "concat": [Function],
+                  "destroyOnUnregister": false,
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
                   "getState": [Function],
                   "handleSubmit": [Function],
+                  "initialize": [Function],
+                  "insert": [Function],
+                  "isValidationPaused": [Function],
+                  "move": [Function],
                   "onCancel": [MockFunction],
                   "onSubmit": [MockFunction],
+                  "pauseValidation": [Function],
+                  "pop": [Function],
+                  "pristine": true,
+                  "push": [Function],
+                  "registerField": [Function],
+                  "remove": [Function],
+                  "removeBatch": [Function],
                   "renderForm": [Function],
-                  "submit": [MockFunction],
+                  "reset": [Function],
+                  "resetFieldState": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "shift": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
+                  "swap": [Function],
+                  "unshift": [Function],
+                  "update": [Function],
                   "valid": true,
                 }
               }
-              handleNext={[Function]}
-              handlePrev={[Function]}
-              name="foo"
-              stepKey="1"
+              inModal={true}
+              name="wizard"
+              validate={
+                Array [
+                  undefined,
+                ]
+              }
             >
-              <footer
-                className="pf-c-wizard__footer "
+              <WizardFunction
+                FieldProvider={[Function]}
+                FormSpyProvider={[Function]}
+                buttonLabels={Object {}}
+                fields={
+                  Array [
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "foo-field",
+                        },
+                      ],
+                      "name": "foo",
+                      "nextStep": "2",
+                      "stepKey": "1",
+                      "title": "foo-step",
+                    },
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "bar-field",
+                        },
+                      ],
+                      "name": "bar",
+                      "stepKey": "2",
+                      "title": "bar-step",
+                    },
+                  ]
+                }
+                formOptions={
+                  Object {
+                    "batch": [Function],
+                    "blur": [Function],
+                    "change": [Function],
+                    "clearOnUnmount": false,
+                    "clearedValue": undefined,
+                    "concat": [Function],
+                    "destroyOnUnregister": false,
+                    "focus": [Function],
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "handleSubmit": [Function],
+                    "initialize": [Function],
+                    "insert": [Function],
+                    "isValidationPaused": [Function],
+                    "move": [Function],
+                    "onCancel": [MockFunction],
+                    "onSubmit": [MockFunction],
+                    "pauseValidation": [Function],
+                    "pop": [Function],
+                    "pristine": true,
+                    "push": [Function],
+                    "registerField": [Function],
+                    "remove": [Function],
+                    "removeBatch": [Function],
+                    "renderForm": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "shift": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                    "valid": true,
+                  }
+                }
+                inModal={true}
+                name="wizard"
+                validate={[Function]}
               >
-                <SubmitButton
-                  handleSubmit={[Function]}
-                  submitLabel="Submit"
-                >
-                  <Component
-                    onClick={[Function]}
-                    type="button"
-                    variant="primary"
-                  >
-                    <ComponentWithOuia
-                      component={[Function]}
-                      componentProps={
-                        Object {
-                          "children": "Submit",
-                          "onClick": [Function],
-                          "type": "button",
-                          "variant": "primary",
-                        }
-                      }
-                      consumerContext={null}
-                    >
-                      <Button
-                        onClick={[Function]}
-                        ouiaContext={
+                <Wizard
+                  FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
+                  buttonLabels={
+                    Object {
+                      "back": "Back",
+                      "cancel": "Cancel",
+                      "next": "Next",
+                      "submit": "Submit",
+                    }
+                  }
+                  fields={
+                    Array [
+                      Object {
+                        "fields": Array [
                           Object {
-                            "isOuia": false,
-                            "ouiaId": null,
-                          }
-                        }
-                        type="button"
-                        variant="primary"
-                      >
-                        <button
-                          aria-disabled={null}
-                          aria-label={null}
-                          className="pf-c-button pf-m-primary"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={null}
-                          type="button"
+                            "component": "text-field",
+                            "name": "foo-field",
+                          },
+                        ],
+                        "name": "foo",
+                        "nextStep": "2",
+                        "stepKey": "1",
+                        "title": "foo-step",
+                      },
+                      Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "bar-field",
+                          },
+                        ],
+                        "name": "bar",
+                        "stepKey": "2",
+                        "title": "bar-step",
+                      },
+                    ]
+                  }
+                  formOptions={
+                    Object {
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "clearOnUnmount": false,
+                      "clearedValue": undefined,
+                      "concat": [Function],
+                      "destroyOnUnregister": false,
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "handleSubmit": [Function],
+                      "initialize": [Function],
+                      "insert": [Function],
+                      "isValidationPaused": [Function],
+                      "move": [Function],
+                      "onCancel": [MockFunction],
+                      "onSubmit": [MockFunction],
+                      "pauseValidation": [Function],
+                      "pop": [Function],
+                      "pristine": true,
+                      "push": [Function],
+                      "registerField": [Function],
+                      "remove": [Function],
+                      "removeBatch": [Function],
+                      "renderForm": [Function],
+                      "reset": [Function],
+                      "resetFieldState": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "shift": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
+                      "swap": [Function],
+                      "unshift": [Function],
+                      "update": [Function],
+                      "valid": true,
+                    }
+                  }
+                  inModal={true}
+                  name="wizard"
+                  validate={[Function]}
+                >
+                  <Modal
+                    container={
+                      <div>
+                        <div
+                          class="pf-c-backdrop"
                         >
-                          Submit
-                        </button>
-                      </Button>
-                    </ComponentWithOuia>
-                  </Component>
-                </SubmitButton>
-                <Component
-                  isDisabled={true}
-                  onClick={[Function]}
-                  type="button"
-                  variant="secondary"
-                >
-                  <ComponentWithOuia
-                    component={[Function]}
-                    componentProps={
-                      Object {
-                        "children": "Back",
-                        "isDisabled": true,
-                        "onClick": [Function],
-                        "type": "button",
-                        "variant": "secondary",
-                      }
+                          <div
+                            class="pf-l-bullseye"
+                          >
+                            <div
+                              aria-modal="true"
+                              class="pf-c-wizard    "
+                              role="dialog"
+                            >
+                              <div
+                                class="pf-c-wizard__outer-wrap"
+                              >
+                                <nav
+                                  class="pf-c-wizard__nav"
+                                >
+                                  <ol
+                                    class="pf-c-wizard__nav-list"
+                                  >
+                                    <li
+                                      class="pf-c-wizard__nav-item"
+                                    >
+                                      <a
+                                        aria-current="page"
+                                        aria-disabled="false"
+                                        class="pf-c-wizard__nav-link pf-m-current"
+                                      >
+                                        foo-step
+                                      </a>
+                                    </li>
+                                    <li
+                                      class="pf-c-wizard__nav-item"
+                                    >
+                                      <a
+                                        aria-current="false"
+                                        aria-disabled="true"
+                                        class="pf-c-wizard__nav-link pf-m-disabled"
+                                        tabindex="-1"
+                                      >
+                                        bar-step
+                                      </a>
+                                    </li>
+                                  </ol>
+                                </nav>
+                                <main
+                                  class="pf-c-wizard__main"
+                                >
+                                  <div
+                                    class="pf-c-wizard__main-body"
+                                  >
+                                    <div
+                                      class="pf-c-form"
+                                    >
+                                      <div
+                                        class="pf-c-form__group"
+                                      >
+                                        <input
+                                          aria-invalid="false"
+                                          class="pf-c-form-control"
+                                          id="foo-field"
+                                          name="foo-field"
+                                          type="text"
+                                          value=""
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                </main>
+                                <footer
+                                  class="pf-c-wizard__footer "
+                                >
+                                  <button
+                                    class="pf-c-button pf-m-primary"
+                                    type="button"
+                                  >
+                                    Next
+                                  </button>
+                                  <button
+                                    class="pf-c-button pf-m-secondary"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    Back
+                                  </button>
+                                  <button
+                                    class="pf-c-button pf-m-link"
+                                    type="button"
+                                  >
+                                    Cancel
+                                  </button>
+                                </footer>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
                     }
-                    consumerContext={null}
+                    inModal={true}
                   >
-                    <Button
-                      isDisabled={true}
-                      onClick={[Function]}
-                      ouiaContext={
-                        Object {
-                          "isOuia": false,
-                          "ouiaId": null,
-                        }
+                    <Portal
+                      containerInfo={
+                        <div>
+                          <div
+                            class="pf-c-backdrop"
+                          >
+                            <div
+                              class="pf-l-bullseye"
+                            >
+                              <div
+                                aria-modal="true"
+                                class="pf-c-wizard    "
+                                role="dialog"
+                              >
+                                <div
+                                  class="pf-c-wizard__outer-wrap"
+                                >
+                                  <nav
+                                    class="pf-c-wizard__nav"
+                                  >
+                                    <ol
+                                      class="pf-c-wizard__nav-list"
+                                    >
+                                      <li
+                                        class="pf-c-wizard__nav-item"
+                                      >
+                                        <a
+                                          aria-current="page"
+                                          aria-disabled="false"
+                                          class="pf-c-wizard__nav-link pf-m-current"
+                                        >
+                                          foo-step
+                                        </a>
+                                      </li>
+                                      <li
+                                        class="pf-c-wizard__nav-item"
+                                      >
+                                        <a
+                                          aria-current="false"
+                                          aria-disabled="true"
+                                          class="pf-c-wizard__nav-link pf-m-disabled"
+                                          tabindex="-1"
+                                        >
+                                          bar-step
+                                        </a>
+                                      </li>
+                                    </ol>
+                                  </nav>
+                                  <main
+                                    class="pf-c-wizard__main"
+                                  >
+                                    <div
+                                      class="pf-c-wizard__main-body"
+                                    >
+                                      <div
+                                        class="pf-c-form"
+                                      >
+                                        <div
+                                          class="pf-c-form__group"
+                                        >
+                                          <input
+                                            aria-invalid="false"
+                                            class="pf-c-form-control"
+                                            id="foo-field"
+                                            name="foo-field"
+                                            type="text"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </main>
+                                  <footer
+                                    class="pf-c-wizard__footer "
+                                  >
+                                    <button
+                                      class="pf-c-button pf-m-primary"
+                                      type="button"
+                                    >
+                                      Next
+                                    </button>
+                                    <button
+                                      class="pf-c-button pf-m-secondary"
+                                      disabled=""
+                                      type="button"
+                                    >
+                                      Back
+                                    </button>
+                                    <button
+                                      class="pf-c-button pf-m-link"
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </footer>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
                       }
-                      type="button"
-                      variant="secondary"
                     >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-secondary"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Back
-                      </button>
-                    </Button>
-                  </ComponentWithOuia>
-                </Component>
-                <Component
-                  onClick={[Function]}
-                  type="button"
-                  variant="link"
-                >
-                  <ComponentWithOuia
-                    component={[Function]}
-                    componentProps={
-                      Object {
-                        "children": "Cancel",
-                        "onClick": [Function],
-                        "type": "button",
-                        "variant": "link",
-                      }
-                    }
-                    consumerContext={null}
-                  >
-                    <Button
-                      onClick={[Function]}
-                      ouiaContext={
-                        Object {
-                          "isOuia": false,
-                          "ouiaId": null,
-                        }
-                      }
-                      type="button"
-                      variant="link"
-                    >
-                      <button
-                        aria-disabled={null}
-                        aria-label={null}
-                        className="pf-c-button pf-m-link"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={null}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                    </Button>
-                  </ComponentWithOuia>
-                </Component>
-              </footer>
-            </WizardStepButtons>
-          </WizardStep>
-        </div>
-      </div>
-    </Modal>
-  </Wizard>
-</WizardFunction>
+                      <Backdrop>
+                        <div
+                          className="pf-c-backdrop"
+                        >
+                          <Bullseye>
+                            <div
+                              className="pf-l-bullseye"
+                            >
+                              <div
+                                aria-modal="true"
+                                className="pf-c-wizard    "
+                                onKeyDown={[Function]}
+                                role="dialog"
+                              >
+                                <div
+                                  className="pf-c-wizard__outer-wrap"
+                                >
+                                  <WizardNav>
+                                    <nav
+                                      className="pf-c-wizard__nav"
+                                    >
+                                      <ol
+                                        className="pf-c-wizard__nav-list"
+                                      >
+                                        <ReactFinalForm(FormSpy)>
+                                          <FormSpy
+                                            reactFinalForm={
+                                              Object {
+                                                "batch": [Function],
+                                                "blur": [Function],
+                                                "change": [Function],
+                                                "destroyOnUnregister": false,
+                                                "focus": [Function],
+                                                "getFieldState": [Function],
+                                                "getRegisteredFields": [Function],
+                                                "getState": [Function],
+                                                "initialize": [Function],
+                                                "isValidationPaused": [Function],
+                                                "mutators": Object {
+                                                  "concat": [Function],
+                                                  "insert": [Function],
+                                                  "move": [Function],
+                                                  "pop": [Function],
+                                                  "push": [Function],
+                                                  "remove": [Function],
+                                                  "removeBatch": [Function],
+                                                  "shift": [Function],
+                                                  "swap": [Function],
+                                                  "unshift": [Function],
+                                                  "update": [Function],
+                                                },
+                                                "pauseValidation": [Function],
+                                                "registerField": [Function],
+                                                "reset": [Function],
+                                                "resetFieldState": [Function],
+                                                "resumeValidation": [Function],
+                                                "setConfig": [Function],
+                                                "submit": [Function],
+                                                "subscribe": [Function],
+                                              }
+                                            }
+                                          >
+                                            <WizardNavigationClass
+                                              activeStepIndex={0}
+                                              formOptions={
+                                                Object {
+                                                  "batch": [Function],
+                                                  "blur": [Function],
+                                                  "change": [Function],
+                                                  "clearOnUnmount": false,
+                                                  "clearedValue": undefined,
+                                                  "concat": [Function],
+                                                  "destroyOnUnregister": false,
+                                                  "focus": [Function],
+                                                  "getFieldState": [Function],
+                                                  "getRegisteredFields": [Function],
+                                                  "getState": [Function],
+                                                  "handleSubmit": [Function],
+                                                  "initialize": [Function],
+                                                  "insert": [Function],
+                                                  "isValidationPaused": [Function],
+                                                  "move": [Function],
+                                                  "onCancel": [MockFunction],
+                                                  "onSubmit": [MockFunction],
+                                                  "pauseValidation": [Function],
+                                                  "pop": [Function],
+                                                  "pristine": true,
+                                                  "push": [Function],
+                                                  "registerField": [Function],
+                                                  "remove": [Function],
+                                                  "removeBatch": [Function],
+                                                  "renderForm": [Function],
+                                                  "reset": [Function],
+                                                  "resetFieldState": [Function],
+                                                  "resumeValidation": [Function],
+                                                  "setConfig": [Function],
+                                                  "shift": [Function],
+                                                  "submit": [Function],
+                                                  "subscribe": [Function],
+                                                  "swap": [Function],
+                                                  "unshift": [Function],
+                                                  "update": [Function],
+                                                  "valid": true,
+                                                }
+                                              }
+                                              isDynamic={false}
+                                              jumpToStep={[Function]}
+                                              maxStepIndex={0}
+                                              navSchema={
+                                                Array [
+                                                  Object {
+                                                    "index": 0,
+                                                    "primary": true,
+                                                    "substepOf": undefined,
+                                                    "title": "foo-step",
+                                                  },
+                                                  Object {
+                                                    "index": 1,
+                                                    "primary": true,
+                                                    "substepOf": undefined,
+                                                    "title": "bar-step",
+                                                  },
+                                                ]
+                                              }
+                                              setPrevSteps={[Function]}
+                                              values={Object {}}
+                                            >
+                                              <Component
+                                                activeStepIndex={0}
+                                                formOptions={
+                                                  Object {
+                                                    "batch": [Function],
+                                                    "blur": [Function],
+                                                    "change": [Function],
+                                                    "clearOnUnmount": false,
+                                                    "clearedValue": undefined,
+                                                    "concat": [Function],
+                                                    "destroyOnUnregister": false,
+                                                    "focus": [Function],
+                                                    "getFieldState": [Function],
+                                                    "getRegisteredFields": [Function],
+                                                    "getState": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialize": [Function],
+                                                    "insert": [Function],
+                                                    "isValidationPaused": [Function],
+                                                    "move": [Function],
+                                                    "onCancel": [MockFunction],
+                                                    "onSubmit": [MockFunction],
+                                                    "pauseValidation": [Function],
+                                                    "pop": [Function],
+                                                    "pristine": true,
+                                                    "push": [Function],
+                                                    "registerField": [Function],
+                                                    "remove": [Function],
+                                                    "removeBatch": [Function],
+                                                    "renderForm": [Function],
+                                                    "reset": [Function],
+                                                    "resetFieldState": [Function],
+                                                    "resumeValidation": [Function],
+                                                    "setConfig": [Function],
+                                                    "shift": [Function],
+                                                    "submit": [Function],
+                                                    "subscribe": [Function],
+                                                    "swap": [Function],
+                                                    "unshift": [Function],
+                                                    "update": [Function],
+                                                    "valid": true,
+                                                  }
+                                                }
+                                                jumpToStep={[Function]}
+                                                maxStepIndex={0}
+                                                navSchema={
+                                                  Array [
+                                                    Object {
+                                                      "index": 0,
+                                                      "primary": true,
+                                                      "substepOf": undefined,
+                                                      "title": "foo-step",
+                                                    },
+                                                    Object {
+                                                      "index": 1,
+                                                      "primary": true,
+                                                      "substepOf": undefined,
+                                                      "title": "bar-step",
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                <WizardNavItem
+                                                  isCurrent={true}
+                                                  isDisabled={false}
+                                                  key="foo-step"
+                                                  onNavItemClick={[Function]}
+                                                  step={0}
+                                                  text="foo-step"
+                                                >
+                                                  <li
+                                                    className="pf-c-wizard__nav-item"
+                                                  >
+                                                    <a
+                                                      aria-current="page"
+                                                      aria-disabled={false}
+                                                      className="pf-c-wizard__nav-link pf-m-current"
+                                                      onClick={[Function]}
+                                                    >
+                                                      foo-step
+                                                    </a>
+                                                  </li>
+                                                </WizardNavItem>
+                                                <WizardNavItem
+                                                  isCurrent={false}
+                                                  isDisabled={true}
+                                                  key="bar-step"
+                                                  onNavItemClick={[Function]}
+                                                  step={1}
+                                                  text="bar-step"
+                                                >
+                                                  <li
+                                                    className="pf-c-wizard__nav-item"
+                                                  >
+                                                    <a
+                                                      aria-current={false}
+                                                      aria-disabled={true}
+                                                      className="pf-c-wizard__nav-link pf-m-disabled"
+                                                      onClick={[Function]}
+                                                      tabIndex={-1}
+                                                    >
+                                                      bar-step
+                                                    </a>
+                                                  </li>
+                                                </WizardNavItem>
+                                              </Component>
+                                            </WizardNavigationClass>
+                                          </FormSpy>
+                                        </ReactFinalForm(FormSpy)>
+                                      </ol>
+                                    </nav>
+                                  </WizardNav>
+                                  <WizardStep
+                                    FieldProvider={[Function]}
+                                    buttonLabels={
+                                      Object {
+                                        "back": "Back",
+                                        "cancel": "Cancel",
+                                        "next": "Next",
+                                        "submit": "Submit",
+                                      }
+                                    }
+                                    disableBack={true}
+                                    fields={
+                                      Array [
+                                        Object {
+                                          "component": "text-field",
+                                          "name": "foo-field",
+                                        },
+                                      ]
+                                    }
+                                    formOptions={
+                                      Object {
+                                        "batch": [Function],
+                                        "blur": [Function],
+                                        "change": [Function],
+                                        "clearOnUnmount": false,
+                                        "clearedValue": undefined,
+                                        "concat": [Function],
+                                        "destroyOnUnregister": false,
+                                        "focus": [Function],
+                                        "getFieldState": [Function],
+                                        "getRegisteredFields": [Function],
+                                        "getState": [Function],
+                                        "handleSubmit": [Function],
+                                        "initialize": [Function],
+                                        "insert": [Function],
+                                        "isValidationPaused": [Function],
+                                        "move": [Function],
+                                        "onCancel": [MockFunction],
+                                        "onSubmit": [MockFunction],
+                                        "pauseValidation": [Function],
+                                        "pop": [Function],
+                                        "pristine": true,
+                                        "push": [Function],
+                                        "registerField": [Function],
+                                        "remove": [Function],
+                                        "removeBatch": [Function],
+                                        "renderForm": [Function],
+                                        "reset": [Function],
+                                        "resetFieldState": [Function],
+                                        "resumeValidation": [Function],
+                                        "setConfig": [Function],
+                                        "shift": [Function],
+                                        "submit": [Function],
+                                        "subscribe": [Function],
+                                        "swap": [Function],
+                                        "unshift": [Function],
+                                        "update": [Function],
+                                        "valid": true,
+                                      }
+                                    }
+                                    handleNext={[Function]}
+                                    handlePrev={[Function]}
+                                    name="foo"
+                                    nextStep="2"
+                                    stepKey="1"
+                                    title="foo-step"
+                                  >
+                                    <WizardBody
+                                      hasBodyPadding={true}
+                                    >
+                                      <main
+                                        className="pf-c-wizard__main"
+                                      >
+                                        <div
+                                          className="pf-c-wizard__main-body"
+                                        >
+                                          <div
+                                            className="pf-c-form"
+                                          >
+                                            <FormConditionWrapper>
+                                              <FormFieldHideWrapper
+                                                hideField={false}
+                                              >
+                                                <FieldWrapper
+                                                  component={[Function]}
+                                                  componentType="text-field"
+                                                  formOptions={
+                                                    Object {
+                                                      "batch": [Function],
+                                                      "blur": [Function],
+                                                      "change": [Function],
+                                                      "clearOnUnmount": false,
+                                                      "clearedValue": undefined,
+                                                      "concat": [Function],
+                                                      "destroyOnUnregister": false,
+                                                      "focus": [Function],
+                                                      "getFieldState": [Function],
+                                                      "getRegisteredFields": [Function],
+                                                      "getState": [Function],
+                                                      "handleSubmit": [Function],
+                                                      "initialize": [Function],
+                                                      "insert": [Function],
+                                                      "isValidationPaused": [Function],
+                                                      "move": [Function],
+                                                      "onCancel": [MockFunction],
+                                                      "onSubmit": [MockFunction],
+                                                      "pauseValidation": [Function],
+                                                      "pop": [Function],
+                                                      "pristine": true,
+                                                      "push": [Function],
+                                                      "registerField": [Function],
+                                                      "remove": [Function],
+                                                      "removeBatch": [Function],
+                                                      "renderForm": [Function],
+                                                      "reset": [Function],
+                                                      "resetFieldState": [Function],
+                                                      "resumeValidation": [Function],
+                                                      "setConfig": [Function],
+                                                      "shift": [Function],
+                                                      "submit": [Function],
+                                                      "subscribe": [Function],
+                                                      "swap": [Function],
+                                                      "unshift": [Function],
+                                                      "update": [Function],
+                                                      "valid": true,
+                                                    }
+                                                  }
+                                                  name="foo-field"
+                                                  validate={
+                                                    Array [
+                                                      undefined,
+                                                    ]
+                                                  }
+                                                >
+                                                  <FieldProvider
+                                                    FieldArrayProvider={[Function]}
+                                                    FieldProvider={[Function]}
+                                                    component={[Function]}
+                                                    formOptions={
+                                                      Object {
+                                                        "batch": [Function],
+                                                        "blur": [Function],
+                                                        "change": [Function],
+                                                        "clearOnUnmount": false,
+                                                        "clearedValue": undefined,
+                                                        "concat": [Function],
+                                                        "destroyOnUnregister": false,
+                                                        "focus": [Function],
+                                                        "getFieldState": [Function],
+                                                        "getRegisteredFields": [Function],
+                                                        "getState": [Function],
+                                                        "handleSubmit": [Function],
+                                                        "initialize": [Function],
+                                                        "insert": [Function],
+                                                        "isValidationPaused": [Function],
+                                                        "move": [Function],
+                                                        "onCancel": [MockFunction],
+                                                        "onSubmit": [MockFunction],
+                                                        "pauseValidation": [Function],
+                                                        "pop": [Function],
+                                                        "pristine": true,
+                                                        "push": [Function],
+                                                        "registerField": [Function],
+                                                        "remove": [Function],
+                                                        "removeBatch": [Function],
+                                                        "renderForm": [Function],
+                                                        "reset": [Function],
+                                                        "resetFieldState": [Function],
+                                                        "resumeValidation": [Function],
+                                                        "setConfig": [Function],
+                                                        "shift": [Function],
+                                                        "submit": [Function],
+                                                        "subscribe": [Function],
+                                                        "swap": [Function],
+                                                        "unshift": [Function],
+                                                        "update": [Function],
+                                                        "valid": true,
+                                                      }
+                                                    }
+                                                    name="foo-field"
+                                                    validate={[Function]}
+                                                  >
+                                                    <ReactFinalForm(Field)
+                                                      FieldArrayProvider={[Function]}
+                                                      FieldProvider={[Function]}
+                                                      formOptions={
+                                                        Object {
+                                                          "batch": [Function],
+                                                          "blur": [Function],
+                                                          "change": [Function],
+                                                          "clearOnUnmount": false,
+                                                          "clearedValue": undefined,
+                                                          "concat": [Function],
+                                                          "destroyOnUnregister": false,
+                                                          "focus": [Function],
+                                                          "getFieldState": [Function],
+                                                          "getRegisteredFields": [Function],
+                                                          "getState": [Function],
+                                                          "handleSubmit": [Function],
+                                                          "initialize": [Function],
+                                                          "insert": [Function],
+                                                          "isValidationPaused": [Function],
+                                                          "move": [Function],
+                                                          "onCancel": [MockFunction],
+                                                          "onSubmit": [MockFunction],
+                                                          "pauseValidation": [Function],
+                                                          "pop": [Function],
+                                                          "pristine": true,
+                                                          "push": [Function],
+                                                          "registerField": [Function],
+                                                          "remove": [Function],
+                                                          "removeBatch": [Function],
+                                                          "renderForm": [Function],
+                                                          "reset": [Function],
+                                                          "resetFieldState": [Function],
+                                                          "resumeValidation": [Function],
+                                                          "setConfig": [Function],
+                                                          "shift": [Function],
+                                                          "submit": [Function],
+                                                          "subscribe": [Function],
+                                                          "swap": [Function],
+                                                          "unshift": [Function],
+                                                          "update": [Function],
+                                                          "valid": true,
+                                                        }
+                                                      }
+                                                      name="foo-field"
+                                                      render={[Function]}
+                                                      validate={[Function]}
+                                                    >
+                                                      <Field
+                                                        FieldArrayProvider={[Function]}
+                                                        FieldProvider={[Function]}
+                                                        formOptions={
+                                                          Object {
+                                                            "batch": [Function],
+                                                            "blur": [Function],
+                                                            "change": [Function],
+                                                            "clearOnUnmount": false,
+                                                            "clearedValue": undefined,
+                                                            "concat": [Function],
+                                                            "destroyOnUnregister": false,
+                                                            "focus": [Function],
+                                                            "getFieldState": [Function],
+                                                            "getRegisteredFields": [Function],
+                                                            "getState": [Function],
+                                                            "handleSubmit": [Function],
+                                                            "initialize": [Function],
+                                                            "insert": [Function],
+                                                            "isValidationPaused": [Function],
+                                                            "move": [Function],
+                                                            "onCancel": [MockFunction],
+                                                            "onSubmit": [MockFunction],
+                                                            "pauseValidation": [Function],
+                                                            "pop": [Function],
+                                                            "pristine": true,
+                                                            "push": [Function],
+                                                            "registerField": [Function],
+                                                            "remove": [Function],
+                                                            "removeBatch": [Function],
+                                                            "renderForm": [Function],
+                                                            "reset": [Function],
+                                                            "resetFieldState": [Function],
+                                                            "resumeValidation": [Function],
+                                                            "setConfig": [Function],
+                                                            "shift": [Function],
+                                                            "submit": [Function],
+                                                            "subscribe": [Function],
+                                                            "swap": [Function],
+                                                            "unshift": [Function],
+                                                            "update": [Function],
+                                                            "valid": true,
+                                                          }
+                                                        }
+                                                        format={[Function]}
+                                                        name="foo-field"
+                                                        parse={[Function]}
+                                                        reactFinalForm={
+                                                          Object {
+                                                            "batch": [Function],
+                                                            "blur": [Function],
+                                                            "change": [Function],
+                                                            "destroyOnUnregister": false,
+                                                            "focus": [Function],
+                                                            "getFieldState": [Function],
+                                                            "getRegisteredFields": [Function],
+                                                            "getState": [Function],
+                                                            "initialize": [Function],
+                                                            "isValidationPaused": [Function],
+                                                            "mutators": Object {
+                                                              "concat": [Function],
+                                                              "insert": [Function],
+                                                              "move": [Function],
+                                                              "pop": [Function],
+                                                              "push": [Function],
+                                                              "remove": [Function],
+                                                              "removeBatch": [Function],
+                                                              "shift": [Function],
+                                                              "swap": [Function],
+                                                              "unshift": [Function],
+                                                              "update": [Function],
+                                                            },
+                                                            "pauseValidation": [Function],
+                                                            "registerField": [Function],
+                                                            "reset": [Function],
+                                                            "resetFieldState": [Function],
+                                                            "resumeValidation": [Function],
+                                                            "setConfig": [Function],
+                                                            "submit": [Function],
+                                                            "subscribe": [Function],
+                                                          }
+                                                        }
+                                                        render={[Function]}
+                                                        validate={[Function]}
+                                                      >
+                                                        <TextField
+                                                          FieldArrayProvider={[Function]}
+                                                          FieldProvider={[Function]}
+                                                          formOptions={
+                                                            Object {
+                                                              "batch": [Function],
+                                                              "blur": [Function],
+                                                              "change": [Function],
+                                                              "clearOnUnmount": false,
+                                                              "clearedValue": undefined,
+                                                              "concat": [Function],
+                                                              "destroyOnUnregister": false,
+                                                              "focus": [Function],
+                                                              "getFieldState": [Function],
+                                                              "getRegisteredFields": [Function],
+                                                              "getState": [Function],
+                                                              "handleSubmit": [Function],
+                                                              "initialize": [Function],
+                                                              "insert": [Function],
+                                                              "isValidationPaused": [Function],
+                                                              "move": [Function],
+                                                              "onCancel": [MockFunction],
+                                                              "onSubmit": [MockFunction],
+                                                              "pauseValidation": [Function],
+                                                              "pop": [Function],
+                                                              "pristine": true,
+                                                              "push": [Function],
+                                                              "registerField": [Function],
+                                                              "remove": [Function],
+                                                              "removeBatch": [Function],
+                                                              "renderForm": [Function],
+                                                              "reset": [Function],
+                                                              "resetFieldState": [Function],
+                                                              "resumeValidation": [Function],
+                                                              "setConfig": [Function],
+                                                              "shift": [Function],
+                                                              "submit": [Function],
+                                                              "subscribe": [Function],
+                                                              "swap": [Function],
+                                                              "unshift": [Function],
+                                                              "update": [Function],
+                                                              "valid": true,
+                                                            }
+                                                          }
+                                                          input={
+                                                            Object {
+                                                              "name": "foo-field",
+                                                              "onBlur": [Function],
+                                                              "onChange": [Function],
+                                                              "onFocus": [Function],
+                                                              "value": "",
+                                                            }
+                                                          }
+                                                          meta={
+                                                            Object {
+                                                              "active": false,
+                                                              "data": Object {},
+                                                              "dirty": false,
+                                                              "dirtySinceLastSubmit": false,
+                                                              "error": undefined,
+                                                              "initial": undefined,
+                                                              "invalid": false,
+                                                              "modified": false,
+                                                              "pristine": true,
+                                                              "submitError": undefined,
+                                                              "submitFailed": false,
+                                                              "submitSucceeded": false,
+                                                              "submitting": false,
+                                                              "touched": false,
+                                                              "valid": true,
+                                                              "visited": false,
+                                                            }
+                                                          }
+                                                        >
+                                                          <FieldInterface
+                                                            FieldArrayProvider={[Function]}
+                                                            FieldProvider={[Function]}
+                                                            componentType="text-field"
+                                                            formOptions={
+                                                              Object {
+                                                                "batch": [Function],
+                                                                "blur": [Function],
+                                                                "change": [Function],
+                                                                "clearOnUnmount": false,
+                                                                "clearedValue": undefined,
+                                                                "concat": [Function],
+                                                                "destroyOnUnregister": false,
+                                                                "focus": [Function],
+                                                                "getFieldState": [Function],
+                                                                "getRegisteredFields": [Function],
+                                                                "getState": [Function],
+                                                                "handleSubmit": [Function],
+                                                                "initialize": [Function],
+                                                                "insert": [Function],
+                                                                "isValidationPaused": [Function],
+                                                                "move": [Function],
+                                                                "onCancel": [MockFunction],
+                                                                "onSubmit": [MockFunction],
+                                                                "pauseValidation": [Function],
+                                                                "pop": [Function],
+                                                                "pristine": true,
+                                                                "push": [Function],
+                                                                "registerField": [Function],
+                                                                "remove": [Function],
+                                                                "removeBatch": [Function],
+                                                                "renderForm": [Function],
+                                                                "reset": [Function],
+                                                                "resetFieldState": [Function],
+                                                                "resumeValidation": [Function],
+                                                                "setConfig": [Function],
+                                                                "shift": [Function],
+                                                                "submit": [Function],
+                                                                "subscribe": [Function],
+                                                                "swap": [Function],
+                                                                "unshift": [Function],
+                                                                "update": [Function],
+                                                                "valid": true,
+                                                              }
+                                                            }
+                                                            input={
+                                                              Object {
+                                                                "name": "foo-field",
+                                                                "onBlur": [Function],
+                                                                "onChange": [Function],
+                                                                "onFocus": [Function],
+                                                                "value": "",
+                                                              }
+                                                            }
+                                                            meta={
+                                                              Object {
+                                                                "active": false,
+                                                                "data": Object {},
+                                                                "dirty": false,
+                                                                "dirtySinceLastSubmit": false,
+                                                                "error": undefined,
+                                                                "initial": undefined,
+                                                                "invalid": false,
+                                                                "modified": false,
+                                                                "pristine": true,
+                                                                "submitError": undefined,
+                                                                "submitFailed": false,
+                                                                "submitSucceeded": false,
+                                                                "submitting": false,
+                                                                "touched": false,
+                                                                "valid": true,
+                                                                "visited": false,
+                                                              }
+                                                            }
+                                                            name="foo-field"
+                                                          >
+                                                            <FormGroup
+                                                              fieldId="foo-field"
+                                                              isValid={true}
+                                                            >
+                                                              <div
+                                                                className="pf-c-form__group"
+                                                              >
+                                                                <TextInput
+                                                                  aria-label={null}
+                                                                  className=""
+                                                                  id="foo-field"
+                                                                  isDisabled={false}
+                                                                  isReadOnly={false}
+                                                                  isRequired={false}
+                                                                  isValid={true}
+                                                                  name="foo-field"
+                                                                  onBlur={[Function]}
+                                                                  onChange={[Function]}
+                                                                  onFocus={[Function]}
+                                                                  type="text"
+                                                                  value=""
+                                                                >
+                                                                  <input
+                                                                    aria-invalid={false}
+                                                                    aria-label={null}
+                                                                    className="pf-c-form-control"
+                                                                    disabled={false}
+                                                                    id="foo-field"
+                                                                    name="foo-field"
+                                                                    onBlur={[Function]}
+                                                                    onChange={[Function]}
+                                                                    onFocus={[Function]}
+                                                                    readOnly={false}
+                                                                    required={false}
+                                                                    type="text"
+                                                                    value=""
+                                                                  />
+                                                                </TextInput>
+                                                              </div>
+                                                            </FormGroup>
+                                                          </FieldInterface>
+                                                        </TextField>
+                                                      </Field>
+                                                    </ReactFinalForm(Field)>
+                                                  </FieldProvider>
+                                                </FieldWrapper>
+                                              </FormFieldHideWrapper>
+                                            </FormConditionWrapper>
+                                          </div>
+                                        </div>
+                                      </main>
+                                    </WizardBody>
+                                    <WizardStepButtons
+                                      FieldProvider={[Function]}
+                                      buttonLabels={
+                                        Object {
+                                          "back": "Back",
+                                          "cancel": "Cancel",
+                                          "next": "Next",
+                                          "submit": "Submit",
+                                        }
+                                      }
+                                      disableBack={true}
+                                      formOptions={
+                                        Object {
+                                          "batch": [Function],
+                                          "blur": [Function],
+                                          "change": [Function],
+                                          "clearOnUnmount": false,
+                                          "clearedValue": undefined,
+                                          "concat": [Function],
+                                          "destroyOnUnregister": false,
+                                          "focus": [Function],
+                                          "getFieldState": [Function],
+                                          "getRegisteredFields": [Function],
+                                          "getState": [Function],
+                                          "handleSubmit": [Function],
+                                          "initialize": [Function],
+                                          "insert": [Function],
+                                          "isValidationPaused": [Function],
+                                          "move": [Function],
+                                          "onCancel": [MockFunction],
+                                          "onSubmit": [MockFunction],
+                                          "pauseValidation": [Function],
+                                          "pop": [Function],
+                                          "pristine": true,
+                                          "push": [Function],
+                                          "registerField": [Function],
+                                          "remove": [Function],
+                                          "removeBatch": [Function],
+                                          "renderForm": [Function],
+                                          "reset": [Function],
+                                          "resetFieldState": [Function],
+                                          "resumeValidation": [Function],
+                                          "setConfig": [Function],
+                                          "shift": [Function],
+                                          "submit": [Function],
+                                          "subscribe": [Function],
+                                          "swap": [Function],
+                                          "unshift": [Function],
+                                          "update": [Function],
+                                          "valid": true,
+                                        }
+                                      }
+                                      handleNext={[Function]}
+                                      handlePrev={[Function]}
+                                      name="foo"
+                                      nextStep="2"
+                                      stepKey="1"
+                                    >
+                                      <footer
+                                        className="pf-c-wizard__footer "
+                                      >
+                                        <SimpleNext
+                                          batch={[Function]}
+                                          blur={[Function]}
+                                          change={[Function]}
+                                          clearOnUnmount={false}
+                                          concat={[Function]}
+                                          destroyOnUnregister={false}
+                                          focus={[Function]}
+                                          getFieldState={[Function]}
+                                          getRegisteredFields={[Function]}
+                                          getState={[Function]}
+                                          handleNext={[Function]}
+                                          initialize={[Function]}
+                                          insert={[Function]}
+                                          isValidationPaused={[Function]}
+                                          move={[Function]}
+                                          nextLabel="Next"
+                                          nextStep="2"
+                                          onCancel={[MockFunction]}
+                                          onSubmit={[MockFunction]}
+                                          pauseValidation={[Function]}
+                                          pop={[Function]}
+                                          pristine={true}
+                                          push={[Function]}
+                                          registerField={[Function]}
+                                          remove={[Function]}
+                                          removeBatch={[Function]}
+                                          renderForm={[Function]}
+                                          reset={[Function]}
+                                          resetFieldState={[Function]}
+                                          resumeValidation={[Function]}
+                                          setConfig={[Function]}
+                                          shift={[Function]}
+                                          submit={[Function]}
+                                          subscribe={[Function]}
+                                          swap={[Function]}
+                                          unshift={[Function]}
+                                          update={[Function]}
+                                          valid={true}
+                                        >
+                                          <Component
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                            variant="primary"
+                                          >
+                                            <ComponentWithOuia
+                                              component={[Function]}
+                                              componentProps={
+                                                Object {
+                                                  "children": "Next",
+                                                  "isDisabled": false,
+                                                  "onClick": [Function],
+                                                  "type": "button",
+                                                  "variant": "primary",
+                                                }
+                                              }
+                                              consumerContext={null}
+                                            >
+                                              <Button
+                                                isDisabled={false}
+                                                onClick={[Function]}
+                                                ouiaContext={
+                                                  Object {
+                                                    "isOuia": false,
+                                                    "ouiaId": null,
+                                                  }
+                                                }
+                                                type="button"
+                                                variant="primary"
+                                              >
+                                                <button
+                                                  aria-disabled={null}
+                                                  aria-label={null}
+                                                  className="pf-c-button pf-m-primary"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  tabIndex={null}
+                                                  type="button"
+                                                >
+                                                  Next
+                                                </button>
+                                              </Button>
+                                            </ComponentWithOuia>
+                                          </Component>
+                                        </SimpleNext>
+                                        <Component
+                                          isDisabled={true}
+                                          onClick={[Function]}
+                                          type="button"
+                                          variant="secondary"
+                                        >
+                                          <ComponentWithOuia
+                                            component={[Function]}
+                                            componentProps={
+                                              Object {
+                                                "children": "Back",
+                                                "isDisabled": true,
+                                                "onClick": [Function],
+                                                "type": "button",
+                                                "variant": "secondary",
+                                              }
+                                            }
+                                            consumerContext={null}
+                                          >
+                                            <Button
+                                              isDisabled={true}
+                                              onClick={[Function]}
+                                              ouiaContext={
+                                                Object {
+                                                  "isOuia": false,
+                                                  "ouiaId": null,
+                                                }
+                                              }
+                                              type="button"
+                                              variant="secondary"
+                                            >
+                                              <button
+                                                aria-disabled={null}
+                                                aria-label={null}
+                                                className="pf-c-button pf-m-secondary"
+                                                disabled={true}
+                                                onClick={[Function]}
+                                                tabIndex={null}
+                                                type="button"
+                                              >
+                                                Back
+                                              </button>
+                                            </Button>
+                                          </ComponentWithOuia>
+                                        </Component>
+                                        <Component
+                                          onClick={[Function]}
+                                          type="button"
+                                          variant="link"
+                                        >
+                                          <ComponentWithOuia
+                                            component={[Function]}
+                                            componentProps={
+                                              Object {
+                                                "children": "Cancel",
+                                                "onClick": [Function],
+                                                "type": "button",
+                                                "variant": "link",
+                                              }
+                                            }
+                                            consumerContext={null}
+                                          >
+                                            <Button
+                                              onClick={[Function]}
+                                              ouiaContext={
+                                                Object {
+                                                  "isOuia": false,
+                                                  "ouiaId": null,
+                                                }
+                                              }
+                                              type="button"
+                                              variant="link"
+                                            >
+                                              <button
+                                                aria-disabled={null}
+                                                aria-label={null}
+                                                className="pf-c-button pf-m-link"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                tabIndex={null}
+                                                type="button"
+                                              >
+                                                Cancel
+                                              </button>
+                                            </Button>
+                                          </ComponentWithOuia>
+                                        </Component>
+                                      </footer>
+                                    </WizardStepButtons>
+                                  </WizardStep>
+                                </div>
+                              </div>
+                            </div>
+                          </Bullseye>
+                        </div>
+                      </Backdrop>
+                    </Portal>
+                  </Modal>
+                </Wizard>
+              </WizardFunction>
+            </FieldWrapper>
+          </FormFieldHideWrapper>
+        </FormConditionWrapper>
+      </form>
+    </Form>
+  </ReactFinalForm>
+</FormRenderer>
 `;
+
+exports[`<Wizard /> should render correctly in modal and unmount 2`] = `null`;

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard-nav.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard-nav.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import WizardNavigationClass from '../../form-fields/wizard/wizard-nav';
+
+describe('WizardNav', () => {
+  it('WizardNavigationClass rerender nav schema only when values are changed', () => {
+    const initialProps  = {
+      activeStepIndex: 0,
+      formOptions: { valid: true },
+      maxStepIndex: 0,
+      jumpToStep: jest.fn(),
+      navSchema: [
+        { title: 'step' },
+      ],
+      setPrevSteps: jest.fn(),
+      values: { name: 'value 1' },
+      crossroads: [ 'name' ],
+    };
+
+    const wrapper = mount(<WizardNavigationClass { ...initialProps }/>);
+
+    expect(initialProps.setPrevSteps).not.toHaveBeenCalled();
+
+    wrapper.setProps({ values: { name: 'different value' }});
+
+    expect(initialProps.setPrevSteps.mock.calls).toHaveLength(1);
+
+    wrapper.setProps({ values: { name: 'different value' }});
+
+    expect(initialProps.setPrevSteps.mock.calls).toHaveLength(1);
+
+    wrapper.setProps({ values: { name: 'another value' }});
+
+    expect(initialProps.setPrevSteps.mock.calls).toHaveLength(2);
+
+    wrapper.setProps({ values: { name: 'another value', password: 'do not render nav' }});
+
+    expect(initialProps.setPrevSteps.mock.calls).toHaveLength(2);
+  });
+
+  it('WizardNavigationClass change maxStepIndex to activeStepIndex when switching', () => {
+    const activeStepIndex = 3;
+
+    const initialProps  = {
+      activeStepIndex,
+      formOptions: { valid: true },
+      maxStepIndex: 5,
+      jumpToStep: jest.fn(),
+      navSchema: [
+        { title: 'step' },
+      ],
+      setPrevSteps: jest.fn(),
+      values: { name: 'value 1' },
+      crossroads: [ 'name' ],
+    };
+
+    const wrapper = mount(<WizardNavigationClass { ...initialProps }/>);
+
+    expect(initialProps.setPrevSteps).not.toHaveBeenCalled();
+
+    wrapper.setProps({ values: { name: 'different value' }});
+
+    expect(wrapper.state().maxStepIndex).toEqual(activeStepIndex);
+  });
+});

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -1,30 +1,26 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import toJSon from 'enzyme-to-json';
+import { TextInput } from '@patternfly/react-core';
 
 import FormRenderer, { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import * as enterHandle from '@data-driven-forms/common/src/wizard/enter-handler';
 
 import { formFieldsMapper, layoutMapper } from '../../index';
 import Wizard from '../../form-fields/wizard/wizard';
-import FieldProvider from '../../../../../__mocks__/mock-field-provider';
 
 describe('<Wizard />', () => {
   let initialProps;
   let schema;
   let nestedSchema;
-  let getRegisteredFieldsSchemaMock;
-  let getRegisteredFieldsNestedSchemaMock;
-  let getValuesNestedSchema;
   let initialValues;
+  let schemaWithHeader;
+  let Title;
+  let Description;
+  let initialValuesNestedSchema;
 
   const nextButtonClick = (wrapper) =>  {
     wrapper.find('button').at(0).simulate('click');
-    wrapper.update();
-  };
-
-  const nextButtonClickWithHeader = (wrapper) =>  {
-    wrapper.find('button').at(1).simulate('click');
     wrapper.update();
   };
 
@@ -33,13 +29,8 @@ describe('<Wizard />', () => {
     wrapper.update();
   };
 
-  const backButtonClickWithHeader = (wrapper) =>  {
+  const cancelButtonClick = (wrapper) =>  {
     wrapper.find('button').at(2).simulate('click');
-    wrapper.update();
-  };
-
-  const cancelButtonClickWithHeader = (wrapper) =>  {
-    wrapper.find('button').at(3).simulate('click');
     wrapper.update();
   };
 
@@ -60,90 +51,106 @@ describe('<Wizard />', () => {
       'bar-field': 'bar-field-value',
       'not-visited-field': 'not-visted-field-value',
     };
-    initialProps = {
-      FieldProvider,
-      title: 'Wizard',
-      description: 'wizard description',
-      formOptions: {
-        renderForm: ([{ name }]) => <div key={ name }>{ name }</div>,
-        getState: () => ({
-          values: initialValues,
-        }),
-        onCancel: jest.fn(),
-        onSubmit: jest.fn(),
-        submit: jest.fn(),
-        valid: true,
-        getRegisteredFields: jest.fn(),
-      },
-      fields: [{
-        stepKey: '1',
-        name: 'foo',
-        fields: [],
-      }],
+
+    schema = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          fields: [{
+            title: 'foo-step',
+            stepKey: '1',
+            name: 'foo',
+            fields: [{
+              name: 'foo-field',
+              component: 'text-field',
+            }],
+            nextStep: '2',
+          }, {
+            stepKey: '2',
+            title: 'bar-step',
+            name: 'bar',
+            fields: [{
+              name: 'bar-field',
+              component: 'text-field',
+            }],
+          }]},
+      ],
     };
 
-    schema = [{
-      title: 'foo-step',
-      stepKey: '1',
-      name: 'foo',
-      fields: [{
-        name: 'foo-field',
-      }],
-      nextStep: '2',
-    }, {
-      stepKey: '2',
-      title: 'bar-step',
-      name: 'bar',
-      fields: [{
-        name: 'bar-field',
-      }],
-    }];
+    initialProps = {
+      schema,
+      formFieldsMapper,
+      layoutMapper,
+      onSubmit: jest.fn(),
+      onCancel: jest.fn(),
+      showFormControls: false,
+    };
 
-    getRegisteredFieldsSchemaMock = jest.fn();
+    nestedSchema = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          fields: [{
+            title: 'foo-step',
+            stepKey: '1',
+            name: 'foo',
+            fields: [{
+              name: 'nested.foo-field',
+              component: 'text-field',
+            }],
+            nextStep: '2',
+          }, {
+            stepKey: '2',
+            title: 'bar-step',
+            name: 'bar',
+            fields: [{
+              name: 'nested.second.bar-field',
+              component: 'text-field',
+            }],
+          }],
+        },
+      ],
+    };
 
-    getRegisteredFieldsSchemaMock
-    .mockReturnValueOnce('foo-field')
-    .mockReturnValueOnce('bar-field');
-
-    nestedSchema = [{
-      title: 'foo-step',
-      stepKey: '1',
-      name: 'foo',
-      fields: [{
-        name: 'nested.foo-field',
-      }],
-      nextStep: '2',
-    }, {
-      stepKey: '2',
-      title: 'bar-step',
-      name: 'bar',
-      fields: [{
-        name: 'nested.second.bar-field',
-      }],
-    }];
-
-    getRegisteredFieldsNestedSchemaMock = jest.fn();
-
-    getRegisteredFieldsNestedSchemaMock
-    .mockReturnValueOnce('nested.foo-field')
-    .mockReturnValueOnce('nested.second.bar-field');
-
-    getValuesNestedSchema = () => ({
-      values: {
-        'nested.foo-field': 'foo-field-value',
-        'nested.second.bar-field': 'bar-field-value',
-        'not-visited-field': 'not-visted-field-value',
+    initialValuesNestedSchema = {
+      nested: {
+        'foo-field': 'foo-field-value',
+        second: {
+          'bar-field': 'bar-field-value',
+        },
       },
-    });
-  });
+      'not-visited-field': 'not-visted-field-value',
+    };
 
-  afterEach(() => {
-    getRegisteredFieldsSchemaMock.mockReset();
-    getRegisteredFieldsNestedSchemaMock.mockReset();
+    Title = () => 'Title';
+    Description = () => 'description';
+
+    schemaWithHeader = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          title: <Title />,
+          description: <Description />,
+          inModal: true,
+          fields: [{
+            title: 'foo-step',
+            stepKey: '1',
+            name: 'foo',
+            fields: [{
+              name: 'foo-field',
+              component: 'text-field',
+            }],
+          }]},
+      ],
+    };
   });
 
   it('should render correctly and unmount', () => {
-    const wrapper = mount(<Wizard { ...initialProps } />);
+    const wrapper = mount(<FormRenderer { ...initialProps }/>);
+
     expect(toJSon(wrapper)).toMatchSnapshot();
     wrapper.unmount();
     wrapper.update();
@@ -153,7 +160,7 @@ describe('<Wizard />', () => {
   it('should call enter handler when pressing enter', () => {
     enterHandle.default = jest.fn();
 
-    const wrapper = mount(<Wizard { ...initialProps } />);
+    const wrapper = mount(<FormRenderer { ...initialProps }/>);
 
     expect(enterHandle.default).not.toHaveBeenCalled();
 
@@ -178,7 +185,34 @@ describe('<Wizard />', () => {
   });
 
   it('should render correctly in modal and unmount', () => {
-    const wrapper = mount(<Wizard inModal { ...initialProps } />);
+    schema = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          inModal: true,
+          fields: [{
+            title: 'foo-step',
+            stepKey: '1',
+            name: 'foo',
+            fields: [{
+              name: 'foo-field',
+              component: 'text-field',
+            }],
+            nextStep: '2',
+          }, {
+            stepKey: '2',
+            title: 'bar-step',
+            name: 'bar',
+            fields: [{
+              name: 'bar-field',
+              component: 'text-field',
+            }],
+          }]},
+      ],
+    };
+
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schema }/>);
     expect(toJSon(wrapper)).toMatchSnapshot();
     wrapper.unmount();
     wrapper.update();
@@ -186,49 +220,62 @@ describe('<Wizard />', () => {
   });
 
   it('should render correctly with custom title and description', () => {
-    const wrapper = mount(<Wizard { ...initialProps } title={ <div>Title</div> } description={ <div>description</div> } />);
-    expect(toJSon(wrapper)).toMatchSnapshot();
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schemaWithHeader }/>);
+
+    expect(wrapper.find(Title)).toHaveLength(1);
+    expect(wrapper.find(Description)).toHaveLength(1);
   });
 
   it('should render correctly with custom buttons', () => {
     const Buttons = () => <div>Hello</div>;
 
-    const wrapper = mount(<Wizard { ...initialProps } fields={ [{
-      title: 'foo-step',
-      stepKey: '1',
-      name: 'foo',
-      buttons: Buttons,
-      fields: [{
-        name: 'foo-field',
-      }],
-      nextStep: '2',
-    }] }/>);
-    expect(wrapper.find(Buttons).length).toEqual(1);
+    schema = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          fields: [{
+            title: 'foo-step',
+            stepKey: '1',
+            name: 'foo',
+            buttons: Buttons,
+            fields: [{
+              name: 'foo-field',
+              component: 'text-field',
+            }],
+          }]},
+      ],
+    };
+
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schema }/>);
+
+    expect(wrapper.find(Buttons)).toHaveLength(1);
   });
 
   it('should call submit function', () => {
     const onSubmit = jest.fn();
-    const wrapper = mount(<Wizard { ...initialProps } formOptions={{ ...initialProps.formOptions, onSubmit }} />);
-    nextButtonClickWithHeader(wrapper);
+
+    const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit }/>);
+
+    nextButtonClick(wrapper);
+    nextButtonClick(wrapper);
 
     expect(onSubmit).toHaveBeenCalled();
   });
 
   it('should go to next step correctly and submit data and formOptions', () => {
     const onSubmit = jest.fn();
-    const formOptions = { ...initialProps.formOptions, onSubmit, getRegisteredFields: getRegisteredFieldsSchemaMock };
 
-    const wrapper = mount(<Wizard
-      { ...initialProps }
-      formOptions={ formOptions }
-      fields={ schema }
-    />);
-    nextButtonClickWithHeader(wrapper);
+    const wrapper = mount(<FormRenderer { ...initialProps } onSubmit={ onSubmit } initialValues={ initialValues }/>);
 
-    expect(wrapper.children().instance().state.activeStep).toEqual('2');
-    expect(wrapper.children().instance().state.prevSteps).toEqual([ '1' ]);
+    nextButtonClick(wrapper);
 
-    nextButtonClickWithHeader(wrapper);
+    expect(wrapper.find(Wizard).children().instance().state.activeStep).toEqual('2');
+    expect(wrapper.find(Wizard).children().instance().state.prevSteps).toEqual([ '1' ]);
+
+    nextButtonClick(wrapper);
+
+    const formOptions = expect.any(Object);
 
     expect(onSubmit).toHaveBeenCalledWith({
       'foo-field': 'foo-field-value',
@@ -238,24 +285,18 @@ describe('<Wizard />', () => {
 
   it('should pass values to cancel button', () => {
     const onCancel = jest.fn();
-    const wrapper = mount(<Wizard
-      { ...initialProps }
-      fields={ schema }
-      formOptions={{ ...initialProps.formOptions, onCancel }}
-    />);
 
-    cancelButtonClickWithHeader(wrapper);
+    const wrapper = mount(<FormRenderer { ...initialProps } onCancel={ onCancel } initialValues={ initialValues }/>);
+
+    cancelButtonClick(wrapper);
 
     expect(onCancel).toHaveBeenCalledWith(initialValues);
   });
 
   it('should pass values to cancel - close icon', () => {
     const onCancel = jest.fn();
-    const wrapper = mount(<Wizard
-      { ...initialProps }
-      fields={ schema }
-      formOptions={{ ...initialProps.formOptions, onCancel }}
-    />);
+
+    const wrapper = mount(<FormRenderer { ...initialProps } onCancel={ onCancel } initialValues={ initialValues } schema={ schemaWithHeader }/>);
 
     closeIconClickWithHeader(wrapper);
 
@@ -264,21 +305,15 @@ describe('<Wizard />', () => {
 
   it('should submit data when nested schema', () => {
     const onSubmit = jest.fn();
-    const formOptions = {
-      ...initialProps.formOptions,
-      onSubmit,
-      getRegisteredFields: getRegisteredFieldsNestedSchemaMock,
-      getState: getValuesNestedSchema,
-    };
 
-    const wrapper = mount(<Wizard
-      { ...initialProps }
-      formOptions={ formOptions }
-      fields={ nestedSchema }
-    />);
+    const wrapper = mount(
+      <FormRenderer { ...initialProps } schema={ nestedSchema } onSubmit={ onSubmit } initialValues={ initialValuesNestedSchema }/>
+    );
 
-    nextButtonClickWithHeader(wrapper);
-    nextButtonClickWithHeader(wrapper);
+    nextButtonClick(wrapper);
+    nextButtonClick(wrapper);
+
+    const formOptions = expect.any(Object);
 
     expect(onSubmit).toHaveBeenCalledWith({
       nested: {
@@ -291,7 +326,7 @@ describe('<Wizard />', () => {
   });
 
   it('should build simple navigation', () => {
-    const wrapper = mount(<Wizard { ...initialProps } fields={ schema } />);
+    const wrapper = mount(<FormRenderer { ...initialProps }/>);
 
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(2);
     expect(wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).text()).toEqual('foo-step');
@@ -299,151 +334,208 @@ describe('<Wizard />', () => {
   });
 
   it('should build progressive navigation', () => {
-    const wrapper = mount(<Wizard { ...initialProps } isDynamic fields={ schema }  />);
+    schema = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          isDynamic: true,
+          fields: [{
+            title: 'foo-step',
+            stepKey: '1',
+            name: 'foo',
+            fields: [{
+              name: 'foo-field',
+              component: 'text-field',
+            }],
+            nextStep: '2',
+          }, {
+            stepKey: '2',
+            title: 'bar-step',
+            name: 'bar',
+            fields: [{
+              name: 'bar-field',
+              component: 'text-field',
+            }],
+          }]},
+      ],
+    };
+
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schema }/>);
 
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
     expect(wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).text()).toEqual('foo-step');
 
-    nextButtonClickWithHeader(wrapper);
+    nextButtonClick(wrapper);
 
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(2);
     expect(wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).text()).toEqual('bar-step');
   });
 
   it('should jump when click simple navigation', () => {
-    const wrapper = mount(<Wizard { ...initialProps } fields={ schema } />);
+    const wrapper = mount(<FormRenderer { ...initialProps }/>);
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
 
-    nextButtonClickWithHeader(wrapper);
+    nextButtonClick(wrapper);
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
 
     // click on first nav link
     wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
     wrapper.update();
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
 
     // go back
     wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).simulate('click');
     wrapper.update();
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
   });
 
   it('should build simple navigation with substeps', () => {
-    const wrapper = mount(<Wizard { ...initialProps } fields={ [{
-      title: 'foo-step',
-      stepKey: '1',
-      name: 'foo',
+    schema = {
       fields: [{
-        name: 'foo-field',
+        component: 'wizard',
+        name: 'wizard',
+        fields: [{
+          title: 'foo-step',
+          stepKey: '1',
+          name: 'foo',
+          fields: [{
+            name: 'foo-field',
+            component: 'text-field',
+          }],
+          nextStep: '2',
+        }, {
+          stepKey: '2',
+          title: 'bar-step',
+          name: 'bar',
+          substepOf: 'barbar',
+          fields: [{
+            name: 'bar-field',
+            component: 'text-field',
+          }],
+        }],
       }],
-      nextStep: '2',
-    }, {
-      stepKey: '2',
-      title: 'bar-step',
-      name: 'bar',
-      substepOf: 'barbar',
-      fields: [{
-        name: 'bar-field',
-      }],
-    }] } />);
+    };
+
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schema }/>);
 
     expect(wrapper.find('.pf-c-wizard__nav-list')).toHaveLength(2);
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
     expect(wrapper.find('.pf-c-wizard__nav-item').at(1).childAt(0).text()).toEqual('barbar');
     expect(wrapper.find('.pf-c-wizard__nav-list').last().childAt(0).childAt(0).text()).toEqual('bar-step');
-
   });
 
-  it('should jumb with substeps', () => {
-    const wrapper = mount(<Wizard { ...initialProps } fields={ [{
-      title: 'foo-step',
-      stepKey: '1',
-      name: 'foo',
+  it('should jump with substeps', () => {
+    schema = {
       fields: [{
-        name: 'foo-field',
+        component: 'wizard',
+        name: 'wizard',
+        fields: [{
+          title: 'foo-step',
+          stepKey: '1',
+          name: 'foo',
+          fields: [{
+            name: 'foo-field',
+            component: 'text-field',
+          }],
+          nextStep: '2',
+        }, {
+          stepKey: '2',
+          title: 'bar-step',
+          name: 'bar',
+          substepOf: 'barbar',
+          fields: [{
+            name: 'bar-field',
+            component: 'text-field',
+          }],
+        }],
       }],
-      nextStep: '2',
-    }, {
-      stepKey: '2',
-      title: 'bar-step',
-      name: 'bar',
-      substepOf: 'barbar',
-      fields: [{
-        name: 'bar-field',
-      }],
-    }] } />);
+    };
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schema }/>);
 
-    nextButtonClickWithHeader(wrapper);
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    nextButtonClick(wrapper);
+
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
 
     // click on first nav link
     wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
     wrapper.update();
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
 
     // go back through the primary step
     wrapper.find('.pf-c-wizard__nav-item').at(1).childAt(0).simulate('click');
     wrapper.update();
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
 
-    backButtonClickWithHeader(wrapper);
+    backButtonClick(wrapper);
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
 
     // go back through the substep
     wrapper.find('.pf-c-wizard__nav-item').last().childAt(0).simulate('click');
     wrapper.update();
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
   });
 
-  it('should jumb with substeps and dynamic', () => {
-    const wrapper = mount(<Wizard { ...initialProps } isDynamic fields={ [{
-      title: 'foo-step',
-      stepKey: '1',
-      name: 'foo',
+  it('should jump with substeps and dynamic', () => {
+    schema = {
       fields: [{
-        name: 'foo-field',
+        component: 'wizard',
+        name: 'wizard',
+        isDynamic: true,
+        fields: [{
+          title: 'foo-step',
+          stepKey: '1',
+          name: 'foo',
+          fields: [{
+            name: 'foo-field',
+            component: 'text-field',
+          }],
+          nextStep: '2',
+        }, {
+          stepKey: '2',
+          title: 'bar-step',
+          name: 'bar',
+          substepOf: 'barbar',
+          fields: [{
+            name: 'bar-field',
+            component: 'text-field',
+          }],
+        }],
       }],
-      nextStep: '2',
-    }, {
-      stepKey: '2',
-      title: 'bar-step',
-      name: 'bar',
-      substepOf: 'barbar',
-      fields: [{
-        name: 'bar-field',
-      }],
-    }] } />);
+    };
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    const wrapper = mount(<FormRenderer { ...initialProps } schema={ schema }/>);
+
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
 
-    nextButtonClickWithHeader(wrapper);
+    nextButtonClick(wrapper);
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
 
     // click on first nav link
     wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
     wrapper.update();
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('foo-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
     // visited step perished from navigation
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
 
-    nextButtonClickWithHeader(wrapper);
+    nextButtonClick(wrapper);
 
-    expect(wrapper.find('.pf-c-wizard__main-body').children().last().childAt(0).text()).toEqual('bar-field');
+    expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
     expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
   });
 

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -920,5 +920,155 @@ describe('<Wizard />', () => {
       expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
       expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
     });
+
+    it('crossroads variable predicts in realtime', () => {
+      const wizardSchema = {
+        fields: [{
+          component: componentTypes.WIZARD,
+          name: 'wizard',
+          predictSteps: true,
+          crossroads: [ 'source.source-type' ],
+          fields: [{
+            title: 'first-step',
+            stepKey: 1,
+            nextStep: {
+              when: 'source.source-type',
+              stepMapper: {
+                aws: 'aws',
+                google: 'summary',
+              },
+            },
+            fields: [{
+              name: 'source.source-type',
+              label: 'Source type',
+              component: componentTypes.TEXT_FIELD,
+            }],
+          }, {
+            title: 'second-step',
+            stepKey: 'aws',
+            nextStep: 'summary',
+            fields: [],
+          },
+          {
+            title: 'summary',
+            stepKey: 'summary',
+            fields: [],
+          }],
+        }],
+      };
+
+      const wrapper = mount(<FormRenderer
+        { ...initialProps }
+        schema={ wizardSchema }
+      />);
+
+      expect(wrapper.find('WizardNavItem')).toHaveLength(1);
+
+      changeValue(wrapper, 'aws');
+
+      // predict steps for aws
+      expect(wrapper.find('WizardNavItem')).toHaveLength(3);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
+      expect(wrapper.find('WizardNavItem').at(2).props().isDisabled).toEqual(true);
+
+      changeValue(wrapper, 'google');
+
+      // predict steps for google
+      expect(wrapper.find('WizardNavItem')).toHaveLength(2);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
+
+      nextButtonClick(wrapper);
+
+      expect(wrapper.find('WizardNavItem')).toHaveLength(2);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(false);
+
+      // click on first nav link
+      wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
+      wrapper.update();
+
+      // keep the second step enabled
+      expect(wrapper.find('WizardNavItem')).toHaveLength(2);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(false);
+
+      changeValue(wrapper, 'aws');
+
+      expect(wrapper.find('WizardNavItem')).toHaveLength(3);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
+      expect(wrapper.find('WizardNavItem').at(2).props().isDisabled).toEqual(true);
+
+      changeValue(wrapper, 'google');
+
+      expect(wrapper.find('WizardNavItem')).toHaveLength(2);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
+    });
+
+    it('crossroads variable predicts in realtime - disableForwardJumping', () => {
+      const wizardSchema = {
+        fields: [{
+          component: componentTypes.WIZARD,
+          name: 'wizard',
+          predictSteps: true,
+          crossroads: [ 'source.source-type' ],
+          fields: [{
+            title: 'first-step',
+            stepKey: 1,
+            nextStep: {
+              when: 'source.source-type',
+              stepMapper: {
+                aws: 'aws',
+                google: 'summary',
+              },
+            },
+            disableForwardJumping: true,
+            fields: [{
+              name: 'source.source-type',
+              label: 'Source type',
+              component: componentTypes.TEXT_FIELD,
+            }],
+          }, {
+            title: 'second-step',
+            stepKey: 'aws',
+            nextStep: 'summary',
+            fields: [],
+          },
+          {
+            title: 'summary',
+            stepKey: 'summary',
+            fields: [],
+          }],
+        }],
+      };
+
+      const wrapper = mount(<FormRenderer
+        { ...initialProps }
+        schema={ wizardSchema }
+      />);
+
+      expect(wrapper.find('WizardNavItem')).toHaveLength(1);
+
+      changeValue(wrapper, 'google');
+
+      // predict steps for google
+      expect(wrapper.find('WizardNavItem')).toHaveLength(2);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
+
+      nextButtonClick(wrapper);
+
+      // click on first nav link
+      wrapper.find('.pf-c-wizard__nav-item').first().childAt(0).simulate('click');
+      wrapper.update();
+
+      // keep the second step enabled
+      expect(wrapper.find('WizardNavItem')).toHaveLength(2);
+      expect(wrapper.find('WizardNavItem').at(0).props().isDisabled).toEqual(false);
+      expect(wrapper.find('WizardNavItem').at(1).props().isDisabled).toEqual(true);
+    });
   });
 });

--- a/packages/react-form-renderer/src/form-renderer/field-wrapper.js
+++ b/packages/react-form-renderer/src/form-renderer/field-wrapper.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormSpy } from 'react-final-form';
 
 import { components } from '../constants';
 import FieldProvider from './field-provider';
@@ -38,7 +39,7 @@ const FieldWrapper = ({ componentType, validate, component, ...rest }) => {
   const Component = component;
   return shouldWrapInField(componentType)
     ? <FieldProvider { ...componentProps } />
-    : <Component validate={ composeValidators(validate) } { ...rest } FieldProvider={ FieldProvider } />;
+    : <Component validate={ composeValidators(validate) } { ...rest } FieldProvider={ FieldProvider } FormSpyProvider={ FormSpy } />;
 };
 
 FieldWrapper.propTypes = {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -960,6 +960,7 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
             >
               <Component
                 FieldProvider={[Function]}
+                FormSpyProvider={[Function]}
                 formOptions={
                   Object {
                     "batch": [Function],
@@ -1079,6 +1080,7 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
               >
                 <Component
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "batch": [Function],

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -538,6 +538,7 @@ exports[`renderForm function #condition should render condition field only if co
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -547,6 +548,7 @@ exports[`renderForm function #condition should render condition field only if co
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -762,6 +764,7 @@ exports[`renderForm function #condition should render condition field only if on
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -771,6 +774,7 @@ exports[`renderForm function #condition should render condition field only if on
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -986,6 +990,7 @@ exports[`renderForm function #condition should render condition field only if on
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -995,6 +1000,7 @@ exports[`renderForm function #condition should render condition field only if on
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -1198,6 +1204,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -1207,6 +1214,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -1325,6 +1333,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -1334,6 +1343,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -1452,6 +1462,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -1461,6 +1472,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -1577,6 +1589,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -1586,6 +1599,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -1702,6 +1716,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -1711,6 +1726,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -1914,6 +1930,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -1923,6 +1940,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -2126,6 +2144,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -2135,6 +2154,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -2253,6 +2273,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -2262,6 +2283,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -2380,6 +2402,7 @@ exports[`renderForm function #condition should render condition field only if th
               >
                 <customComponent
                   FieldProvider={[Function]}
+                  FormSpyProvider={[Function]}
                   formOptions={
                     Object {
                       "renderForm": [Function],
@@ -2389,6 +2412,7 @@ exports[`renderForm function #condition should render condition field only if th
                   validate={[Function]}
                 >
                   <div
+                    FormSpyProvider={[Function]}
                     name="foo"
                     validate={[Function]}
                   >
@@ -2452,6 +2476,7 @@ exports[`renderForm function should render single field form with custom compone
         >
           <customComponent
             FieldProvider={[Function]}
+            FormSpyProvider={[Function]}
             formOptions={
               Object {
                 "renderForm": [Function],
@@ -2461,18 +2486,21 @@ exports[`renderForm function should render single field form with custom compone
             validate={[Function]}
           >
             <FieldProvider
+              FormSpyProvider={[Function]}
               formOptions={Object {}}
               name="foo"
               render={[Function]}
               validate={[Function]}
             >
               <ReactFinalForm(Field)
+                FormSpyProvider={[Function]}
                 formOptions={Object {}}
                 name="foo"
                 render={[Function]}
                 validate={[Function]}
               >
                 <Field
+                  FormSpyProvider={[Function]}
                   formOptions={Object {}}
                   format={[Function]}
                   name="foo"
@@ -2782,6 +2810,7 @@ exports[`renderForm function should render single field from with custom compone
         >
           <customComponent
             FieldProvider={[Function]}
+            FormSpyProvider={[Function]}
             formOptions={
               Object {
                 "renderForm": [Function],
@@ -2791,6 +2820,7 @@ exports[`renderForm function should render single field from with custom compone
             validate={[Function]}
           >
             <div
+              FormSpyProvider={[Function]}
               name="foo"
               validate={[Function]}
             >

--- a/packages/react-renderer-demo/src/app/pages/renderer/field-provider.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/field-provider.md
@@ -119,6 +119,10 @@ and informations about the formState.
 }
 ```
 
+# FormSpy provider
+
+Every component also receives component `FormSpyProvider` as a prop. You can find more info <a href="https://final-form.org/docs/react-final-form/api/FormSpy" rel="noopener noreferrer" target="_blank">here!</a>
+
 </Grid>
 <Grid item xs={false} md={2}>
   <ListOfContents file="renderer/field-provider" />

--- a/packages/react-renderer-demo/src/app/src/doc-components/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/pf4-wizard.md
@@ -16,6 +16,7 @@ Don't forget hide form controls by setting \`showFormControls\` to \`false\` as 
 | isDynamic  | bool  | undefined  | will dynamically generate steps navigation (=progressive wizard), please use if you use any condition fields which changes any field in other steps (wizards with conditional steps are dynamic by default) |
 |showTitles|bool|undefined|If true, step titles will be shown in the wizard body|
 |predictSteps|bool|undefined|If true, dynamic wizard will predict steps in the navigation.|
+|crossroads|array|undefined|Array of field names, which change next steps|
 
 **Default buttonLabels**
 
@@ -36,6 +37,12 @@ You can rewrite only selection of them, e.g.
 ```
 
 (Others will stay default)
+
+**Crossroads**
+
+With the help of `crossroads` you can manually defined which fields change next steps and together with `predictSteps`, it will cause that the wizard navigation is always refreshed, when one of the crossroads name is changed.
+
+Ex.: `crossroads: ['name', 'nested.password']`
 
 **Docs for steps**
 
@@ -174,6 +181,7 @@ Progressive wizard
 - use `isDynamic` prop to enforce it
 - use `predictSteps` to allow navigation to show future steps
     - if you have any conditional fields in the step, you should use `disableForwardJumping` in the step definition, to disable jumping forward in the navigation, otherwise user could miss the changed fields in next steps.
+- you can use `crossroads` to define, which fields the wizzard will listen to and change the navigation according to changes of the defined values 
 
 ![progressivewizard](https://user-images.githubusercontent.com/32869456/58427241-5b370a80-809f-11e9-8e79-a4a829b8d181.gif)
 


### PR DESCRIPTION
PF4 Wizard is now able to generate the schema in a realtime. It just needs to get a list of names, that can change next steps of the wizard.

Also, FormSpy is passed to all components as a FormSpyProvider.

TODO:
- [x] fix tests
- [x] add tests
- [x] control if FormSpyProvider do not do evil
- [x] add tests for wizard nav

![wizardmagic](https://user-images.githubusercontent.com/32869456/73001211-6135e480-3e02-11ea-89dd-950a25d63ec8.gif)

**docs**

**Crossroads**

With the help of `crossroads` you can manually defined which fields change next steps and together with `predictSteps`, it will cause that the wizard navigation is always refreshed, when one of the crossroads name is changed.

Ex.: `crossroads: ['name', 'nested.password']`

| Prop  | Type | Default |  Description |
| ------------- | ------------- | ------------- | ------------- |
|crossroads|array|undefined|Array of field names, which change next steps|