### PR TITLE
[V2] Use form api instead of formOptions

### DIFF
--- a/__mocks__/mock-form-template.js
+++ b/__mocks__/mock-form-template.js
@@ -1,6 +1,9 @@
 import React from 'react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const FormTemplate = ({ schema: { title, label, description }, formFields, formOptions, FormSpy }) => {
+const FormTemplate = ({ schema: { title, label, description }, formFields, FormSpy }) => {
+  const formOptions = useFormApi();
+
   return (
     <form onSubmit={ formOptions.handleSubmit }>
       { title || label && <h1>{ title || label }</h1> }

--- a/__mocks__/mock-form-template.js
+++ b/__mocks__/mock-form-template.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { useFormApi as useFormApiInternal } from '../packages/react-form-renderer/src';
+const path = require('path')
 
 const FormTemplate = ({ schema: { title, label, description }, formFields, FormSpy }) => {
-  const formOptions = useFormApi();
+  // When testing inside the renderer package, it cannot import things from itself!
+  const isInternal = path.dirname(module.parent.filename).includes('/react-form-renderer/');
+
+  const formOptions = isInternal ? useFormApiInternal() : useFormApi();
 
   return (
     <form onSubmit={ formOptions.handleSubmit }>

--- a/__mocks__/with-provider.js
+++ b/__mocks__/with-provider.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RendererContext } from "@data-driven-forms/react-form-renderer";
+
+const RenderWithProvider = ({value, children}) => <RendererContext.Provider
+    value={{
+        ...value
+    }}
+>
+    {children}
+</RendererContext.Provider>;
+
+export default RenderWithProvider

--- a/packages/common/src/form-template.js
+++ b/packages/common/src/form-template.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 export const isDisabled = (disableStates, getState) => disableStates.map((item) => getState()[item]).find((item) => !!item);
 
@@ -104,28 +105,32 @@ const formTemplate = ({
   showFormControls = true,
   disableSubmit = [],
   ...options
-}) => ({ schema: { title, description, label }, formFields, FormSpy, formOptions }) => (
-  <FormWrapper onSubmit={formOptions.handleSubmit} {...formWrapperProps}>
-    {(title || label) && <Title>{title || label}</Title>}
-    {description && <Description>{description}</Description>}
-    {formFields}
-    {showFormControls && (
-      <FormSpy>
-        {(formSpyProps) => (
-          <FormControls
-            Button={Button}
-            FormSpy={FormSpy}
-            ButtonGroup={ButtonGroup}
-            onReset={formOptions.onReset}
-            onCancel={formOptions.onCancel}
-            disableSubmit={isDisabled(disableSubmit, formOptions.getState)}
-            formSpyProps={formSpyProps}
-            {...options}
-          />
-        )}
-      </FormSpy>
-    )}
-  </FormWrapper>
-);
+}) => ({ schema: { title, description, label }, formFields, FormSpy }) => {
+  const { onReset, onCancel, getState, handleSubmit } = useFormApi();
+
+  return (
+    <FormWrapper onSubmit={handleSubmit} {...formWrapperProps}>
+      {(title || label) && <Title>{title || label}</Title>}
+      {description && <Description>{description}</Description>}
+      {formFields}
+      {showFormControls && (
+        <FormSpy>
+          {(formSpyProps) => (
+            <FormControls
+              Button={Button}
+              FormSpy={FormSpy}
+              ButtonGroup={ButtonGroup}
+              onReset={onReset}
+              onCancel={onCancel}
+              disableSubmit={isDisabled(disableSubmit, getState)}
+              formSpyProps={formSpyProps}
+              {...options}
+            />
+          )}
+        </FormSpy>
+      )}
+    </FormWrapper>
+  );
+};
 
 export default formTemplate;

--- a/packages/common/src/multiple-choice-list.js
+++ b/packages/common/src/multiple-choice-list.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { composeValidators } from '@data-driven-forms/react-form-renderer';
+import { composeValidators, useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { formGroup } from './prop-types-templates';
 
-const MultipleChoiceList = ({ validate, FieldProvider, Wrapper, Checkbox, ...props }) => (
+const MultipleChoiceList = ({ validate, FieldProvider, Wrapper, Checkbox, ...props }) => {
+  const formOptions = useFormApi();
+
+  return (
   <FieldProvider
     { ...props }
     validate={ composeValidators(props.validate || []) }
@@ -35,7 +38,7 @@ const MultipleChoiceList = ({ validate, FieldProvider, Wrapper, Checkbox, ...pro
         >
           { options.map(option =>
             (<FieldProvider
-              formOptions={ rest.formOptions }
+              formOptions={ formOptions }
               id={ `${rest.id}-${option.value}` }
               key={ option.value }
               { ...option }
@@ -60,7 +63,7 @@ const MultipleChoiceList = ({ validate, FieldProvider, Wrapper, Checkbox, ...pro
         </Wrapper>);
     } }
   />
-);
+)};
 
 MultipleChoiceList.propTypes = {
   validate: PropTypes.func,

--- a/packages/mui-component-mapper/src/components/sub-form.js
+++ b/packages/mui-component-mapper/src/components/sub-form.js
@@ -3,35 +3,31 @@ import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 
-const SubForm = ({
-  formOptions,
-  fields,
-  title,
-  description,
-  FieldProvider: _FieldProvider,
-  FormSpyProvider: _FormSpyProvider,
-  validate: _validate,
-  ...rest
-}) => (
-  <Grid item xs={12} container style={{ paddingRight: 0, paddingLeft: 0 }} {...rest}>
-    {title && (
-      <Grid item xs={12}>
-        <Typography variant="h5">{title}</Typography>
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+
+const SubForm = ({ fields, title, description, FieldProvider: _FieldProvider, FormSpyProvider: _FormSpyProvider, validate: _validate, ...rest }) => {
+  const { renderForm } = useFormApi();
+
+  return (
+    <Grid item xs={12} container style={{ paddingRight: 0, paddingLeft: 0 }} {...rest}>
+      {title && (
+        <Grid item xs={12}>
+          <Typography variant="h5">{title}</Typography>
+        </Grid>
+      )}
+      {description && (
+        <Grid item xs={12}>
+          <Typography paragraph>{description}</Typography>
+        </Grid>
+      )}
+      <Grid item xs={12} container>
+        {renderForm(fields)}
       </Grid>
-    )}
-    {description && (
-      <Grid item xs={12}>
-        <Typography paragraph>{description}</Typography>
-      </Grid>
-    )}
-    <Grid item xs={12} container>
-      {formOptions.renderForm(fields)}
     </Grid>
-  </Grid>
-);
+  );
+};
 
 SubForm.propTypes = {
-  formOptions: PropTypes.object.isRequired,
   fields: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   title: PropTypes.string,
   description: PropTypes.string,

--- a/packages/mui-component-mapper/src/components/tabs.js
+++ b/packages/mui-component-mapper/src/components/tabs.js
@@ -1,38 +1,32 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+
 const renderTabHeader = (items) => items.map(({ title, key, name }) => <Tab key={name} label={title} />);
 const renderTabContet = ({ name, fields }, formOptions) => <Fragment key={name}>{formOptions.renderForm(fields, formOptions)}</Fragment>;
 
-class FormTabs extends Component {
-  state = {
-    activeTab: 0
-  };
+const FormTabs = ({ fields }) => {
+  const formOptions = useFormApi();
+  const [activeTab, setActiveTab] = useState(0);
 
-  handleTabChange = (event, tabIndex) => this.setState({ activeTab: tabIndex });
-
-  render() {
-    const { fields, formOptions } = this.props;
-    const { activeTab } = this.state;
-    return (
-      <div>
-        <AppBar position="static">
-          <Tabs value={activeTab} onChange={this.handleTabChange}>
-            {renderTabHeader(fields)}
-          </Tabs>
-        </AppBar>
-        {renderTabContet(fields[activeTab], formOptions)}
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <AppBar position="static">
+        <Tabs value={activeTab} onChange={(_e, tabIndex) => setActiveTab(tabIndex)}>
+          {renderTabHeader(fields)}
+        </Tabs>
+      </AppBar>
+      {renderTabContet(fields[activeTab], formOptions)}
+    </div>
+  );
+};
 
 FormTabs.propTypes = {
-  fields: PropTypes.array.isRequired,
-  formOptions: PropTypes.object.isRequired
+  fields: PropTypes.array.isRequired
 };
 
 export default FormTabs;

--- a/packages/mui-component-mapper/src/tests/subform.test.js
+++ b/packages/mui-component-mapper/src/tests/subform.test.js
@@ -4,6 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 
 import Subform from '../components/sub-form';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('subform', () => {
   const props = {
@@ -18,17 +19,24 @@ describe('subform', () => {
         name: 'cosiName2',
         fields: []
       }
-    ],
-    formOptions: {
-      renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
-    }
+    ]
   };
 
   const TITLE = 'TIIIITLE';
   const DESCRIPTION = 'THIS IS DESCRIPTION';
 
   it('should render correctly', () => {
-    const wrapper = mount(<Subform {...props} />);
+    const wrapper = mount(
+      <RenderWithProvider
+        value={{
+          formOptions: {
+            renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
+          }
+        }}
+      >
+        <Subform {...props} />
+      </RenderWithProvider>
+    );
 
     expect(wrapper.find(Grid)).toHaveLength(2);
     expect(wrapper.find(Typography)).toHaveLength(0);
@@ -36,7 +44,17 @@ describe('subform', () => {
   });
 
   it('should render correctly with title', () => {
-    const wrapper = mount(<Subform {...props} title={TITLE} />);
+    const wrapper = mount(
+      <RenderWithProvider
+        value={{
+          formOptions: {
+            renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
+          }
+        }}
+      >
+        <Subform {...props} title={TITLE} />
+      </RenderWithProvider>
+    );
 
     expect(wrapper.find(Grid)).toHaveLength(3);
     expect(wrapper.find(Typography)).toHaveLength(1);
@@ -50,7 +68,17 @@ describe('subform', () => {
   });
 
   it('should render correctly with description', () => {
-    const wrapper = mount(<Subform {...props} description={DESCRIPTION} />);
+    const wrapper = mount(
+      <RenderWithProvider
+        value={{
+          formOptions: {
+            renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
+          }
+        }}
+      >
+        <Subform {...props} description={DESCRIPTION} />
+      </RenderWithProvider>
+    );
 
     expect(wrapper.find(Grid)).toHaveLength(3);
     expect(wrapper.find(Typography)).toHaveLength(1);
@@ -64,7 +92,17 @@ describe('subform', () => {
   });
 
   it('should render correctly with title and description', () => {
-    const wrapper = mount(<Subform {...props} title={TITLE} description={DESCRIPTION} />);
+    const wrapper = mount(
+      <RenderWithProvider
+        value={{
+          formOptions: {
+            renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
+          }
+        }}
+      >
+        <Subform {...props} title={TITLE} description={DESCRIPTION} />
+      </RenderWithProvider>
+    );
 
     expect(wrapper.find(Grid)).toHaveLength(4);
     expect(wrapper.find(Typography)).toHaveLength(2);

--- a/packages/mui-component-mapper/src/tests/tabs.test.js
+++ b/packages/mui-component-mapper/src/tests/tabs.test.js
@@ -5,6 +5,7 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 
 import FormTabs from '../components/tabs';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('tabs', () => {
   const props = {
@@ -19,14 +20,19 @@ describe('tabs', () => {
         name: 'cosiName2',
         fields: []
       }
-    ],
-    formOptions: {
-      renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
-    }
+    ]
+  };
+
+  const formOptions = {
+    renderForm: jest.fn().mockImplementation(() => <h1>Content</h1>)
   };
 
   it('should render tabs correctly', () => {
-    const wrapper = mount(<FormTabs {...props} />);
+    const wrapper = mount(
+      <RenderWithProvider value={{ formOptions }}>
+        <FormTabs {...props} />
+      </RenderWithProvider>
+    );
 
     expect(wrapper.find(AppBar)).toHaveLength(1);
     expect(wrapper.find(Tabs)).toHaveLength(1);
@@ -35,12 +41,39 @@ describe('tabs', () => {
   });
 
   it('should switch tabs correctly', () => {
-    const wrapper = mount(<FormTabs {...props} />);
-    expect(wrapper.instance().state.activeTab).toEqual(0);
+    const wrapper = mount(
+      <RenderWithProvider value={{ formOptions }}>
+        <FormTabs {...props} />
+      </RenderWithProvider>
+    );
+
+    expect(
+      wrapper
+      .find(Tab)
+      .first()
+      .props().selected
+    ).toEqual(true);
+    expect(
+      wrapper
+      .find(Tab)
+      .last()
+      .props().selected
+    ).toEqual(false);
 
     const secondTabButton = wrapper.find('button').last();
     secondTabButton.simulate('click');
+    wrapper.update();
 
-    expect(wrapper.instance().state.activeTab).toEqual(1);
-  });
+    expect(
+      wrapper
+      .find(Tab)
+      .first()
+      .props().selected
+    ).toEqual(false);
+    expect(
+      wrapper
+      .find(Tab)
+      .last()
+      .props().selected
+    ).toEqual(true);  });
 });

--- a/packages/pf3-component-mapper/src/components/sub-form.js
+++ b/packages/pf3-component-mapper/src/components/sub-form.js
@@ -1,34 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const SubForm = ({
-  formOptions,
-  fields,
-  title,
-  description,
-  FieldProvider: _FieldProvider,
-  FormSpyProvider: _FormSpyProvider,
-  validate: _validate,
-  ...rest
-}) => (
-  <div { ...rest }>
-    { title && <h3>{ title }</h3> }
-    { description && <p>{ description }</p> }
-    { formOptions.renderForm(fields, formOptions) }
-  </div>
-);
+const SubForm = ({ fields, title, description, FieldProvider: _FieldProvider, FormSpyProvider: _FormSpyProvider, validate: _validate, ...rest }) => {
+  const formOptions = useFormApi();
+  return (
+    <div {...rest}>
+      {title && <h3>{title}</h3>}
+      {description && <p>{description}</p>}
+      {formOptions.renderForm(fields, formOptions)}
+    </div>
+  );
+};
 
 SubForm.propTypes = {
-  formOptions: PropTypes.object.isRequired,
-  fields: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.array,
-  ]).isRequired,
+  fields: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   title: PropTypes.string,
   description: PropTypes.string,
   FieldProvider: PropTypes.any,
   FormSpyProvider: PropTypes.any,
-  validate: PropTypes.any,
+  validate: PropTypes.any
 };
 
 export default SubForm;

--- a/packages/pf3-component-mapper/src/components/tabs.js
+++ b/packages/pf3-component-mapper/src/components/tabs.js
@@ -2,37 +2,42 @@ import React from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import { TabContainer, Nav, NavItem, TabContent, TabPane, Icon } from 'patternfly-react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const renderTabHeader = (items, formOptions) => items.map(({ title, name, validateFields = []}, index) => {
-  const errors = formOptions.getState().errors;
-  const hasError = validateFields.find(name => !!get(errors, name));
-  return (
-    <NavItem key={ name } eventKey={ index }>
-      { hasError && <Icon style={{ marginRight: 8, color: '#CC0000' }} type="fa" name="exclamation-circle" /> }
-      { title }
-    </NavItem>
-  );
-});
+const renderTabHeader = (items, formOptions) =>
+  items.map(({ title, name, validateFields = []}, index) => {
+    const errors = formOptions.getState().errors;
+    const hasError = validateFields.find((name) => !!get(errors, name));
+    return (
+      <NavItem key={name} eventKey={index}>
+        {hasError && <Icon style={{ marginRight: 8, color: '#CC0000' }} type="fa" name="exclamation-circle" />}
+        {title}
+      </NavItem>
+    );
+  });
+
 const renderTabContent = (items, formOptions) =>
-  items.map(({ name, fields }, index) =>
-    <TabPane key={ name } eventKey={ index } >{ formOptions.renderForm(fields, formOptions) }</TabPane>);
+  items.map(({ name, fields }, index) => (
+    <TabPane key={name} eventKey={index}>
+      {formOptions.renderForm(fields, formOptions)}
+    </TabPane>
+  ));
 
-const FormTabs = ({ fields, formOptions }) => (
-  <TabContainer id="basic-tabs-pf" defaultActiveKey={ 0 }>
-    <div>
-      <Nav bsClass="nav nav-tabs">
-        { renderTabHeader(fields, formOptions) }
-      </Nav>
-      <TabContent animation>
-        { renderTabContent(fields, formOptions) }
-      </TabContent>
-    </div>
-  </TabContainer>
-);
+const FormTabs = ({ fields }) => {
+  const formOptions = useFormApi();
+
+  return (
+    <TabContainer id="basic-tabs-pf" defaultActiveKey={0}>
+      <div>
+        <Nav bsClass="nav nav-tabs">{renderTabHeader(fields, formOptions)}</Nav>
+        <TabContent animation>{renderTabContent(fields, formOptions)}</TabContent>
+      </div>
+    </TabContainer>
+  );
+};
 
 FormTabs.propTypes = {
-  fields: PropTypes.array.isRequired,
-  formOptions: PropTypes.object.isRequired,
+  fields: PropTypes.array.isRequired
 };
 
 export default FormTabs;

--- a/packages/pf3-component-mapper/src/components/wizard.js
+++ b/packages/pf3-component-mapper/src/components/wizard.js
@@ -24,16 +24,16 @@ const Wizard = ({ title, FieldProvider, buttonLabels, stepsInfo, fields, inModal
   };
 
   const handlePrev = () => {
-    const newSteps = prevSteps.slice(0, x.length - 1);
+    const newSteps = prevSteps.slice(0, Math.max(prevSteps.length - 1, 1));
 
-    setActiveStep(newSteps[newSteps.length]);
+    setActiveStep(newSteps[newSteps.length - 1]);
     setPrevSteps(newSteps);
   };
 
+  const findCurrentStep = (activeStep) => fields.find(({ stepKey }) => stepKey === activeStep);
+
   const findActiveFields = (visitedSteps) =>
-    visitedSteps
-      .map((key) => this.findCurrentStep(key).fields.map(({ name }) => name))
-      .reduce((acc, curr) => curr.concat(acc.map((item) => item)), []);
+    visitedSteps.map((key) => findCurrentStep(key).fields.map(({ name }) => name)).reduce((acc, curr) => curr.concat(acc.map((item) => item)), []);
 
   const getValues = (values, visitedSteps) =>
     Object.keys(values)
@@ -41,8 +41,6 @@ const Wizard = ({ title, FieldProvider, buttonLabels, stepsInfo, fields, inModal
       .reduce((acc, curr) => ({ ...acc, [curr]: values[curr] }), {});
 
   const handleSubmit = () => formOptions.onSubmit(getValues(formOptions.getState().values, [...prevSteps, activeStep]));
-
-  const findCurrentStep = (activeStep) => fields.find(({ stepKey }) => stepKey === activeStep);
 
   const renderSteps = () =>
     stepsInfo.map((step, stepIndex) => (
@@ -96,7 +94,7 @@ Wizard.propTypes = {
   buttonLabels: PropTypes.object,
   stepsInfo: PropTypes.array,
   inModal: PropTypes.bool,
-  fields: PropTypes.array(
+  fields: PropTypes.arrayOf(
     PropTypes.shape({
       stepKey: PropTypes.string
     })

--- a/packages/pf3-component-mapper/src/components/wizard/step-buttons.js
+++ b/packages/pf3-component-mapper/src/components/wizard/step-buttons.js
@@ -2,20 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../common/button';
 import { Icon, Wizard } from 'patternfly-react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const SimpleNext = ({
-  next,
-  valid,
-  handleNext,
-  submit,
-  buttonLabels,
-}) => (
-  <Button
-    bsStyle="primary"
-    type="button"
-    onClick={ () => valid ? handleNext(next) : submit() }
-  >
-    { buttonLabels.next }<Icon type="fa" name="angle-right" />
+const SimpleNext = ({ next, valid, handleNext, submit, buttonLabels }) => (
+  <Button bsStyle="primary" type="button" onClick={() => (valid ? handleNext(next) : submit())}>
+    {buttonLabels.next}
+    <Icon type="fa" name="angle-right" />
   </Button>
 );
 
@@ -24,74 +16,65 @@ SimpleNext.propTypes = {
   valid: PropTypes.bool,
   handleNext: PropTypes.func.isRequired,
   submit: PropTypes.func.isRequired,
-  buttonLabels: PropTypes.object.isRequired,
+  buttonLabels: PropTypes.object.isRequired
 };
 
-const ConditionalNext = ({
-  nextStep,
-  FieldProvider,
-  ...rest
-}) => (
-  <FieldProvider
-    name={ nextStep.when }
-    subscription={{ value: true }}
-  >
-    { ({ input: { value }}) => <SimpleNext next={ nextStep.stepMapper[value] } { ...rest } /> }
+const ConditionalNext = ({ nextStep, FieldProvider, ...rest }) => (
+  <FieldProvider name={nextStep.when} subscription={{ value: true }}>
+    {({ input: { value }}) => <SimpleNext next={nextStep.stepMapper[value]} {...rest} />}
   </FieldProvider>
 );
 
 ConditionalNext.propTypes = {
   nextStep: PropTypes.shape({
     when: PropTypes.string.isRequired,
-    stepMapper: PropTypes.object.isRequired,
+    stepMapper: PropTypes.object.isRequired
   }).isRequired,
-  FieldProvider: PropTypes.func.isRequired,
+  FieldProvider: PropTypes.func.isRequired
 };
 
-const submitButton = (handleSubmit, submitText) => <Button type="button" bsStyle="primary" onClick={ handleSubmit }>
-  { submitText }
-</Button>;
-
-const renderNextButton = ({ nextStep, handleSubmit, buttonLabels, ...rest }) =>
-  !nextStep
-    ? submitButton(handleSubmit, buttonLabels.submit)
-    : typeof nextStep === 'object'
-      ? <ConditionalNext nextStep={ nextStep } buttonLabels={ buttonLabels } { ...rest }/>
-      : <SimpleNext next={ nextStep } buttonLabels={ buttonLabels } { ...rest } />;
-
-const WizardStepButtons = ({ formOptions, disableBack, handlePrev, nextStep, FieldProvider, handleNext, buttonLabels }) => (
-  <Wizard.Footer>
-    { formOptions.onCancel && (
-      <Button
-        style={{ marginRight: 20 }}
-        type="button" variant="contained"
-        color="secondary" onClick={ formOptions.onCancel }>
-        { buttonLabels.cancel }
-      </Button>
-    ) }
-
-    <Button
-      type="button"
-      variant="contained"
-      disabled={ disableBack }
-      onClick={ handlePrev }>
-      <Icon type="fa" name="angle-left" />{ buttonLabels.back }
-    </Button>
-    { renderNextButton({
-      ...formOptions,
-      handleNext,
-      nextStep,
-      FieldProvider,
-      buttonLabels,
-    }) }
-  </Wizard.Footer>
+const submitButton = (handleSubmit, submitText) => (
+  <Button type="button" bsStyle="primary" onClick={handleSubmit}>
+    {submitText}
+  </Button>
 );
 
+const renderNextButton = ({ nextStep, handleSubmit, buttonLabels, ...rest }) =>
+  !nextStep ? (
+    submitButton(handleSubmit, buttonLabels.submit)
+  ) : typeof nextStep === 'object' ? (
+    <ConditionalNext nextStep={nextStep} buttonLabels={buttonLabels} {...rest} />
+  ) : (
+    <SimpleNext next={nextStep} buttonLabels={buttonLabels} {...rest} />
+  );
+
+const WizardStepButtons = ({ disableBack, handlePrev, nextStep, FieldProvider, handleNext, buttonLabels }) => {
+  const formOptions = useFormApi();
+
+  return (
+    <Wizard.Footer>
+      {formOptions.onCancel && (
+        <Button style={{ marginRight: 20 }} type="button" variant="contained" color="secondary" onClick={formOptions.onCancel}>
+          {buttonLabels.cancel}
+        </Button>
+      )}
+
+      <Button type="button" variant="contained" disabled={disableBack} onClick={handlePrev}>
+        <Icon type="fa" name="angle-left" />
+        {buttonLabels.back}
+      </Button>
+      {renderNextButton({
+        ...formOptions,
+        handleNext,
+        nextStep,
+        FieldProvider,
+        buttonLabels
+      })}
+    </Wizard.Footer>
+  );
+};
+
 WizardStepButtons.propTypes = {
-  formOptions: PropTypes.shape({
-    onCancel: PropTypes.func,
-    handleSubmit: PropTypes.func,
-  }),
   disableBack: PropTypes.bool,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
@@ -99,15 +82,15 @@ WizardStepButtons.propTypes = {
     PropTypes.string,
     PropTypes.shape({
       when: PropTypes.string.isRequired,
-      stepMapper: PropTypes.object.isRequired,
-    }),
+      stepMapper: PropTypes.object.isRequired
+    })
   ]),
   FieldProvider: PropTypes.func.isRequired,
-  buttonLabels: PropTypes.object.isRequired,
+  buttonLabels: PropTypes.object.isRequired
 };
 
 WizardStepButtons.defaultProps = {
-  formOptions: undefined,
+  formOptions: undefined
 };
 
 export default WizardStepButtons;

--- a/packages/pf3-component-mapper/src/components/wizard/step-buttons.js
+++ b/packages/pf3-component-mapper/src/components/wizard/step-buttons.js
@@ -48,31 +48,27 @@ const renderNextButton = ({ nextStep, handleSubmit, buttonLabels, ...rest }) =>
     <SimpleNext next={nextStep} buttonLabels={buttonLabels} {...rest} />
   );
 
-const WizardStepButtons = ({ disableBack, handlePrev, nextStep, FieldProvider, handleNext, buttonLabels }) => {
-  const formOptions = useFormApi();
-
-  return (
-    <Wizard.Footer>
-      {formOptions.onCancel && (
-        <Button style={{ marginRight: 20 }} type="button" variant="contained" color="secondary" onClick={formOptions.onCancel}>
-          {buttonLabels.cancel}
-        </Button>
-      )}
-
-      <Button type="button" variant="contained" disabled={disableBack} onClick={handlePrev}>
-        <Icon type="fa" name="angle-left" />
-        {buttonLabels.back}
+const WizardStepButtons = ({ disableBack, handlePrev, nextStep, FieldProvider, formOptions, handleNext, buttonLabels }) => (
+  <Wizard.Footer>
+    {formOptions.onCancel && (
+      <Button style={{ marginRight: 20 }} type="button" variant="contained" color="secondary" onClick={formOptions.onCancel}>
+        {buttonLabels.cancel}
       </Button>
-      {renderNextButton({
-        ...formOptions,
-        handleNext,
-        nextStep,
-        FieldProvider,
-        buttonLabels
-      })}
-    </Wizard.Footer>
-  );
-};
+    )}
+
+    <Button type="button" variant="contained" disabled={disableBack} onClick={handlePrev}>
+      <Icon type="fa" name="angle-left" />
+      {buttonLabels.back}
+    </Button>
+    {renderNextButton({
+      ...formOptions,
+      handleNext,
+      nextStep,
+      FieldProvider,
+      buttonLabels
+    })}
+  </Wizard.Footer>
+);
 
 WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
@@ -86,7 +82,10 @@ WizardStepButtons.propTypes = {
     })
   ]),
   FieldProvider: PropTypes.func.isRequired,
-  buttonLabels: PropTypes.object.isRequired
+  buttonLabels: PropTypes.object.isRequired,
+  formOptions: PropTypes.shape({
+    onCancel: PropTypes.func.isRequired
+  }).isRequired
 };
 
 WizardStepButtons.defaultProps = {

--- a/packages/pf3-component-mapper/src/components/wizard/wizard-step.js
+++ b/packages/pf3-component-mapper/src/components/wizard/wizard-step.js
@@ -2,27 +2,25 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import WizardStepButtons from './step-buttons';
 import { Wizard as PfWizard } from 'patternfly-react';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const WizardStep = ({ fields, ...rest }) => {
-  const formOptions = useFormApi();
-
-  return (
-    <Fragment>
-      <PfWizard.Body>
-        <PfWizard.Row>
-          <PfWizard.Main>
-            <div className="form-horizontal">{fields.map((item) => formOptions.renderForm([item], formOptions))}</div>
-          </PfWizard.Main>
-        </PfWizard.Row>
-      </PfWizard.Body>
-      <WizardStepButtons formOptions={formOptions} {...rest} />
-    </Fragment>
-  );
-};
+const WizardStep = ({ fields, formOptions, ...rest }) => (
+  <Fragment>
+    <PfWizard.Body>
+      <PfWizard.Row>
+        <PfWizard.Main>
+          <div className="form-horizontal">{fields.map((item) => formOptions.renderForm([item], formOptions))}</div>
+        </PfWizard.Main>
+      </PfWizard.Row>
+    </PfWizard.Body>
+    <WizardStepButtons formOptions={formOptions} {...rest} />
+  </Fragment>
+);
 
 WizardStep.propTypes = {
-  fields: PropTypes.array
+  fields: PropTypes.array,
+  formOptions: PropTypes.shape({
+    renderForm: PropTypes.func.isRequired
+  }).isRequired
 };
 
 WizardStep.defaultProps = {

--- a/packages/pf3-component-mapper/src/components/wizard/wizard-step.js
+++ b/packages/pf3-component-mapper/src/components/wizard/wizard-step.js
@@ -2,41 +2,31 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import WizardStepButtons from './step-buttons';
 import { Wizard as PfWizard } from 'patternfly-react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const WizardStep = ({
-  fields,
-  formOptions,
-  ...rest
-}) => {
+const WizardStep = ({ fields, ...rest }) => {
+  const formOptions = useFormApi();
+
   return (
     <Fragment>
       <PfWizard.Body>
         <PfWizard.Row>
           <PfWizard.Main>
-            <div className='form-horizontal'>
-              { fields.map(item => formOptions.renderForm([ item ], formOptions)) }
-            </div>
+            <div className="form-horizontal">{fields.map((item) => formOptions.renderForm([item], formOptions))}</div>
           </PfWizard.Main>
         </PfWizard.Row>
       </PfWizard.Body>
-      <WizardStepButtons
-        formOptions={ formOptions }
-        { ...rest }
-      />
+      <WizardStepButtons formOptions={formOptions} {...rest} />
     </Fragment>
   );
 };
 
 WizardStep.propTypes = {
-  fields: PropTypes.array,
-  formOptions: PropTypes.shape({
-    renderForm: PropTypes.func,
-  }),
+  fields: PropTypes.array
 };
 
 WizardStep.defaultProps = {
-  formOptions: undefined,
-  fields: [],
+  fields: []
 };
 
 export default WizardStep;

--- a/packages/pf3-component-mapper/src/form-fields/switch-field.js
+++ b/packages/pf3-component-mapper/src/form-fields/switch-field.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+
 import './switch-field.scss';
 import { computeTextWidth } from '../helpers/html-helper';
 
@@ -7,109 +9,97 @@ export const DIVIDER_SIZE = 34;
 export const COMBINED_MARGIN = 12;
 export const TEXT_PADDING = 1;
 
-export const computeLabelWidth = text => {
-  return computeTextWidth(text, [ 'pf3-switch' ]) + TEXT_PADDING;
+export const computeLabelWidth = (text) => {
+  return computeTextWidth(text, ['pf3-switch']) + TEXT_PADDING;
 };
 
 export const createLabelStyles = (labelWidth, isLeft = true) => {
   let width = COMBINED_MARGIN + labelWidth;
   let left = isLeft ? -width : DIVIDER_SIZE;
-  return ({
+  return {
     width,
-    left,
-  });
+    left
+  };
 };
 
 export const createTransform = (labelWidth, isChecked, isOffText = false) => {
   let dividerSize = isOffText ? DIVIDER_SIZE : 0;
   let width = COMBINED_MARGIN + labelWidth + dividerSize;
-  return isChecked ? {
-    WebkitTransform: `translateX(${width}px)`,
-    msTransform: `translateX(${width}px)`,
-    transform: `translateX(${width}px)`,
-  } : {};
+  return isChecked
+    ? {
+      WebkitTransform: `translateX(${width}px)`,
+      msTransform: `translateX(${width}px)`,
+      transform: `translateX(${width}px)`
+    }
+    : {};
 };
 
-class Switch extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      labelWidth: Math.max(computeLabelWidth(this.props.onText), computeLabelWidth(this.props.offText), DIVIDER_SIZE),
-    };
-  }
+const Switch = ({ onText, offText, disabled, isReadOnly, bsSize, ...props }) => {
+  const { handleSubmit } = useFormApi();
+  const [labelWidth, setLabelWidth] = useState(0);
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.offText !== this.props.offText || prevProps.onText !== this.props.onText){
-      this.setState({
-        labelWidth: Math.max(computeLabelWidth(this.props.onText), computeLabelWidth(this.props.offText), DIVIDER_SIZE),
-      });
-    }
-  }
+  useEffect(() => {
+    setLabelWidth(Math.max(computeLabelWidth(onText), computeLabelWidth(offText), DIVIDER_SIZE));
+  }, [onText, offText]);
 
-  render() {
-    const { onText, offText, disabled, isReadOnly, bsSize, formOptions, ...props } = this.props;
-    return (
-      <div>
-        <label
-          className={ `pf3-switch${disabled || isReadOnly ? ' disabled' : ''}${bsSize === 'mini' || bsSize === 'mn' ? ' mini' : ''}` }
-          style={{ width: this.state.labelWidth + DIVIDER_SIZE + COMBINED_MARGIN }}
-          tabIndex={ disabled || isReadOnly ? -1 : 0 }
-          onKeyDown={ (e) => {
-            const SPACEBAR_CODE = 32;
-            const ENTER_CODE = 13;
-            if (e.keyCode === SPACEBAR_CODE) {
-              e.preventDefault();
-              props.onChange({ target: { checked: !props.checked }});
-            } else if (e.keyCode === ENTER_CODE) {
-              e.preventDefault();
-              formOptions.handleSubmit();
-            }
-          } }
-        >
-          <input type="checkbox" { ...props } disabled={ disabled || isReadOnly } />
-          <span className={ `pf3-switch-slider${props.checked ? ' checked' : ''}` }>
-            <span
-              className="on-text"
-              style={{
-                ...createLabelStyles(this.state.labelWidth),
-                ...createTransform(this.state.labelWidth, props.checked),
-              }}
-            >
-              { onText }
-            </span>
-            <span className="divider" style={ createTransform(this.state.labelWidth, props.checked) }/>
-            <span
-              className="off-text"
-              style={{
-                ...createLabelStyles(this.state.labelWidth, false),
-                ...createTransform(this.state.labelWidth, props.checked, true),
-              }}
-            >
-              { offText }
-            </span>
+  return (
+    <div>
+      <label
+        className={`pf3-switch${disabled || isReadOnly ? ' disabled' : ''}${bsSize === 'mini' || bsSize === 'mn' ? ' mini' : ''}`}
+        style={{ width: labelWidth + DIVIDER_SIZE + COMBINED_MARGIN }}
+        tabIndex={disabled || isReadOnly ? -1 : 0}
+        onKeyDown={(e) => {
+          const SPACEBAR_CODE = 32;
+          const ENTER_CODE = 13;
+          if (e.keyCode === SPACEBAR_CODE) {
+            e.preventDefault();
+            props.onChange({ target: { checked: !props.checked }});
+          } else if (e.keyCode === ENTER_CODE) {
+            e.preventDefault();
+            handleSubmit();
+          }
+        }}
+      >
+        <input type="checkbox" {...props} disabled={disabled || isReadOnly} />
+        <span className={`pf3-switch-slider${props.checked ? ' checked' : ''}`}>
+          <span
+            className="on-text"
+            style={{
+              ...createLabelStyles(labelWidth),
+              ...createTransform(labelWidth, props.checked)
+            }}
+          >
+            {onText}
           </span>
-        </label>
-      </div>
-    );
-  }
-}
+          <span className="divider" style={createTransform(labelWidth, props.checked)} />
+          <span
+            className="off-text"
+            style={{
+              ...createLabelStyles(labelWidth, false),
+              ...createTransform(labelWidth, props.checked, true)
+            }}
+          >
+            {offText}
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+};
 
 Switch.propTypes = {
   onText: PropTypes.string,
   offText: PropTypes.string,
   disabled: PropTypes.bool,
   isReadOnly: PropTypes.bool,
-  checked: PropTypes.oneOfType([ PropTypes.bool, PropTypes.string ]),
+  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   onChange: PropTypes.func.isRequired,
-  bsSize: PropTypes.oneOf([ 'mn', 'mini' ]),
-  formOptions: PropTypes.shape({
-    handleSubmit: PropTypes.func.isRequired,
-  }).isRequired,
+  bsSize: PropTypes.oneOf(['mn', 'mini'])
 };
 
 Switch.defaultProps = {
   onText: 'ON',
-  offText: 'OFF',
+  offText: 'OFF'
 };
 
 export default Switch;

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
@@ -296,25 +296,17 @@ exports[`FormFields <Radio /> should render correctly 1`] = `
 `;
 
 exports[`FormFields <Switch /> should render Switch correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
-    }
-  }
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
 >
-  <FieldProvider
-    component={[Function]}
+  <Switch
+    FieldProvider={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -330,25 +322,26 @@ exports[`FormFields <Switch /> should render Switch correctly 1`] = `
       }
     }
   >
-    <div>
-      <MockFieldProvider
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-      >
-        <SwitchGroup
+      }
+    >
+      <div>
+        <MockFieldProvider
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -364,7 +357,15 @@ exports[`FormFields <Switch /> should render Switch correctly 1`] = `
             }
           }
         >
-          <FormGroup
+          <SwitchGroup
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
             meta={
               Object {
                 "error": false,
@@ -373,102 +374,102 @@ exports[`FormFields <Switch /> should render Switch correctly 1`] = `
             }
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  dataType="someDataType"
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <input
-                        dataType="someDataType"
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    dataType="someDataType"
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={0}
+                      >
+                        <input
+                          dataType="someDataType"
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render Switch with label correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
-    }
-  }
-  label="Label"
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
 >
-  <FieldProvider
-    component={[Function]}
+  <Switch
+    FieldProvider={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -485,26 +486,27 @@ exports[`FormFields <Switch /> should render Switch with label correctly 1`] = `
       }
     }
   >
-    <div>
-      <MockFieldProvider
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        label="Label"
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      label="Label"
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-      >
-        <SwitchGroup
+      }
+    >
+      <div>
+        <MockFieldProvider
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -521,7 +523,15 @@ exports[`FormFields <Switch /> should render Switch with label correctly 1`] = `
             }
           }
         >
-          <FormGroup
+          <SwitchGroup
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
             label="Label"
             meta={
               Object {
@@ -531,112 +541,113 @@ exports[`FormFields <Switch /> should render Switch with label correctly 1`] = `
             }
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              label="Label"
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <ControlLabel
-                  bsClass="control-label"
-                  srOnly={false}
+                <div
+                  className="form-group"
                 >
-                  <label
-                    className="control-label"
+                  <ControlLabel
+                    bsClass="control-label"
+                    srOnly={false}
                   >
-                    Label
-                  </label>
-                </ControlLabel>
-                <Switch
-                  dataType="someDataType"
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
-                >
-                  <div>
                     <label
-                      className="pf3-switch"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={0}
+                      className="control-label"
                     >
-                      <input
-                        dataType="someDataType"
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                      Label
+                    </label>
+                  </ControlLabel>
+                  <Switch
+                    dataType="someDataType"
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={0}
+                      >
+                        <input
+                          dataType="someDataType"
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render Switch with onText (custom prop) correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
-    }
-  }
-  onText="OnText"
 >
-  <FieldProvider
-    component={[Function]}
+  <Switch
+    FieldProvider={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -653,26 +664,27 @@ exports[`FormFields <Switch /> should render Switch with onText (custom prop) co
     }
     onText="OnText"
   >
-    <div>
-      <MockFieldProvider
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-        onText="OnText"
-      >
-        <SwitchGroup
+      }
+      onText="OnText"
+    >
+      <div>
+        <MockFieldProvider
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -689,111 +701,120 @@ exports[`FormFields <Switch /> should render Switch with onText (custom prop) co
           }
           onText="OnText"
         >
-          <FormGroup
+          <SwitchGroup
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
             meta={
               Object {
                 "error": false,
                 "touched": false,
               }
             }
+            onText="OnText"
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  dataType="someDataType"
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="OnText"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <input
-                        dataType="someDataType"
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    dataType="someDataType"
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="OnText"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          OnText
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={0}
+                      >
+                        <input
+                          dataType="someDataType"
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OnText
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render Switch with placeholder correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
-    }
-  }
-  placeholder="Placeholder"
 >
-  <FieldProvider
-    component={[Function]}
+  <Switch
+    FieldProvider={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -810,26 +831,27 @@ exports[`FormFields <Switch /> should render Switch with placeholder correctly 1
     }
     placeholder="Placeholder"
   >
-    <div>
-      <MockFieldProvider
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-        placeholder="Placeholder"
-      >
-        <SwitchGroup
+      }
+      placeholder="Placeholder"
+    >
+      <div>
+        <MockFieldProvider
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -846,111 +868,120 @@ exports[`FormFields <Switch /> should render Switch with placeholder correctly 1
           }
           placeholder="Placeholder"
         >
-          <FormGroup
+          <SwitchGroup
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
             meta={
               Object {
                 "error": false,
                 "touched": false,
               }
             }
+            placeholder="Placeholder"
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  dataType="someDataType"
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <input
-                        dataType="someDataType"
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    dataType="someDataType"
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={0}
+                      >
+                        <input
+                          dataType="someDataType"
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render disabled Switch correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
-    }
-  }
-  isDisabled={true}
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
 >
-  <FieldProvider
-    component={[Function]}
+  <Switch
+    FieldProvider={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -967,26 +998,27 @@ exports[`FormFields <Switch /> should render disabled Switch correctly 1`] = `
       }
     }
   >
-    <div>
-      <MockFieldProvider
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        isDisabled={true}
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      isDisabled={true}
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-      >
-        <SwitchGroup
+      }
+    >
+      <div>
+        <MockFieldProvider
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -1003,7 +1035,16 @@ exports[`FormFields <Switch /> should render disabled Switch correctly 1`] = `
             }
           }
         >
-          <FormGroup
+          <SwitchGroup
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
+            isDisabled={true}
             meta={
               Object {
                 "error": false,
@@ -1012,105 +1053,105 @@ exports[`FormFields <Switch /> should render disabled Switch correctly 1`] = `
             }
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  dataType="someDataType"
-                  disabled={true}
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch disabled"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={-1}
-                    >
-                      <input
-                        dataType="someDataType"
-                        disabled={true}
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    dataType="someDataType"
+                    disabled={true}
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch disabled"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={-1}
+                      >
+                        <input
+                          dataType="someDataType"
+                          disabled={true}
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render mini Switch correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  bsSize="mini"
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
-    }
-  }
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
 >
-  <FieldProvider
+  <Switch
+    FieldProvider={[Function]}
     bsSize="mini"
-    component={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -1126,27 +1167,28 @@ exports[`FormFields <Switch /> should render mini Switch correctly 1`] = `
       }
     }
   >
-    <div>
-      <MockFieldProvider
-        bsSize="mini"
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      bsSize="mini"
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-      >
-        <SwitchGroup
+      }
+    >
+      <div>
+        <MockFieldProvider
           bsSize="mini"
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -1162,7 +1204,16 @@ exports[`FormFields <Switch /> should render mini Switch correctly 1`] = `
             }
           }
         >
-          <FormGroup
+          <SwitchGroup
+            bsSize="mini"
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
             meta={
               Object {
                 "error": false,
@@ -1171,103 +1222,103 @@ exports[`FormFields <Switch /> should render mini Switch correctly 1`] = `
             }
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  bsSize="mini"
-                  dataType="someDataType"
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch mini"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <input
-                        dataType="someDataType"
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    bsSize="mini"
+                    dataType="someDataType"
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch mini"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={0}
+                      >
+                        <input
+                          dataType="someDataType"
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render readOnly Switch correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
-    }
-  }
-  isReadOnly={true}
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
 >
-  <FieldProvider
-    component={[Function]}
+  <Switch
+    FieldProvider={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -1284,26 +1335,27 @@ exports[`FormFields <Switch /> should render readOnly Switch correctly 1`] = `
       }
     }
   >
-    <div>
-      <MockFieldProvider
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        isReadOnly={true}
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      isReadOnly={true}
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-      >
-        <SwitchGroup
+      }
+    >
+      <div>
+        <MockFieldProvider
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -1320,7 +1372,16 @@ exports[`FormFields <Switch /> should render readOnly Switch correctly 1`] = `
             }
           }
         >
-          <FormGroup
+          <SwitchGroup
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
+            isReadOnly={true}
             meta={
               Object {
                 "error": false,
@@ -1329,105 +1390,105 @@ exports[`FormFields <Switch /> should render readOnly Switch correctly 1`] = `
             }
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  dataType="someDataType"
-                  id="someIdKey"
-                  isReadOnly={true}
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch disabled"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={-1}
-                    >
-                      <input
-                        dataType="someDataType"
-                        disabled={true}
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    dataType="someDataType"
+                    id="someIdKey"
+                    isReadOnly={true}
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch disabled"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={-1}
+                      >
+                        <input
+                          dataType="someDataType"
+                          disabled={true}
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <Switch /> should render sm Switch correctly 1`] = `
-<Switch
-  FieldProvider={[Function]}
-  bsSize="mn"
-  dataType="someDataType"
-  id="someIdKey"
-  input={
+<RenderWithProvider
+  value={
     Object {
-      "name": "Name of the field",
-      "value": "",
-    }
-  }
-  meta={
-    Object {
-      "error": false,
-      "touched": false,
+      "formOptions": Object {
+        "handleSubmit": [MockFunction],
+      },
     }
   }
 >
-  <FieldProvider
+  <Switch
+    FieldProvider={[Function]}
     bsSize="mn"
-    component={[Function]}
     dataType="someDataType"
     id="someIdKey"
     input={
@@ -1443,27 +1504,28 @@ exports[`FormFields <Switch /> should render sm Switch correctly 1`] = `
       }
     }
   >
-    <div>
-      <MockFieldProvider
-        bsSize="mn"
-        component={[Function]}
-        dataType="someDataType"
-        id="someIdKey"
-        input={
-          Object {
-            "name": "Foo",
-            "onChange": [MockFunction],
-          }
+    <FieldProvider
+      bsSize="mn"
+      component={[Function]}
+      dataType="someDataType"
+      id="someIdKey"
+      input={
+        Object {
+          "name": "Name of the field",
+          "value": "",
         }
-        meta={
-          Object {
-            "error": false,
-            "touched": false,
-          }
+      }
+      meta={
+        Object {
+          "error": false,
+          "touched": false,
         }
-      >
-        <SwitchGroup
+      }
+    >
+      <div>
+        <MockFieldProvider
           bsSize="mn"
+          component={[Function]}
           dataType="someDataType"
           id="someIdKey"
           input={
@@ -1479,7 +1541,16 @@ exports[`FormFields <Switch /> should render sm Switch correctly 1`] = `
             }
           }
         >
-          <FormGroup
+          <SwitchGroup
+            bsSize="mn"
+            dataType="someDataType"
+            id="someIdKey"
+            input={
+              Object {
+                "name": "Foo",
+                "onChange": [MockFunction],
+              }
+            }
             meta={
               Object {
                 "error": false,
@@ -1488,80 +1559,89 @@ exports[`FormFields <Switch /> should render sm Switch correctly 1`] = `
             }
           >
             <FormGroup
-              bsClass="form-group"
-              validationState={null}
+              meta={
+                Object {
+                  "error": false,
+                  "touched": false,
+                }
+              }
             >
-              <div
-                className="form-group"
+              <FormGroup
+                bsClass="form-group"
+                validationState={null}
               >
-                <Switch
-                  bsSize="mn"
-                  dataType="someDataType"
-                  id="someIdKey"
-                  name="Foo"
-                  offText="OFF"
-                  onChange={[Function]}
-                  onText="ON"
+                <div
+                  className="form-group"
                 >
-                  <div>
-                    <label
-                      className="pf3-switch mini"
-                      onKeyDown={[Function]}
-                      style={
-                        Object {
-                          "width": 80,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <input
-                        dataType="someDataType"
-                        id="someIdKey"
-                        name="Foo"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf3-switch-slider"
-                      >
-                        <span
-                          className="on-text"
-                          style={
-                            Object {
-                              "left": -46,
-                              "width": 46,
-                            }
+                  <Switch
+                    bsSize="mn"
+                    dataType="someDataType"
+                    id="someIdKey"
+                    name="Foo"
+                    offText="OFF"
+                    onChange={[Function]}
+                    onText="ON"
+                  >
+                    <div>
+                      <label
+                        className="pf3-switch mini"
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "width": 80,
                           }
-                        >
-                          ON
-                        </span>
-                        <span
-                          className="divider"
-                          style={Object {}}
+                        }
+                        tabIndex={0}
+                      >
+                        <input
+                          dataType="someDataType"
+                          id="someIdKey"
+                          name="Foo"
+                          onChange={[Function]}
+                          type="checkbox"
                         />
                         <span
-                          className="off-text"
-                          style={
-                            Object {
-                              "left": 34,
-                              "width": 46,
-                            }
-                          }
+                          className="pf3-switch-slider"
                         >
-                          OFF
+                          <span
+                            className="on-text"
+                            style={
+                              Object {
+                                "left": -46,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            ON
+                          </span>
+                          <span
+                            className="divider"
+                            style={Object {}}
+                          />
+                          <span
+                            className="off-text"
+                            style={
+                              Object {
+                                "left": 34,
+                                "width": 46,
+                              }
+                            }
+                          >
+                            OFF
+                          </span>
                         </span>
-                      </span>
-                    </label>
-                  </div>
-                </Switch>
-              </div>
+                      </label>
+                    </div>
+                  </Switch>
+                </div>
+              </FormGroup>
             </FormGroup>
-          </FormGroup>
-        </SwitchGroup>
-      </MockFieldProvider>
-    </div>
-  </FieldProvider>
-</Switch>
+          </SwitchGroup>
+        </MockFieldProvider>
+      </div>
+    </FieldProvider>
+  </Switch>
+</RenderWithProvider>
 `;
 
 exports[`FormFields <TextField /> should render correctly 1`] = `

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/sub-form.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/sub-form.test.js.snap
@@ -1,37 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SubForm /> should render sub form with description 1`] = `
-<div>
-  <p>
-    Bar
-  </p>
-  <div>
-    Form item
-  </div>
-</div>
+Array [
+  <SubForm
+    description="Bar"
+    fields={Array []}
+  />,
+  " ",
+]
 `;
 
 exports[`<SubForm /> should render sub form with title 1`] = `
-<div>
-  <h3>
-    Foo
-  </h3>
-  <div>
-    Form item
-  </div>
-</div>
+Array [
+  <SubForm
+    fields={Array []}
+    title="Foo"
+  />,
+  " ",
+]
 `;
 
 exports[`<SubForm /> should render sub form with title and description 1`] = `
-<div>
-  <h3>
-    Foo
-  </h3>
-  <p>
-    Bar
-  </p>
-  <div>
-    Form item
-  </div>
-</div>
+<SubForm
+  description="Bar"
+  fields={Array []}
+  title="Foo"
+/>
 `;

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
@@ -1,355 +1,354 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FormTabs /> should render form tabs 1`] = `
-<FormTabs
-  fields={
-    Array [
-      Object {
-        "component": "tabs",
-        "fields": Array [
-          Object {
-            "component": "foo",
-            "name": "foo",
-          },
-        ],
-        "name": "tab1",
-        "title": "Tab 1",
-      },
-      Object {
-        "component": "tabs",
-        "fields": Array [],
-        "name": "tab2",
-        "title": "Tab 2",
-      },
-    ]
-  }
-  formOptions={
+<RenderWithProvider
+  value={
     Object {
-      "getState": [Function],
-      "renderForm": [Function],
+      "formOptions": Object {
+        "getState": [Function],
+        "renderForm": [Function],
+      },
     }
   }
 >
-  <ForwardRef
-    defaultActiveKey={0}
-    id="basic-tabs-pf"
+  <FormTabs
+    fields={
+      Array [
+        Object {
+          "component": "tabs",
+          "fields": Array [
+            Object {
+              "component": "foo",
+              "name": "foo",
+            },
+          ],
+          "name": "tab1",
+          "title": "Tab 1",
+        },
+        Object {
+          "component": "tabs",
+          "fields": Array [],
+          "name": "tab2",
+          "title": "Tab 2",
+        },
+      ]
+    }
   >
-    <Uncontrolled(TabContainer)
+    <ForwardRef
       defaultActiveKey={0}
       id="basic-tabs-pf"
-      innerRef={null}
     >
-      <TabContainer
-        activeKey={0}
+      <Uncontrolled(TabContainer)
+        defaultActiveKey={0}
         id="basic-tabs-pf"
-        onSelect={[Function]}
+        innerRef={null}
       >
-        <div
+        <TabContainer
+          activeKey={0}
           id="basic-tabs-pf"
+          onSelect={[Function]}
         >
-          <Nav
-            bsClass="nav nav-tabs"
-            justified={false}
-            pullLeft={false}
-            pullRight={false}
-            stacked={false}
+          <div
+            id="basic-tabs-pf"
           >
-            <ul
-              className="nav nav-tabs"
-              role="tablist"
+            <Nav
+              bsClass="nav nav-tabs"
+              justified={false}
+              pullLeft={false}
+              pullRight={false}
+              stacked={false}
             >
-              <NavItem
-                active={true}
-                activeKey={0}
-                aria-controls="basic-tabs-pf-pane-0"
-                disabled={false}
-                eventKey={0}
-                id="basic-tabs-pf-tab-0"
-                key=".$tab1"
-                onKeyDown={[Function]}
-                onSelect={[Function]}
-                role="tab"
+              <ul
+                className="nav nav-tabs"
+                role="tablist"
               >
-                <li
-                  className="active"
-                  role="presentation"
+                <NavItem
+                  active={true}
+                  activeKey={0}
+                  aria-controls="basic-tabs-pf-pane-0"
+                  disabled={false}
+                  eventKey={0}
+                  id="basic-tabs-pf-tab-0"
+                  key=".$tab1"
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  role="tab"
                 >
-                  <SafeAnchor
-                    aria-controls="basic-tabs-pf-pane-0"
-                    aria-selected={true}
-                    componentClass="a"
-                    disabled={false}
-                    id="basic-tabs-pf-tab-0"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="tab"
+                  <li
+                    className="active"
+                    role="presentation"
                   >
-                    <a
+                    <SafeAnchor
                       aria-controls="basic-tabs-pf-pane-0"
                       aria-selected={true}
-                      href="#"
+                      componentClass="a"
+                      disabled={false}
                       id="basic-tabs-pf-tab-0"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="tab"
                     >
-                      Tab 1
-                    </a>
-                  </SafeAnchor>
-                </li>
-              </NavItem>
-              <NavItem
-                active={false}
-                activeKey={0}
-                aria-controls="basic-tabs-pf-pane-1"
-                disabled={false}
-                eventKey={1}
-                id="basic-tabs-pf-tab-1"
-                key=".$tab2"
-                onKeyDown={[Function]}
-                onSelect={[Function]}
-                role="tab"
-                tabIndex={-1}
-              >
-                <li
-                  className=""
-                  role="presentation"
+                      <a
+                        aria-controls="basic-tabs-pf-pane-0"
+                        aria-selected={true}
+                        href="#"
+                        id="basic-tabs-pf-tab-0"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="tab"
+                      >
+                        Tab 1
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </NavItem>
+                <NavItem
+                  active={false}
+                  activeKey={0}
+                  aria-controls="basic-tabs-pf-pane-1"
+                  disabled={false}
+                  eventKey={1}
+                  id="basic-tabs-pf-tab-1"
+                  key=".$tab2"
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  role="tab"
+                  tabIndex={-1}
                 >
-                  <SafeAnchor
-                    aria-controls="basic-tabs-pf-pane-1"
-                    aria-selected={false}
-                    componentClass="a"
-                    disabled={false}
-                    id="basic-tabs-pf-tab-1"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="tab"
-                    tabIndex={-1}
+                  <li
+                    className=""
+                    role="presentation"
                   >
-                    <a
+                    <SafeAnchor
                       aria-controls="basic-tabs-pf-pane-1"
                       aria-selected={false}
-                      href="#"
+                      componentClass="a"
+                      disabled={false}
                       id="basic-tabs-pf-tab-1"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="tab"
                       tabIndex={-1}
                     >
-                      Tab 2
-                    </a>
-                  </SafeAnchor>
-                </li>
-              </NavItem>
-            </ul>
-          </Nav>
-          <TabContent
-            animation={true}
-            bsClass="tab"
-            componentClass="div"
-            mountOnEnter={false}
-            unmountOnExit={false}
-          >
-            <div
-              className="tab-content"
+                      <a
+                        aria-controls="basic-tabs-pf-pane-1"
+                        aria-selected={false}
+                        href="#"
+                        id="basic-tabs-pf-tab-1"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="tab"
+                        tabIndex={-1}
+                      >
+                        Tab 2
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </NavItem>
+              </ul>
+            </Nav>
+            <TabContent
+              animation={true}
+              bsClass="tab"
+              componentClass="div"
+              mountOnEnter={false}
+              unmountOnExit={false}
             >
-              <TabPane
-                bsClass="tab-pane"
-                eventKey={0}
-                key="tab1"
+              <div
+                className="tab-content"
               >
-                <Fade
-                  appear={false}
-                  in={true}
-                  mountOnEnter={false}
-                  onEnter={[Function]}
-                  onExited={[Function]}
-                  timeout={300}
-                  unmountOnExit={false}
+                <TabPane
+                  bsClass="tab-pane"
+                  eventKey={0}
+                  key="tab1"
                 >
-                  <Transition
+                  <Fade
                     appear={false}
-                    enter={true}
-                    exit={true}
                     in={true}
                     mountOnEnter={false}
                     onEnter={[Function]}
-                    onEntered={[Function]}
-                    onEntering={[Function]}
-                    onExit={[Function]}
                     onExited={[Function]}
-                    onExiting={[Function]}
                     timeout={300}
                     unmountOnExit={false}
                   >
-                    <div
-                      aria-hidden={false}
-                      aria-labelledby="basic-tabs-pf-tab-0"
-                      className="fade tab-pane active in"
-                      id="basic-tabs-pf-pane-0"
-                      role="tabpanel"
+                    <Transition
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={false}
                     >
-                      <div />
-                    </div>
-                  </Transition>
-                </Fade>
-              </TabPane>
-              <TabPane
-                bsClass="tab-pane"
-                eventKey={1}
-                key="tab2"
-              >
-                <Fade
-                  appear={false}
-                  in={false}
-                  mountOnEnter={false}
-                  onEnter={[Function]}
-                  onExited={[Function]}
-                  timeout={300}
-                  unmountOnExit={false}
+                      <div
+                        aria-hidden={false}
+                        aria-labelledby="basic-tabs-pf-tab-0"
+                        className="fade tab-pane active in"
+                        id="basic-tabs-pf-pane-0"
+                        role="tabpanel"
+                      >
+                        <div />
+                      </div>
+                    </Transition>
+                  </Fade>
+                </TabPane>
+                <TabPane
+                  bsClass="tab-pane"
+                  eventKey={1}
+                  key="tab2"
                 >
-                  <Transition
+                  <Fade
                     appear={false}
-                    enter={true}
-                    exit={true}
                     in={false}
                     mountOnEnter={false}
                     onEnter={[Function]}
-                    onEntered={[Function]}
-                    onEntering={[Function]}
-                    onExit={[Function]}
                     onExited={[Function]}
-                    onExiting={[Function]}
                     timeout={300}
                     unmountOnExit={false}
                   >
-                    <div
-                      aria-hidden={true}
-                      aria-labelledby="basic-tabs-pf-tab-1"
-                      className="fade tab-pane"
-                      id="basic-tabs-pf-pane-1"
-                      role="tabpanel"
+                    <Transition
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={false}
+                      mountOnEnter={false}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={false}
                     >
-                      <div />
-                    </div>
-                  </Transition>
-                </Fade>
-              </TabPane>
-            </div>
-          </TabContent>
-        </div>
-      </TabContainer>
-    </Uncontrolled(TabContainer)>
-  </ForwardRef>
-</FormTabs>
+                      <div
+                        aria-hidden={true}
+                        aria-labelledby="basic-tabs-pf-tab-1"
+                        className="fade tab-pane"
+                        id="basic-tabs-pf-pane-1"
+                        role="tabpanel"
+                      >
+                        <div />
+                      </div>
+                    </Transition>
+                  </Fade>
+                </TabPane>
+              </div>
+            </TabContent>
+          </div>
+        </TabContainer>
+      </Uncontrolled(TabContainer)>
+    </ForwardRef>
+  </FormTabs>
+</RenderWithProvider>
 `;
 
 exports[`<FormTabs /> should render form tabs with error state 1`] = `
-<FormTabs
-  fields={
-    Array [
-      Object {
-        "component": "tabs",
-        "fields": Array [
-          Object {
-            "component": "foo",
-            "name": "foo",
-          },
-          Object {
-            "component": "foo",
-            "name": "nested.field",
-          },
-        ],
-        "name": "tab1",
-        "title": "Tab 1",
-        "validateFields": Array [
-          "foo",
-          "nested.field",
-        ],
-      },
-    ]
-  }
-  formOptions={
+<RenderWithProvider
+  value={
     Object {
-      "getState": [Function],
-      "renderForm": [Function],
+      "formOptions": Object {
+        "getState": [Function],
+        "renderForm": [Function],
+      },
     }
   }
 >
-  <ForwardRef
-    defaultActiveKey={0}
-    id="basic-tabs-pf"
+  <FormTabs
+    fields={
+      Array [
+        Object {
+          "component": "tabs",
+          "fields": Array [
+            Object {
+              "component": "foo",
+              "name": "foo",
+            },
+            Object {
+              "component": "foo",
+              "name": "nested.field",
+            },
+          ],
+          "name": "tab1",
+          "title": "Tab 1",
+          "validateFields": Array [
+            "foo",
+            "nested.field",
+          ],
+        },
+      ]
+    }
   >
-    <Uncontrolled(TabContainer)
+    <ForwardRef
       defaultActiveKey={0}
       id="basic-tabs-pf"
-      innerRef={null}
     >
-      <TabContainer
-        activeKey={0}
+      <Uncontrolled(TabContainer)
+        defaultActiveKey={0}
         id="basic-tabs-pf"
-        onSelect={[Function]}
+        innerRef={null}
       >
-        <div
+        <TabContainer
+          activeKey={0}
           id="basic-tabs-pf"
+          onSelect={[Function]}
         >
-          <Nav
-            bsClass="nav nav-tabs"
-            justified={false}
-            pullLeft={false}
-            pullRight={false}
-            stacked={false}
+          <div
+            id="basic-tabs-pf"
           >
-            <ul
-              className="nav nav-tabs"
-              role="tablist"
+            <Nav
+              bsClass="nav nav-tabs"
+              justified={false}
+              pullLeft={false}
+              pullRight={false}
+              stacked={false}
             >
-              <NavItem
-                active={true}
-                activeKey={0}
-                aria-controls="basic-tabs-pf-pane-0"
-                disabled={false}
-                eventKey={0}
-                id="basic-tabs-pf-tab-0"
-                key=".$tab1"
-                onKeyDown={[Function]}
-                onSelect={[Function]}
-                role="tab"
+              <ul
+                className="nav nav-tabs"
+                role="tablist"
               >
-                <li
-                  className="active"
-                  role="presentation"
+                <NavItem
+                  active={true}
+                  activeKey={0}
+                  aria-controls="basic-tabs-pf-pane-0"
+                  disabled={false}
+                  eventKey={0}
+                  id="basic-tabs-pf-tab-0"
+                  key=".$tab1"
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  role="tab"
                 >
-                  <SafeAnchor
-                    aria-controls="basic-tabs-pf-pane-0"
-                    aria-selected={true}
-                    componentClass="a"
-                    disabled={false}
-                    id="basic-tabs-pf-tab-0"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="tab"
+                  <li
+                    className="active"
+                    role="presentation"
                   >
-                    <a
+                    <SafeAnchor
                       aria-controls="basic-tabs-pf-pane-0"
                       aria-selected={true}
-                      href="#"
+                      componentClass="a"
+                      disabled={false}
                       id="basic-tabs-pf-tab-0"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="tab"
                     >
-                      <Icon
-                        name="exclamation-circle"
-                        style={
-                          Object {
-                            "color": "#CC0000",
-                            "marginRight": 8,
-                          }
-                        }
-                        type="fa"
+                      <a
+                        aria-controls="basic-tabs-pf-pane-0"
+                        aria-selected={true}
+                        href="#"
+                        id="basic-tabs-pf-tab-0"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="tab"
                       >
-                        <FontAwesome
+                        <Icon
                           name="exclamation-circle"
                           style={
                             Object {
@@ -357,82 +356,93 @@ exports[`<FormTabs /> should render form tabs with error state 1`] = `
                               "marginRight": 8,
                             }
                           }
+                          type="fa"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-exclamation-circle"
+                          <FontAwesome
+                            name="exclamation-circle"
                             style={
                               Object {
                                 "color": "#CC0000",
                                 "marginRight": 8,
                               }
                             }
-                          />
-                        </FontAwesome>
-                      </Icon>
-                      Tab 1
-                    </a>
-                  </SafeAnchor>
-                </li>
-              </NavItem>
-            </ul>
-          </Nav>
-          <TabContent
-            animation={true}
-            bsClass="tab"
-            componentClass="div"
-            mountOnEnter={false}
-            unmountOnExit={false}
-          >
-            <div
-              className="tab-content"
+                          >
+                            <span
+                              aria-hidden={true}
+                              className="fa fa-exclamation-circle"
+                              style={
+                                Object {
+                                  "color": "#CC0000",
+                                  "marginRight": 8,
+                                }
+                              }
+                            />
+                          </FontAwesome>
+                        </Icon>
+                        Tab 1
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </NavItem>
+              </ul>
+            </Nav>
+            <TabContent
+              animation={true}
+              bsClass="tab"
+              componentClass="div"
+              mountOnEnter={false}
+              unmountOnExit={false}
             >
-              <TabPane
-                bsClass="tab-pane"
-                eventKey={0}
-                key="tab1"
+              <div
+                className="tab-content"
               >
-                <Fade
-                  appear={false}
-                  in={true}
-                  mountOnEnter={false}
-                  onEnter={[Function]}
-                  onExited={[Function]}
-                  timeout={300}
-                  unmountOnExit={false}
+                <TabPane
+                  bsClass="tab-pane"
+                  eventKey={0}
+                  key="tab1"
                 >
-                  <Transition
+                  <Fade
                     appear={false}
-                    enter={true}
-                    exit={true}
                     in={true}
                     mountOnEnter={false}
                     onEnter={[Function]}
-                    onEntered={[Function]}
-                    onEntering={[Function]}
-                    onExit={[Function]}
                     onExited={[Function]}
-                    onExiting={[Function]}
                     timeout={300}
                     unmountOnExit={false}
                   >
-                    <div
-                      aria-hidden={false}
-                      aria-labelledby="basic-tabs-pf-tab-0"
-                      className="fade tab-pane active in"
-                      id="basic-tabs-pf-pane-0"
-                      role="tabpanel"
+                    <Transition
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={false}
                     >
-                      <div />
-                    </div>
-                  </Transition>
-                </Fade>
-              </TabPane>
-            </div>
-          </TabContent>
-        </div>
-      </TabContainer>
-    </Uncontrolled(TabContainer)>
-  </ForwardRef>
-</FormTabs>
+                      <div
+                        aria-hidden={false}
+                        aria-labelledby="basic-tabs-pf-tab-0"
+                        className="fade tab-pane active in"
+                        id="basic-tabs-pf-pane-0"
+                        role="tabpanel"
+                      >
+                        <div />
+                      </div>
+                    </Transition>
+                  </Fade>
+                </TabPane>
+              </div>
+            </TabContent>
+          </div>
+        </TabContainer>
+      </Uncontrolled(TabContainer)>
+    </ForwardRef>
+  </FormTabs>
+</RenderWithProvider>
 `;

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/wizard.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/wizard.test.js.snap
@@ -1,111 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Wizard /> should render Wizard correctly 1`] = `
-<Wizard
-  FieldProvider={[Function]}
-  buttonLabels={
+<RenderWithProvider
+  value={
     Object {
-      "back": "Back",
-      "cancel": "Cancel",
-      "next": "Next",
-      "submit": "Submit",
+      "formOptions": Object {
+        "getState": [Function],
+        "onCancel": [MockFunction],
+        "onSubmit": [MockFunction],
+        "submit": [Function],
+        "valid": true,
+      },
     }
   }
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "step-1",
-        "nextStep": "step-2",
-        "stepKey": 1,
-        "title": "Step 1",
-      },
-      Object {
-        "fields": Array [],
-        "name": "step-2",
-        "stepKey": "step-2",
-        "title": "Step 2",
-      },
-    ]
-  }
-  formOptions={
-    Object {
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "submit": [Function],
-      "valid": true,
-    }
-  }
-  inModal={false}
-  name="Wizard"
 >
-  <div
-    onKeyDown={[Function]}
+  <Wizard
+    FieldProvider={[Function]}
+    buttonLabels={
+      Object {
+        "back": "Back",
+        "cancel": "Cancel",
+        "next": "Next",
+        "submit": "Submit",
+      }
+    }
+    fields={
+      Array [
+        Object {
+          "fields": Array [],
+          "name": "step-1",
+          "nextStep": "step-2",
+          "stepKey": 1,
+          "title": "Step 1",
+        },
+        Object {
+          "fields": Array [],
+          "name": "step-2",
+          "stepKey": "step-2",
+          "title": "Step 2",
+        },
+      ]
+    }
+    inModal={false}
+    name="Wizard"
   >
-    <WizardStep
-      FieldProvider={[Function]}
-      buttonLabels={
-        Object {
-          "back": "Back",
-          "cancel": "Cancel",
-          "next": "Next",
-          "submit": "Submit",
-        }
-      }
-      disableBack={true}
-      fields={Array []}
-      formOptions={
-        Object {
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "onCancel": [MockFunction],
-          "onSubmit": [MockFunction],
-          "submit": [Function],
-          "valid": true,
-        }
-      }
-      handleNext={[Function]}
-      handlePrev={[Function]}
-      name="step-1"
-      nextStep="step-2"
-      stepKey={1}
-      title="Step 1"
+    <div
+      onKeyDown={[Function]}
     >
-      <WizardBody
-        className=""
-      >
-        <ModalBody
-          bsClass="modal-body"
-          className="wizard-pf-body clearfix"
-          componentClass="div"
-        >
-          <div
-            className="wizard-pf-body clearfix modal-body"
-          >
-            <WizardRow
-              className=""
-            >
-              <section
-                className="wizard-pf-row"
-              >
-                <WizardMain
-                  className=""
-                >
-                  <div
-                    className="wizard-pf-main"
-                  >
-                    <div
-                      className="form-horizontal"
-                    />
-                  </div>
-                </WizardMain>
-              </section>
-            </WizardRow>
-          </div>
-        </ModalBody>
-      </WizardBody>
-      <WizardStepButtons
+      <WizardStep
         FieldProvider={[Function]}
         buttonLabels={
           Object {
@@ -116,6 +58,7 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
           }
         }
         disableBack={true}
+        fields={Array []}
         formOptions={
           Object {
             "getState": [Function],
@@ -133,35 +76,80 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
         stepKey={1}
         title="Step 1"
       >
-        <WizardFooter
+        <WizardBody
           className=""
         >
-          <ModalFooter
-            bsClass="modal-footer"
-            className="wizard-pf-footer"
+          <ModalBody
+            bsClass="modal-body"
+            className="wizard-pf-body clearfix"
             componentClass="div"
           >
             <div
-              className="wizard-pf-footer modal-footer"
+              className="wizard-pf-body clearfix modal-body"
             >
-              <ButtonOverride
-                color="secondary"
-                onClick={[MockFunction]}
-                style={
-                  Object {
-                    "marginRight": 20,
-                  }
-                }
-                type="button"
-                variant="contained"
+              <WizardRow
+                className=""
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                <section
+                  className="wizard-pf-row"
+                >
+                  <WizardMain
+                    className=""
+                  >
+                    <div
+                      className="wizard-pf-main"
+                    >
+                      <div
+                        className="form-horizontal"
+                      />
+                    </div>
+                  </WizardMain>
+                </section>
+              </WizardRow>
+            </div>
+          </ModalBody>
+        </WizardBody>
+        <WizardStepButtons
+          FieldProvider={[Function]}
+          buttonLabels={
+            Object {
+              "back": "Back",
+              "cancel": "Cancel",
+              "next": "Next",
+              "submit": "Submit",
+            }
+          }
+          disableBack={true}
+          formOptions={
+            Object {
+              "getState": [Function],
+              "handleSubmit": [Function],
+              "onCancel": [MockFunction],
+              "onSubmit": [MockFunction],
+              "submit": [Function],
+              "valid": true,
+            }
+          }
+          handleNext={[Function]}
+          handlePrev={[Function]}
+          name="step-1"
+          nextStep="step-2"
+          stepKey={1}
+          title="Step 1"
+        >
+          <WizardFooter
+            className=""
+          >
+            <ModalFooter
+              bsClass="modal-footer"
+              className="wizard-pf-footer"
+              componentClass="div"
+            >
+              <div
+                className="wizard-pf-footer modal-footer"
+              >
+                <ButtonOverride
                   color="secondary"
-                  disabled={false}
                   onClick={[MockFunction]}
                   style={
                     Object {
@@ -171,8 +159,11 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     color="secondary"
                     disabled={false}
                     onClick={[MockFunction]}
@@ -184,33 +175,34 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                     type="button"
                     variant="contained"
                   >
-                    Cancel
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <ButtonOverride
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-                variant="contained"
-              >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                    <button
+                      className="btn btn-default"
+                      color="secondary"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                      style={
+                        Object {
+                          "marginRight": 20,
+                        }
+                      }
+                      type="button"
+                      variant="contained"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <ButtonOverride
                   disabled={true}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 3,
-                    }
-                  }
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     disabled={true}
                     onClick={[Function]}
                     style={
@@ -221,62 +213,63 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                     type="button"
                     variant="contained"
                   >
-                    <Icon
-                      name="angle-left"
-                      type="fa"
-                    >
-                      <FontAwesome
-                        name="angle-left"
-                      >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-angle-left"
-                        />
-                      </FontAwesome>
-                    </Icon>
-                    Back
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <SimpleNext
-                FieldProvider={[Function]}
-                buttonLabels={
-                  Object {
-                    "back": "Back",
-                    "cancel": "Cancel",
-                    "next": "Next",
-                    "submit": "Submit",
-                  }
-                }
-                getState={[Function]}
-                handleNext={[Function]}
-                next="step-2"
-                onCancel={[MockFunction]}
-                onSubmit={[MockFunction]}
-                submit={[Function]}
-                valid={true}
-              >
-                <ButtonOverride
-                  bsStyle="primary"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "marginLeft": 3,
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 3,
+                        }
                       }
+                      type="button"
+                      variant="contained"
+                    >
+                      <Icon
+                        name="angle-left"
+                        type="fa"
+                      >
+                        <FontAwesome
+                          name="angle-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="fa fa-angle-left"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                      Back
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <SimpleNext
+                  FieldProvider={[Function]}
+                  buttonLabels={
+                    Object {
+                      "back": "Back",
+                      "cancel": "Cancel",
+                      "next": "Next",
+                      "submit": "Submit",
                     }
+                  }
+                  getState={[Function]}
+                  handleNext={[Function]}
+                  next="step-2"
+                  onCancel={[MockFunction]}
+                  onSubmit={[MockFunction]}
+                  submit={[Function]}
+                  valid={true}
+                >
+                  <ButtonOverride
+                    bsStyle="primary"
+                    onClick={[Function]}
                     type="button"
                   >
-                    <button
-                      className="btn btn-primary"
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="primary"
                       disabled={false}
                       onClick={[Function]}
                       style={
@@ -286,151 +279,98 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                       }
                       type="button"
                     >
-                      Next
-                      <Icon
-                        name="angle-right"
-                        type="fa"
+                      <button
+                        className="btn btn-primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "marginLeft": 3,
+                          }
+                        }
+                        type="button"
                       >
-                        <FontAwesome
+                        Next
+                        <Icon
                           name="angle-right"
+                          type="fa"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-angle-right"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </button>
-                  </Button>
-                </ButtonOverride>
-              </SimpleNext>
-            </div>
-          </ModalFooter>
-        </WizardFooter>
-      </WizardStepButtons>
-    </WizardStep>
-  </div>
-</Wizard>
+                          <FontAwesome
+                            name="angle-right"
+                          >
+                            <span
+                              aria-hidden={true}
+                              className="fa fa-angle-right"
+                            />
+                          </FontAwesome>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </ButtonOverride>
+                </SimpleNext>
+              </div>
+            </ModalFooter>
+          </WizardFooter>
+        </WizardStepButtons>
+      </WizardStep>
+    </div>
+  </Wizard>
+</RenderWithProvider>
 `;
 
 exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = `
-<Wizard
-  FieldProvider={[Function]}
-  buttonLabels={
+<RenderWithProvider
+  value={
     Object {
-      "back": "Back",
-      "cancel": "Cancel",
-      "next": "Next",
-      "submit": "Submit",
+      "formOptions": Object {
+        "getState": [Function],
+        "onCancel": [MockFunction],
+        "onSubmit": [MockFunction],
+        "submit": [Function],
+        "valid": true,
+      },
     }
   }
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "step-1",
-        "nextStep": Object {
-          "stepMapper": Object {
-            "step": "step-2",
-          },
-          "when": "step",
-        },
-        "stepKey": 1,
-        "title": "Step 1",
-      },
-      Object {
-        "fields": Array [],
-        "name": "step-2",
-        "stepKey": "step-2",
-        "title": "Step 2",
-      },
-    ]
-  }
-  formOptions={
-    Object {
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "submit": [Function],
-      "valid": true,
-    }
-  }
-  inModal={false}
-  name="Wizard"
 >
-  <div
-    onKeyDown={[Function]}
-  >
-    <WizardStep
-      FieldProvider={[Function]}
-      buttonLabels={
-        Object {
-          "back": "Back",
-          "cancel": "Cancel",
-          "next": "Next",
-          "submit": "Submit",
-        }
+  <Wizard
+    FieldProvider={[Function]}
+    buttonLabels={
+      Object {
+        "back": "Back",
+        "cancel": "Cancel",
+        "next": "Next",
+        "submit": "Submit",
       }
-      disableBack={true}
-      fields={Array []}
-      formOptions={
+    }
+    fields={
+      Array [
         Object {
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "onCancel": [MockFunction],
-          "onSubmit": [MockFunction],
-          "submit": [Function],
-          "valid": true,
-        }
-      }
-      handleNext={[Function]}
-      handlePrev={[Function]}
-      name="step-1"
-      nextStep={
-        Object {
-          "stepMapper": Object {
-            "step": "step-2",
+          "fields": Array [],
+          "name": "step-1",
+          "nextStep": Object {
+            "stepMapper": Object {
+              "step": "step-2",
+            },
+            "when": "step",
           },
-          "when": "step",
-        }
-      }
-      stepKey={1}
-      title="Step 1"
+          "stepKey": 1,
+          "title": "Step 1",
+        },
+        Object {
+          "fields": Array [],
+          "name": "step-2",
+          "stepKey": "step-2",
+          "title": "Step 2",
+        },
+      ]
+    }
+    inModal={false}
+    name="Wizard"
+  >
+    <div
+      onKeyDown={[Function]}
     >
-      <WizardBody
-        className=""
-      >
-        <ModalBody
-          bsClass="modal-body"
-          className="wizard-pf-body clearfix"
-          componentClass="div"
-        >
-          <div
-            className="wizard-pf-body clearfix modal-body"
-          >
-            <WizardRow
-              className=""
-            >
-              <section
-                className="wizard-pf-row"
-              >
-                <WizardMain
-                  className=""
-                >
-                  <div
-                    className="wizard-pf-main"
-                  >
-                    <div
-                      className="form-horizontal"
-                    />
-                  </div>
-                </WizardMain>
-              </section>
-            </WizardRow>
-          </div>
-        </ModalBody>
-      </WizardBody>
-      <WizardStepButtons
+      <WizardStep
         FieldProvider={[Function]}
         buttonLabels={
           Object {
@@ -441,6 +381,7 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
           }
         }
         disableBack={true}
+        fields={Array []}
         formOptions={
           Object {
             "getState": [Function],
@@ -465,35 +406,87 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
         stepKey={1}
         title="Step 1"
       >
-        <WizardFooter
+        <WizardBody
           className=""
         >
-          <ModalFooter
-            bsClass="modal-footer"
-            className="wizard-pf-footer"
+          <ModalBody
+            bsClass="modal-body"
+            className="wizard-pf-body clearfix"
             componentClass="div"
           >
             <div
-              className="wizard-pf-footer modal-footer"
+              className="wizard-pf-body clearfix modal-body"
             >
-              <ButtonOverride
-                color="secondary"
-                onClick={[MockFunction]}
-                style={
-                  Object {
-                    "marginRight": 20,
-                  }
-                }
-                type="button"
-                variant="contained"
+              <WizardRow
+                className=""
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                <section
+                  className="wizard-pf-row"
+                >
+                  <WizardMain
+                    className=""
+                  >
+                    <div
+                      className="wizard-pf-main"
+                    >
+                      <div
+                        className="form-horizontal"
+                      />
+                    </div>
+                  </WizardMain>
+                </section>
+              </WizardRow>
+            </div>
+          </ModalBody>
+        </WizardBody>
+        <WizardStepButtons
+          FieldProvider={[Function]}
+          buttonLabels={
+            Object {
+              "back": "Back",
+              "cancel": "Cancel",
+              "next": "Next",
+              "submit": "Submit",
+            }
+          }
+          disableBack={true}
+          formOptions={
+            Object {
+              "getState": [Function],
+              "handleSubmit": [Function],
+              "onCancel": [MockFunction],
+              "onSubmit": [MockFunction],
+              "submit": [Function],
+              "valid": true,
+            }
+          }
+          handleNext={[Function]}
+          handlePrev={[Function]}
+          name="step-1"
+          nextStep={
+            Object {
+              "stepMapper": Object {
+                "step": "step-2",
+              },
+              "when": "step",
+            }
+          }
+          stepKey={1}
+          title="Step 1"
+        >
+          <WizardFooter
+            className=""
+          >
+            <ModalFooter
+              bsClass="modal-footer"
+              className="wizard-pf-footer"
+              componentClass="div"
+            >
+              <div
+                className="wizard-pf-footer modal-footer"
+              >
+                <ButtonOverride
                   color="secondary"
-                  disabled={false}
                   onClick={[MockFunction]}
                   style={
                     Object {
@@ -503,8 +496,11 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     color="secondary"
                     disabled={false}
                     onClick={[MockFunction]}
@@ -516,33 +512,34 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                     type="button"
                     variant="contained"
                   >
-                    Cancel
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <ButtonOverride
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-                variant="contained"
-              >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                    <button
+                      className="btn btn-default"
+                      color="secondary"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                      style={
+                        Object {
+                          "marginRight": 20,
+                        }
+                      }
+                      type="button"
+                      variant="contained"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <ButtonOverride
                   disabled={true}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 3,
-                    }
-                  }
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     disabled={true}
                     onClick={[Function]}
                     style={
@@ -553,93 +550,94 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                     type="button"
                     variant="contained"
                   >
-                    <Icon
-                      name="angle-left"
-                      type="fa"
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 3,
+                        }
+                      }
+                      type="button"
+                      variant="contained"
                     >
-                      <FontAwesome
+                      <Icon
                         name="angle-left"
+                        type="fa"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-angle-left"
-                        />
-                      </FontAwesome>
-                    </Icon>
-                    Back
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <ConditionalNext
-                FieldProvider={[Function]}
-                buttonLabels={
-                  Object {
-                    "back": "Back",
-                    "cancel": "Cancel",
-                    "next": "Next",
-                    "submit": "Submit",
-                  }
-                }
-                getState={[Function]}
-                handleNext={[Function]}
-                nextStep={
-                  Object {
-                    "stepMapper": Object {
-                      "step": "step-2",
-                    },
-                    "when": "step",
-                  }
-                }
-                onCancel={[MockFunction]}
-                onSubmit={[MockFunction]}
-                submit={[Function]}
-                valid={true}
-              >
-                <MockFieldProvider
-                  name="step"
-                  subscription={
+                        <FontAwesome
+                          name="angle-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="fa fa-angle-left"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                      Back
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <ConditionalNext
+                  FieldProvider={[Function]}
+                  buttonLabels={
                     Object {
-                      "value": true,
+                      "back": "Back",
+                      "cancel": "Cancel",
+                      "next": "Next",
+                      "submit": "Submit",
                     }
                   }
+                  getState={[Function]}
+                  handleNext={[Function]}
+                  nextStep={
+                    Object {
+                      "stepMapper": Object {
+                        "step": "step-2",
+                      },
+                      "when": "step",
+                    }
+                  }
+                  onCancel={[MockFunction]}
+                  onSubmit={[MockFunction]}
+                  submit={[Function]}
+                  valid={true}
                 >
-                  <SimpleNext
-                    buttonLabels={
+                  <MockFieldProvider
+                    name="step"
+                    subscription={
                       Object {
-                        "back": "Back",
-                        "cancel": "Cancel",
-                        "next": "Next",
-                        "submit": "Submit",
+                        "value": true,
                       }
                     }
-                    getState={[Function]}
-                    handleNext={[Function]}
-                    onCancel={[MockFunction]}
-                    onSubmit={[MockFunction]}
-                    submit={[Function]}
-                    valid={true}
                   >
-                    <ButtonOverride
-                      bsStyle="primary"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <Button
-                        active={false}
-                        block={false}
-                        bsClass="btn"
-                        bsStyle="primary"
-                        disabled={false}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "marginLeft": 3,
-                          }
+                    <SimpleNext
+                      buttonLabels={
+                        Object {
+                          "back": "Back",
+                          "cancel": "Cancel",
+                          "next": "Next",
+                          "submit": "Submit",
                         }
+                      }
+                      getState={[Function]}
+                      handleNext={[Function]}
+                      onCancel={[MockFunction]}
+                      onSubmit={[MockFunction]}
+                      submit={[Function]}
+                      valid={true}
+                    >
+                      <ButtonOverride
+                        bsStyle="primary"
+                        onClick={[Function]}
                         type="button"
                       >
-                        <button
-                          className="btn btn-primary"
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
+                          bsStyle="primary"
                           disabled={false}
                           onClick={[Function]}
                           style={
@@ -649,245 +647,199 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                           }
                           type="button"
                         >
-                          Next
-                          <Icon
-                            name="angle-right"
-                            type="fa"
+                          <button
+                            className="btn btn-primary"
+                            disabled={false}
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "marginLeft": 3,
+                              }
+                            }
+                            type="button"
                           >
-                            <FontAwesome
+                            Next
+                            <Icon
                               name="angle-right"
+                              type="fa"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="fa fa-angle-right"
-                              />
-                            </FontAwesome>
-                          </Icon>
-                        </button>
-                      </Button>
-                    </ButtonOverride>
-                  </SimpleNext>
-                </MockFieldProvider>
-              </ConditionalNext>
-            </div>
-          </ModalFooter>
-        </WizardFooter>
-      </WizardStepButtons>
-    </WizardStep>
-  </div>
-</Wizard>
+                              <FontAwesome
+                                name="angle-right"
+                              >
+                                <span
+                                  aria-hidden={true}
+                                  className="fa fa-angle-right"
+                                />
+                              </FontAwesome>
+                            </Icon>
+                          </button>
+                        </Button>
+                      </ButtonOverride>
+                    </SimpleNext>
+                  </MockFieldProvider>
+                </ConditionalNext>
+              </div>
+            </ModalFooter>
+          </WizardFooter>
+        </WizardStepButtons>
+      </WizardStep>
+    </div>
+  </Wizard>
+</RenderWithProvider>
 `;
 
 exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
-<Wizard
-  FieldProvider={[Function]}
-  buttonLabels={
+<RenderWithProvider
+  value={
     Object {
-      "back": "Back",
-      "cancel": "Cancel",
-      "next": "Next",
-      "submit": "Submit",
+      "formOptions": Object {
+        "getState": [Function],
+        "onCancel": [MockFunction],
+        "onSubmit": [MockFunction],
+        "submit": [Function],
+        "valid": true,
+      },
     }
-  }
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "step-1",
-        "nextStep": "step-2",
-        "stepKey": 1,
-        "title": "Step 1",
-      },
-      Object {
-        "fields": Array [],
-        "name": "step-2",
-        "stepKey": "step-2",
-        "title": "Step 2",
-      },
-    ]
-  }
-  formOptions={
-    Object {
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "submit": [Function],
-      "valid": true,
-    }
-  }
-  inModal={false}
-  name="Wizard"
-  stepsInfo={
-    Array [
-      Object {
-        "title": "step1",
-      },
-      Object {
-        "title": "step2",
-      },
-    ]
   }
 >
-  <div
-    onKeyDown={[Function]}
+  <Wizard
+    FieldProvider={[Function]}
+    buttonLabels={
+      Object {
+        "back": "Back",
+        "cancel": "Cancel",
+        "next": "Next",
+        "submit": "Submit",
+      }
+    }
+    fields={
+      Array [
+        Object {
+          "fields": Array [],
+          "name": "step-1",
+          "nextStep": "step-2",
+          "stepKey": 1,
+          "title": "Step 1",
+        },
+        Object {
+          "fields": Array [],
+          "name": "step-2",
+          "stepKey": "step-2",
+          "title": "Step 2",
+        },
+      ]
+    }
+    inModal={false}
+    name="Wizard"
+    stepsInfo={
+      Array [
+        Object {
+          "title": "step1",
+        },
+        Object {
+          "title": "step2",
+        },
+      ]
+    }
   >
-    <WizardSteps
-      className=""
-      steps={
-        Array [
-          <WizardStep
-            activeStep={1}
-            className=""
-            label="1"
-            onClick={[Function]}
-            step={1}
-            stepIndex={1}
-            title="step1"
-          />,
-          <WizardStep
-            activeStep={1}
-            className=""
-            label="2"
-            onClick={[Function]}
-            step={2}
-            stepIndex={2}
-            title="step2"
-          />,
-        ]
-      }
+    <div
+      onKeyDown={[Function]}
     >
-      <div
-        className="wizard-pf-steps"
-      >
-        <ul
-          className="wizard-pf-steps-indicator"
-        >
-          <WizardStep
-            activeStep={1}
-            className=""
-            key="1"
-            label="1"
-            onClick={[Function]}
-            step={1}
-            stepIndex={1}
-            title="step1"
-          >
-            <li
-              className="wizard-pf-step active"
-            >
-              <a
-                href="#"
-                onClick={[Function]}
-              >
-                <span
-                  className="wizard-pf-step-number"
-                >
-                  1
-                </span>
-                <span
-                  className="wizard-pf-step-title"
-                >
-                  step1
-                </span>
-              </a>
-            </li>
-          </WizardStep>
-          <WizardStep
-            activeStep={1}
-            className=""
-            key="2"
-            label="2"
-            onClick={[Function]}
-            step={2}
-            stepIndex={2}
-            title="step2"
-          >
-            <li
-              className="wizard-pf-step"
-            >
-              <a
-                href="#"
-                onClick={[Function]}
-              >
-                <span
-                  className="wizard-pf-step-number"
-                >
-                  2
-                </span>
-                <span
-                  className="wizard-pf-step-title"
-                >
-                  step2
-                </span>
-              </a>
-            </li>
-          </WizardStep>
-        </ul>
-      </div>
-    </WizardSteps>
-    <WizardStep
-      FieldProvider={[Function]}
-      buttonLabels={
-        Object {
-          "back": "Back",
-          "cancel": "Cancel",
-          "next": "Next",
-          "submit": "Submit",
-        }
-      }
-      disableBack={true}
-      fields={Array []}
-      formOptions={
-        Object {
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "onCancel": [MockFunction],
-          "onSubmit": [MockFunction],
-          "submit": [Function],
-          "valid": true,
-        }
-      }
-      handleNext={[Function]}
-      handlePrev={[Function]}
-      name="step-1"
-      nextStep="step-2"
-      stepKey={1}
-      title="Step 1"
-    >
-      <WizardBody
+      <WizardSteps
         className=""
-      >
-        <ModalBody
-          bsClass="modal-body"
-          className="wizard-pf-body clearfix"
-          componentClass="div"
-        >
-          <div
-            className="wizard-pf-body clearfix modal-body"
-          >
-            <WizardRow
+        steps={
+          Array [
+            <WizardStep
+              activeStep={1}
               className=""
+              label="1"
+              onClick={[Function]}
+              step={1}
+              stepIndex={1}
+              title="step1"
+            />,
+            <WizardStep
+              activeStep={1}
+              className=""
+              label="2"
+              onClick={[Function]}
+              step={2}
+              stepIndex={2}
+              title="step2"
+            />,
+          ]
+        }
+      >
+        <div
+          className="wizard-pf-steps"
+        >
+          <ul
+            className="wizard-pf-steps-indicator"
+          >
+            <WizardStep
+              activeStep={1}
+              className=""
+              key="1"
+              label="1"
+              onClick={[Function]}
+              step={1}
+              stepIndex={1}
+              title="step1"
             >
-              <section
-                className="wizard-pf-row"
+              <li
+                className="wizard-pf-step active"
               >
-                <WizardMain
-                  className=""
+                <a
+                  href="#"
+                  onClick={[Function]}
                 >
-                  <div
-                    className="wizard-pf-main"
+                  <span
+                    className="wizard-pf-step-number"
                   >
-                    <div
-                      className="form-horizontal"
-                    />
-                  </div>
-                </WizardMain>
-              </section>
-            </WizardRow>
-          </div>
-        </ModalBody>
-      </WizardBody>
-      <WizardStepButtons
+                    1
+                  </span>
+                  <span
+                    className="wizard-pf-step-title"
+                  >
+                    step1
+                  </span>
+                </a>
+              </li>
+            </WizardStep>
+            <WizardStep
+              activeStep={1}
+              className=""
+              key="2"
+              label="2"
+              onClick={[Function]}
+              step={2}
+              stepIndex={2}
+              title="step2"
+            >
+              <li
+                className="wizard-pf-step"
+              >
+                <a
+                  href="#"
+                  onClick={[Function]}
+                >
+                  <span
+                    className="wizard-pf-step-number"
+                  >
+                    2
+                  </span>
+                  <span
+                    className="wizard-pf-step-title"
+                  >
+                    step2
+                  </span>
+                </a>
+              </li>
+            </WizardStep>
+          </ul>
+        </div>
+      </WizardSteps>
+      <WizardStep
         FieldProvider={[Function]}
         buttonLabels={
           Object {
@@ -898,6 +850,7 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
           }
         }
         disableBack={true}
+        fields={Array []}
         formOptions={
           Object {
             "getState": [Function],
@@ -915,35 +868,80 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
         stepKey={1}
         title="Step 1"
       >
-        <WizardFooter
+        <WizardBody
           className=""
         >
-          <ModalFooter
-            bsClass="modal-footer"
-            className="wizard-pf-footer"
+          <ModalBody
+            bsClass="modal-body"
+            className="wizard-pf-body clearfix"
             componentClass="div"
           >
             <div
-              className="wizard-pf-footer modal-footer"
+              className="wizard-pf-body clearfix modal-body"
             >
-              <ButtonOverride
-                color="secondary"
-                onClick={[MockFunction]}
-                style={
-                  Object {
-                    "marginRight": 20,
-                  }
-                }
-                type="button"
-                variant="contained"
+              <WizardRow
+                className=""
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                <section
+                  className="wizard-pf-row"
+                >
+                  <WizardMain
+                    className=""
+                  >
+                    <div
+                      className="wizard-pf-main"
+                    >
+                      <div
+                        className="form-horizontal"
+                      />
+                    </div>
+                  </WizardMain>
+                </section>
+              </WizardRow>
+            </div>
+          </ModalBody>
+        </WizardBody>
+        <WizardStepButtons
+          FieldProvider={[Function]}
+          buttonLabels={
+            Object {
+              "back": "Back",
+              "cancel": "Cancel",
+              "next": "Next",
+              "submit": "Submit",
+            }
+          }
+          disableBack={true}
+          formOptions={
+            Object {
+              "getState": [Function],
+              "handleSubmit": [Function],
+              "onCancel": [MockFunction],
+              "onSubmit": [MockFunction],
+              "submit": [Function],
+              "valid": true,
+            }
+          }
+          handleNext={[Function]}
+          handlePrev={[Function]}
+          name="step-1"
+          nextStep="step-2"
+          stepKey={1}
+          title="Step 1"
+        >
+          <WizardFooter
+            className=""
+          >
+            <ModalFooter
+              bsClass="modal-footer"
+              className="wizard-pf-footer"
+              componentClass="div"
+            >
+              <div
+                className="wizard-pf-footer modal-footer"
+              >
+                <ButtonOverride
                   color="secondary"
-                  disabled={false}
                   onClick={[MockFunction]}
                   style={
                     Object {
@@ -953,8 +951,11 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     color="secondary"
                     disabled={false}
                     onClick={[MockFunction]}
@@ -966,33 +967,34 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                     type="button"
                     variant="contained"
                   >
-                    Cancel
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <ButtonOverride
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-                variant="contained"
-              >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                    <button
+                      className="btn btn-default"
+                      color="secondary"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                      style={
+                        Object {
+                          "marginRight": 20,
+                        }
+                      }
+                      type="button"
+                      variant="contained"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <ButtonOverride
                   disabled={true}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 3,
-                    }
-                  }
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     disabled={true}
                     onClick={[Function]}
                     style={
@@ -1003,62 +1005,63 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                     type="button"
                     variant="contained"
                   >
-                    <Icon
-                      name="angle-left"
-                      type="fa"
-                    >
-                      <FontAwesome
-                        name="angle-left"
-                      >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-angle-left"
-                        />
-                      </FontAwesome>
-                    </Icon>
-                    Back
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <SimpleNext
-                FieldProvider={[Function]}
-                buttonLabels={
-                  Object {
-                    "back": "Back",
-                    "cancel": "Cancel",
-                    "next": "Next",
-                    "submit": "Submit",
-                  }
-                }
-                getState={[Function]}
-                handleNext={[Function]}
-                next="step-2"
-                onCancel={[MockFunction]}
-                onSubmit={[MockFunction]}
-                submit={[Function]}
-                valid={true}
-              >
-                <ButtonOverride
-                  bsStyle="primary"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "marginLeft": 3,
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 3,
+                        }
                       }
+                      type="button"
+                      variant="contained"
+                    >
+                      <Icon
+                        name="angle-left"
+                        type="fa"
+                      >
+                        <FontAwesome
+                          name="angle-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="fa fa-angle-left"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                      Back
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <SimpleNext
+                  FieldProvider={[Function]}
+                  buttonLabels={
+                    Object {
+                      "back": "Back",
+                      "cancel": "Cancel",
+                      "next": "Next",
+                      "submit": "Submit",
                     }
+                  }
+                  getState={[Function]}
+                  handleNext={[Function]}
+                  next="step-2"
+                  onCancel={[MockFunction]}
+                  onSubmit={[MockFunction]}
+                  submit={[Function]}
+                  valid={true}
+                >
+                  <ButtonOverride
+                    bsStyle="primary"
+                    onClick={[Function]}
                     type="button"
                   >
-                    <button
-                      className="btn btn-primary"
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="primary"
                       disabled={false}
                       onClick={[Function]}
                       style={
@@ -1068,160 +1071,114 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                       }
                       type="button"
                     >
-                      Next
-                      <Icon
-                        name="angle-right"
-                        type="fa"
+                      <button
+                        className="btn btn-primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "marginLeft": 3,
+                          }
+                        }
+                        type="button"
                       >
-                        <FontAwesome
+                        Next
+                        <Icon
                           name="angle-right"
+                          type="fa"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-angle-right"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </button>
-                  </Button>
-                </ButtonOverride>
-              </SimpleNext>
-            </div>
-          </ModalFooter>
-        </WizardFooter>
-      </WizardStepButtons>
-    </WizardStep>
-  </div>
-</Wizard>
+                          <FontAwesome
+                            name="angle-right"
+                          >
+                            <span
+                              aria-hidden={true}
+                              className="fa fa-angle-right"
+                            />
+                          </FontAwesome>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </ButtonOverride>
+                </SimpleNext>
+              </div>
+            </ModalFooter>
+          </WizardFooter>
+        </WizardStepButtons>
+      </WizardStep>
+    </div>
+  </Wizard>
+</RenderWithProvider>
 `;
 
 exports[`<Wizard /> should render Wizard with title correctly 1`] = `
-<Wizard
-  FieldProvider={[Function]}
-  buttonLabels={
+<RenderWithProvider
+  value={
     Object {
-      "back": "Back",
-      "cancel": "Cancel",
-      "next": "Next",
-      "submit": "Submit",
+      "formOptions": Object {
+        "getState": [Function],
+        "onCancel": [MockFunction],
+        "onSubmit": [MockFunction],
+        "submit": [Function],
+        "valid": true,
+      },
     }
   }
-  fields={
-    Array [
-      Object {
-        "fields": Array [],
-        "name": "step-1",
-        "nextStep": "step-2",
-        "stepKey": 1,
-        "title": "Step 1",
-      },
-      Object {
-        "fields": Array [],
-        "name": "step-2",
-        "stepKey": "step-2",
-        "title": "Step 2",
-      },
-    ]
-  }
-  formOptions={
-    Object {
-      "getState": [Function],
-      "onCancel": [MockFunction],
-      "onSubmit": [MockFunction],
-      "submit": [Function],
-      "valid": true,
-    }
-  }
-  inModal={false}
-  name="Wizard"
-  title="Wizard title"
 >
-  <div
-    onKeyDown={[Function]}
+  <Wizard
+    FieldProvider={[Function]}
+    buttonLabels={
+      Object {
+        "back": "Back",
+        "cancel": "Cancel",
+        "next": "Next",
+        "submit": "Submit",
+      }
+    }
+    fields={
+      Array [
+        Object {
+          "fields": Array [],
+          "name": "step-1",
+          "nextStep": "step-2",
+          "stepKey": 1,
+          "title": "Step 1",
+        },
+        Object {
+          "fields": Array [],
+          "name": "step-2",
+          "stepKey": "step-2",
+          "title": "Step 2",
+        },
+      ]
+    }
+    inModal={false}
+    name="Wizard"
+    title="Wizard title"
   >
-    <ModalHeader
-      bsClass="modal-header"
-      closeButton={false}
-      closeLabel="Close"
+    <div
+      onKeyDown={[Function]}
     >
-      <div
-        className="modal-header"
+      <ModalHeader
+        bsClass="modal-header"
+        closeButton={false}
+        closeLabel="Close"
       >
-        <ModalTitle
-          bsClass="modal-title"
-          componentClass="h4"
+        <div
+          className="modal-header"
         >
-          <h4
-            className="modal-title"
+          <ModalTitle
+            bsClass="modal-title"
+            componentClass="h4"
           >
-            Wizard title
-          </h4>
-        </ModalTitle>
-      </div>
-    </ModalHeader>
-    <WizardStep
-      FieldProvider={[Function]}
-      buttonLabels={
-        Object {
-          "back": "Back",
-          "cancel": "Cancel",
-          "next": "Next",
-          "submit": "Submit",
-        }
-      }
-      disableBack={true}
-      fields={Array []}
-      formOptions={
-        Object {
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "onCancel": [MockFunction],
-          "onSubmit": [MockFunction],
-          "submit": [Function],
-          "valid": true,
-        }
-      }
-      handleNext={[Function]}
-      handlePrev={[Function]}
-      name="step-1"
-      nextStep="step-2"
-      stepKey={1}
-      title="Step 1"
-    >
-      <WizardBody
-        className=""
-      >
-        <ModalBody
-          bsClass="modal-body"
-          className="wizard-pf-body clearfix"
-          componentClass="div"
-        >
-          <div
-            className="wizard-pf-body clearfix modal-body"
-          >
-            <WizardRow
-              className=""
+            <h4
+              className="modal-title"
             >
-              <section
-                className="wizard-pf-row"
-              >
-                <WizardMain
-                  className=""
-                >
-                  <div
-                    className="wizard-pf-main"
-                  >
-                    <div
-                      className="form-horizontal"
-                    />
-                  </div>
-                </WizardMain>
-              </section>
-            </WizardRow>
-          </div>
-        </ModalBody>
-      </WizardBody>
-      <WizardStepButtons
+              Wizard title
+            </h4>
+          </ModalTitle>
+        </div>
+      </ModalHeader>
+      <WizardStep
         FieldProvider={[Function]}
         buttonLabels={
           Object {
@@ -1232,6 +1189,7 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
           }
         }
         disableBack={true}
+        fields={Array []}
         formOptions={
           Object {
             "getState": [Function],
@@ -1249,35 +1207,80 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
         stepKey={1}
         title="Step 1"
       >
-        <WizardFooter
+        <WizardBody
           className=""
         >
-          <ModalFooter
-            bsClass="modal-footer"
-            className="wizard-pf-footer"
+          <ModalBody
+            bsClass="modal-body"
+            className="wizard-pf-body clearfix"
             componentClass="div"
           >
             <div
-              className="wizard-pf-footer modal-footer"
+              className="wizard-pf-body clearfix modal-body"
             >
-              <ButtonOverride
-                color="secondary"
-                onClick={[MockFunction]}
-                style={
-                  Object {
-                    "marginRight": 20,
-                  }
-                }
-                type="button"
-                variant="contained"
+              <WizardRow
+                className=""
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                <section
+                  className="wizard-pf-row"
+                >
+                  <WizardMain
+                    className=""
+                  >
+                    <div
+                      className="wizard-pf-main"
+                    >
+                      <div
+                        className="form-horizontal"
+                      />
+                    </div>
+                  </WizardMain>
+                </section>
+              </WizardRow>
+            </div>
+          </ModalBody>
+        </WizardBody>
+        <WizardStepButtons
+          FieldProvider={[Function]}
+          buttonLabels={
+            Object {
+              "back": "Back",
+              "cancel": "Cancel",
+              "next": "Next",
+              "submit": "Submit",
+            }
+          }
+          disableBack={true}
+          formOptions={
+            Object {
+              "getState": [Function],
+              "handleSubmit": [Function],
+              "onCancel": [MockFunction],
+              "onSubmit": [MockFunction],
+              "submit": [Function],
+              "valid": true,
+            }
+          }
+          handleNext={[Function]}
+          handlePrev={[Function]}
+          name="step-1"
+          nextStep="step-2"
+          stepKey={1}
+          title="Step 1"
+        >
+          <WizardFooter
+            className=""
+          >
+            <ModalFooter
+              bsClass="modal-footer"
+              className="wizard-pf-footer"
+              componentClass="div"
+            >
+              <div
+                className="wizard-pf-footer modal-footer"
+              >
+                <ButtonOverride
                   color="secondary"
-                  disabled={false}
                   onClick={[MockFunction]}
                   style={
                     Object {
@@ -1287,8 +1290,11 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     color="secondary"
                     disabled={false}
                     onClick={[MockFunction]}
@@ -1300,33 +1306,34 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                     type="button"
                     variant="contained"
                   >
-                    Cancel
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <ButtonOverride
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-                variant="contained"
-              >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
+                    <button
+                      className="btn btn-default"
+                      color="secondary"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                      style={
+                        Object {
+                          "marginRight": 20,
+                        }
+                      }
+                      type="button"
+                      variant="contained"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <ButtonOverride
                   disabled={true}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "marginLeft": 3,
-                    }
-                  }
                   type="button"
                   variant="contained"
                 >
-                  <button
-                    className="btn btn-default"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
                     disabled={true}
                     onClick={[Function]}
                     style={
@@ -1337,62 +1344,63 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                     type="button"
                     variant="contained"
                   >
-                    <Icon
-                      name="angle-left"
-                      type="fa"
-                    >
-                      <FontAwesome
-                        name="angle-left"
-                      >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-angle-left"
-                        />
-                      </FontAwesome>
-                    </Icon>
-                    Back
-                  </button>
-                </Button>
-              </ButtonOverride>
-              <SimpleNext
-                FieldProvider={[Function]}
-                buttonLabels={
-                  Object {
-                    "back": "Back",
-                    "cancel": "Cancel",
-                    "next": "Next",
-                    "submit": "Submit",
-                  }
-                }
-                getState={[Function]}
-                handleNext={[Function]}
-                next="step-2"
-                onCancel={[MockFunction]}
-                onSubmit={[MockFunction]}
-                submit={[Function]}
-                valid={true}
-              >
-                <ButtonOverride
-                  bsStyle="primary"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "marginLeft": 3,
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 3,
+                        }
                       }
+                      type="button"
+                      variant="contained"
+                    >
+                      <Icon
+                        name="angle-left"
+                        type="fa"
+                      >
+                        <FontAwesome
+                          name="angle-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            className="fa fa-angle-left"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                      Back
+                    </button>
+                  </Button>
+                </ButtonOverride>
+                <SimpleNext
+                  FieldProvider={[Function]}
+                  buttonLabels={
+                    Object {
+                      "back": "Back",
+                      "cancel": "Cancel",
+                      "next": "Next",
+                      "submit": "Submit",
                     }
+                  }
+                  getState={[Function]}
+                  handleNext={[Function]}
+                  next="step-2"
+                  onCancel={[MockFunction]}
+                  onSubmit={[MockFunction]}
+                  submit={[Function]}
+                  valid={true}
+                >
+                  <ButtonOverride
+                    bsStyle="primary"
+                    onClick={[Function]}
                     type="button"
                   >
-                    <button
-                      className="btn btn-primary"
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="primary"
                       disabled={false}
                       onClick={[Function]}
                       style={
@@ -1402,29 +1410,41 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                       }
                       type="button"
                     >
-                      Next
-                      <Icon
-                        name="angle-right"
-                        type="fa"
+                      <button
+                        className="btn btn-primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "marginLeft": 3,
+                          }
+                        }
+                        type="button"
                       >
-                        <FontAwesome
+                        Next
+                        <Icon
                           name="angle-right"
+                          type="fa"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-angle-right"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </button>
-                  </Button>
-                </ButtonOverride>
-              </SimpleNext>
-            </div>
-          </ModalFooter>
-        </WizardFooter>
-      </WizardStepButtons>
-    </WizardStep>
-  </div>
-</Wizard>
+                          <FontAwesome
+                            name="angle-right"
+                          >
+                            <span
+                              aria-hidden={true}
+                              className="fa fa-angle-right"
+                            />
+                          </FontAwesome>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </ButtonOverride>
+                </SimpleNext>
+              </div>
+            </ModalFooter>
+          </WizardFooter>
+        </WizardStepButtons>
+      </WizardStep>
+    </div>
+  </Wizard>
+</RenderWithProvider>
 `;

--- a/packages/pf3-component-mapper/src/tests/form-fields.test.js
+++ b/packages/pf3-component-mapper/src/tests/form-fields.test.js
@@ -9,14 +9,21 @@ import Switch from '../components/switch';
 import Checkbox from '../components/checkbox';
 import Radio from '../components/radio';
 import Textarea from '../components/textarea';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('FormFields', () => {
   describe('<Switch />', () => {
     let FieldProvider;
     let onChangeSpy;
     let props;
+    let formOptions;
+
     beforeEach(() => {
       onChangeSpy = jest.fn();
+
+      formOptions = {
+        handleSubmit: jest.fn()
+      };
 
       FieldProvider = (props) => (
         <div>
@@ -39,47 +46,83 @@ describe('FormFields', () => {
     });
 
     it('should render Switch correctly', () => {
-      const wrapper = mount(<Switch {...props} />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render mini Switch correctly', () => {
-      const wrapper = mount(<Switch {...props} bsSize="mini" />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} bsSize="mini" />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render sm Switch correctly', () => {
-      const wrapper = mount(<Switch {...props} bsSize="mn" />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} bsSize="mn" />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render Switch with label correctly', () => {
-      const wrapper = mount(<Switch {...props} label={'Label'} />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} label={'Label'} />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render Switch with placeholder correctly', () => {
-      const wrapper = mount(<Switch {...props} placeholder={'Placeholder'} />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} placeholder={'Placeholder'} />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render Switch with onText (custom prop) correctly', () => {
-      const wrapper = mount(<Switch {...props} onText={'OnText'} />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} onText={'OnText'} />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render disabled Switch correctly', () => {
-      const wrapper = mount(<Switch {...props} isDisabled />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} isDisabled />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render readOnly Switch correctly', () => {
-      const wrapper = mount(<Switch {...props} isReadOnly />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} isReadOnly />
+        </RenderWithProvider>
+      );
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should call onChange method', () => {
-      const wrapper = mount(<Switch {...props} name="Foo" FieldProvider={FieldProvider} />);
+      const wrapper = mount(
+        <RenderWithProvider value={{ formOptions }}>
+          <Switch {...props} name="Foo" FieldProvider={FieldProvider} />
+        </RenderWithProvider>
+      );
       wrapper.find('input').simulate('change');
       expect(onChangeSpy).toHaveBeenCalled();
     });

--- a/packages/pf3-component-mapper/src/tests/sub-form.test.js
+++ b/packages/pf3-component-mapper/src/tests/sub-form.test.js
@@ -2,31 +2,45 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import SubForm from '../components/sub-form';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('<SubForm />', () => {
   let initialProps;
+  let formOptions;
 
   beforeEach(() => {
+    formOptions = {
+      renderForm: ({ name }) => <div key={name}>Form item</div>
+    };
     initialProps = {
-      formOptions: {
-        renderForm: ({ name }) => <div key={ name }>Form item</div>,
-      },
-      fields: [],
+      fields: []
     };
   });
 
   it('should render sub form with title and description', () => {
-    const wrapper = shallow(<SubForm title="Foo" description="Bar" { ...initialProps } />);
+    const wrapper = shallow(
+      <RenderWithProvider value={{ formOptions }}>
+        <SubForm title="Foo" description="Bar" {...initialProps} />
+      </RenderWithProvider>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render sub form with title', () => {
-    const wrapper = shallow(<SubForm title="Foo" { ...initialProps } />);
+    const wrapper = shallow(
+      <RenderWithProvider value={{ formOptions }}>
+        <SubForm title="Foo" {...initialProps} />{' '}
+      </RenderWithProvider>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render sub form with description', () => {
-    const wrapper = shallow(<SubForm description="Bar" { ...initialProps } />);
+    const wrapper = shallow(
+      <RenderWithProvider value={{ formOptions }}>
+        <SubForm description="Bar" {...initialProps} />{' '}
+      </RenderWithProvider>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/packages/pf3-component-mapper/src/tests/switch-field.test.js
+++ b/packages/pf3-component-mapper/src/tests/switch-field.test.js
@@ -9,6 +9,7 @@ import Switch, {
   TEXT_PADDING
 } from '../form-fields/switch-field';
 import { computeTextWidth } from '../helpers/html-helper';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 jest.mock('../helpers/html-helper', () => ({ computeTextWidth: jest.fn() }));
 
@@ -28,83 +29,62 @@ describe('Switch-field', () => {
 
   describe('createLabelWidth', () => {
     it('return left width object', () => {
-      expect(createLabelStyles(width)).toEqual(
-        {
-          width: computedWidth,
-          left: -computedWidth,
-        }
-      );
+      expect(createLabelStyles(width)).toEqual({
+        width: computedWidth,
+        left: -computedWidth
+      });
     });
 
     it('return right width object', () => {
-      expect(createLabelStyles(width, false)).toEqual(
-        {
-          width: computedWidth,
-          left: DIVIDER_SIZE,
-        }
-      );
+      expect(createLabelStyles(width, false)).toEqual({
+        width: computedWidth,
+        left: DIVIDER_SIZE
+      });
     });
   });
 
   describe('createTransform', () => {
     it('return object when isChecked', () => {
-      expect(createTransform(width, true)).toEqual(
-        {
-          WebkitTransform: `translateX(${computedWidth}px)`,
-          msTransform: `translateX(${computedWidth}px)`,
-          transform: `translateX(${computedWidth}px)`,
-        }
-      );
+      expect(createTransform(width, true)).toEqual({
+        WebkitTransform: `translateX(${computedWidth}px)`,
+        msTransform: `translateX(${computedWidth}px)`,
+        transform: `translateX(${computedWidth}px)`
+      });
     });
 
     it('return empty object when is not checked', () => {
-      expect(createTransform(width, false)).toEqual(
-        {}
-      );
+      expect(createTransform(width, false)).toEqual({});
     });
 
     it('return object when isChecked and is offText', () => {
-      expect(createTransform(width, true, true)).toEqual(
-        {
-          WebkitTransform: `translateX(${computedWidthWithDivider}px)`,
-          msTransform: `translateX(${computedWidthWithDivider}px)`,
-          transform: `translateX(${computedWidthWithDivider}px)`,
-        }
-      );
+      expect(createTransform(width, true, true)).toEqual({
+        WebkitTransform: `translateX(${computedWidthWithDivider}px)`,
+        msTransform: `translateX(${computedWidthWithDivider}px)`,
+        transform: `translateX(${computedWidthWithDivider}px)`
+      });
     });
 
     it('return empty object when is not Checked and is offText', () => {
-      expect(createTransform(width, false, true)).toEqual(
-        {}
-      );
+      expect(createTransform(width, false, true)).toEqual({});
     });
   });
 
   describe('Switch', () => {
-    it('should call componentDidUpdate Switch correctly', () => {
-      const wrapper = mount(
-        <Switch bsSize='mn' onChange={ jest.fn() } formOptions={{ handleSubmit: jest.fn() }}/>
-      );
-      const switchInstance = wrapper.find(Switch).instance();
-      const spy = jest.spyOn(switchInstance, 'setState');
-      expect(spy).not.toHaveBeenCalled();
-      wrapper.setProps({ offText: 'verylongoffteeeeeeeext' });
-      expect(spy).toHaveBeenCalled();
-      spy.mockReset();
-      wrapper.setProps({ offText: 'verylongoffteeeeeeeext' });
-      expect(spy).not.toHaveBeenCalled();
-    });
-
     it('should call submit when press enter', () => {
       const submitSpy = jest.fn();
       const preventDefault = jest.fn();
       const onChange = jest.fn();
 
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: submitSpy }} onChange={ onChange }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: submitSpy } }}>
+          <Switch bsSize="mn" onChange={onChange} />
+        </RenderWithProvider>
       );
 
-      wrapper.find('label').props().onKeyDown({ keyCode: 13, preventDefault });
+      wrapper
+      .find('label')
+      .props()
+      .onKeyDown({ keyCode: 13, preventDefault });
 
       expect(preventDefault).toHaveBeenCalled();
       expect(submitSpy).toHaveBeenCalled();
@@ -118,10 +98,15 @@ describe('Switch-field', () => {
       const checked = false;
 
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: submitSpy }} onChange={ onChange } checked={ checked }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: submitSpy } }}>
+          <Switch bsSize="mn" onChange={onChange} checked={checked} />
+        </RenderWithProvider>
       );
 
-      wrapper.find('label').props().onKeyDown({ keyCode: 32, preventDefault });
+      wrapper
+      .find('label')
+      .props()
+      .onKeyDown({ keyCode: 32, preventDefault });
 
       expect(preventDefault).toHaveBeenCalled();
       expect(submitSpy).not.toHaveBeenCalled();
@@ -135,10 +120,15 @@ describe('Switch-field', () => {
       const checked = true;
 
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: submitSpy }} onChange={ onChange } checked={ checked }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: submitSpy } }}>
+          <Switch bsSize="mn" onChange={onChange} checked={checked} />
+        </RenderWithProvider>
       );
 
-      wrapper.find('label').props().onKeyDown({ keyCode: 32, preventDefault });
+      wrapper
+      .find('label')
+      .props()
+      .onKeyDown({ keyCode: 32, preventDefault });
 
       expect(preventDefault).toHaveBeenCalled();
       expect(submitSpy).not.toHaveBeenCalled();
@@ -151,10 +141,15 @@ describe('Switch-field', () => {
       const onChange = jest.fn();
 
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: submitSpy }} onChange={ onChange }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: submitSpy } }}>
+          <Switch bsSize="mn" onChange={onChange} />
+        </RenderWithProvider>
       );
 
-      wrapper.find('label').props().onKeyDown({ keyCode: 88, preventDefault });
+      wrapper
+      .find('label')
+      .props()
+      .onKeyDown({ keyCode: 88, preventDefault });
 
       expect(preventDefault).not.toHaveBeenCalled();
       expect(submitSpy).not.toHaveBeenCalled();
@@ -163,7 +158,9 @@ describe('Switch-field', () => {
 
     it('tabIndex is 0 by default', () => {
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: jest.fn() }} onChange={ jest.fn() }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: jest.fn() } }}>
+          <Switch bsSize="mn" onChange={jest.fn()} />
+        </RenderWithProvider>
       );
 
       expect(wrapper.find('label').props().tabIndex).toEqual(0);
@@ -171,7 +168,9 @@ describe('Switch-field', () => {
 
     it('tabIndex is -1 when isReadOnly', () => {
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: jest.fn() }} onChange={ jest.fn() } isReadOnly={ true }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: jest.fn() } }}>
+          <Switch bsSize="mn" onChange={jest.fn()} isReadOnly={true} />
+        </RenderWithProvider>
       );
 
       expect(wrapper.find('label').props().tabIndex).toEqual(-1);
@@ -179,7 +178,9 @@ describe('Switch-field', () => {
 
     it('tabIndex is -1 when disabled', () => {
       const wrapper = mount(
-        <Switch bsSize='mn' formOptions={{ handleSubmit: jest.fn() }} onChange={ jest.fn() } disabled={ true }/>
+        <RenderWithProvider value={{ formOptions: { handleSubmit: jest.fn() } }}>
+          <Switch bsSize="mn" onChange={jest.fn()} disabled={true} />
+        </RenderWithProvider>
       );
 
       expect(wrapper.find('label').props().tabIndex).toEqual(-1);

--- a/packages/pf3-component-mapper/src/tests/tabs.test.js
+++ b/packages/pf3-component-mapper/src/tests/tabs.test.js
@@ -4,73 +4,125 @@ import { componentTypes } from '@data-driven-forms/react-form-renderer';
 import { NavItem } from 'patternfly-react';
 import toJson from 'enzyme-to-json';
 import FormTabs from '../components/tabs';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('<FormTabs />', () => {
   let initialProps;
+  let formOptions;
+
   beforeEach(() => {
     initialProps = {
-      fields: [{
-        component: componentTypes.TABS,
-        title: 'Tab 1',
-        name: 'tab1',
-        fields: [{
-          name: 'foo',
-          component: 'foo',
-        }],
-      }, {
-        component: componentTypes.TABS,
-        title: 'Tab 2',
-        name: 'tab2',
-        fields: [],
-      }],
-      formOptions: {
-        renderForm: ({ name, component }) => <div key={ name }>{ component }</div>,
-        getState: () => ({
-          errors: {},
-        }),
-      },
+      fields: [
+        {
+          component: componentTypes.TABS,
+          title: 'Tab 1',
+          name: 'tab1',
+          fields: [
+            {
+              name: 'foo',
+              component: 'foo'
+            }
+          ]
+        },
+        {
+          component: componentTypes.TABS,
+          title: 'Tab 2',
+          name: 'tab2',
+          fields: []
+        }
+      ]
+    };
+    formOptions = {
+      renderForm: ({ name, component }) => <div key={name}>{component}</div>,
+      getState: () => ({
+        errors: {}
+      })
     };
   });
 
   it('should render form tabs', () => {
-    const wrapper = mount(<FormTabs { ...initialProps } />);
+    const wrapper = mount(
+      <RenderWithProvider value={{ formOptions }}>
+        <FormTabs {...initialProps} />
+      </RenderWithProvider>
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render form tabs with error state', () => {
     const validationSchema = {
       ...initialProps,
-      fields: [{
-        component: componentTypes.TABS,
-        title: 'Tab 1',
-        name: 'tab1',
-        validateFields: [ 'foo', 'nested.field' ],
-        fields: [{
-          name: 'foo',
-          component: 'foo',
-        }, {
-          name: 'nested.field',
-          component: 'foo',
-        }],
-      }],
-      formOptions: {
-        renderForm: ({ name, component }) => <div key={ name }>{ component }</div>,
-        getState: () => ({
-          errors: { foo: true, nested: { field: true }},
-        }),
-      },
+      fields: [
+        {
+          component: componentTypes.TABS,
+          title: 'Tab 1',
+          name: 'tab1',
+          validateFields: ['foo', 'nested.field'],
+          fields: [
+            {
+              name: 'foo',
+              component: 'foo'
+            },
+            {
+              name: 'nested.field',
+              component: 'foo'
+            }
+          ]
+        }
+      ]
     };
-    const wrapper = mount(<FormTabs { ...validationSchema } />);
+
+    formOptions = {
+      renderForm: ({ name, component }) => <div key={name}>{component}</div>,
+      getState: () => ({
+        errors: { foo: true, nested: { field: true }}
+      })
+    };
+
+    const wrapper = mount(
+      <RenderWithProvider value={{ formOptions }}>
+        <FormTabs {...validationSchema} />
+      </RenderWithProvider>
+    );
+
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should switch form tabs on click', () => {
-    const wrapper = mount(<FormTabs { ...initialProps } />);
-    expect(wrapper.find(NavItem).first().instance().props.active).toEqual(true);
-    expect(wrapper.find(NavItem).last().instance().props.active).toEqual(false);
+    const wrapper = mount(
+      <RenderWithProvider value={{ formOptions }}>
+        <FormTabs {...initialProps} />
+      </RenderWithProvider>
+    );
 
-    wrapper.find('a').last().simulate('click');
-    expect(wrapper.find(NavItem).first().instance().props.active).toEqual(false);
-    expect(wrapper.find(NavItem).last().instance().props.active).toEqual(true);
+    expect(
+      wrapper
+      .find(NavItem)
+      .first()
+      .instance().props.active
+    ).toEqual(true);
+    expect(
+      wrapper
+      .find(NavItem)
+      .last()
+      .instance().props.active
+    ).toEqual(false);
+
+    wrapper
+    .find('a')
+    .last()
+    .simulate('click');
+    expect(
+      wrapper
+      .find(NavItem)
+      .first()
+      .instance().props.active
+    ).toEqual(false);
+    expect(
+      wrapper
+      .find(NavItem)
+      .last()
+      .instance().props.active
+    ).toEqual(true);
   });
 });

--- a/packages/pf3-component-mapper/src/tests/wizard.test.js
+++ b/packages/pf3-component-mapper/src/tests/wizard.test.js
@@ -4,13 +4,24 @@ import { mount } from 'enzyme';
 import MockFieldProvider from '../../../../__mocks__/mock-field-provider';
 import FormRenderer from '@data-driven-forms/react-form-renderer';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+
 import formTemplate from '../components/form-template';
 import componentMapper from '../components/component-mapper';
 import Wizard from '../components/wizard';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
+import WizardStep from '../components/wizard/wizard-step';
 
 describe('<Wizard />', () => {
   const cancelSpy = jest.fn();
   const submitSpy = jest.fn();
+
+  const formOptions = {
+    onSubmit: submitSpy,
+    onCancel: cancelSpy,
+    valid: true,
+    getState: () => ({ values: { a: 10 }}),
+    submit: () => {}
+  };
 
   const props = {
     name: 'Wizard',
@@ -21,22 +32,15 @@ describe('<Wizard />', () => {
         name: 'step-1',
         stepKey: 1,
         nextStep: 'step-2',
-        fields: [],
+        fields: []
       },
       {
         title: 'Step 2',
         name: 'step-2',
         stepKey: 'step-2',
-        fields: [],
-      },
-    ],
-    formOptions: {
-      onSubmit: submitSpy,
-      onCancel: cancelSpy,
-      valid: true,
-      getState: () => ({ values: { a: 10 }}),
-      submit: () => {},
-    },
+        fields: []
+      }
+    ]
   };
 
   const conditionalProps = {
@@ -49,74 +53,93 @@ describe('<Wizard />', () => {
         nextStep: {
           when: 'step',
           stepMapper: {
-            step: 'step-2',
-          },
+            step: 'step-2'
+          }
         },
-        fields: [],
+        fields: []
       },
       {
         title: 'Step 2',
         name: 'step-2',
         stepKey: 'step-2',
-        fields: [],
-      },
-    ],
+        fields: []
+      }
+    ]
   };
 
   const conditionalSchema = {
-    fields: [{
-      component: componentTypes.WIZARD,
-      name: 'wizzard',
-      fields: [{
-        name: 'step-1',
-        stepKey: 1,
-        nextStep: {
-          when: 'source-type',
-          stepMapper: {
-            aws: 'aws-step',
-            google: 'google-step',
+    fields: [
+      {
+        component: componentTypes.WIZARD,
+        name: 'wizzard',
+        fields: [
+          {
+            name: 'step-1',
+            stepKey: 1,
+            nextStep: {
+              when: 'source-type',
+              stepMapper: {
+                aws: 'aws-step',
+                google: 'google-step'
+              }
+            },
+            fields: [
+              {
+                component: componentTypes.TEXTAREA_FIELD,
+                name: 'source-name',
+                type: 'text',
+                label: 'Source name'
+              },
+              {
+                component: componentTypes.SELECT_COMPONENT,
+                name: 'source-type',
+                label: 'Source type',
+                options: [
+                  {
+                    label: 'Please Choose'
+                  },
+                  {
+                    value: 'aws',
+                    label: 'Aws'
+                  },
+                  {
+                    value: 'google',
+                    label: 'Google'
+                  }
+                ],
+                validate: [
+                  {
+                    type: validatorTypes.REQUIRED
+                  }
+                ]
+              }
+            ]
           },
-        },
-        fields: [{
-          component: componentTypes.TEXTAREA_FIELD,
-          name: 'source-name',
-          type: 'text',
-          label: 'Source name',
-        }, {
-          component: componentTypes.SELECT_COMPONENT,
-          name: 'source-type',
-          label: 'Source type',
-          options: [{
-            label: 'Please Choose',
-          }, {
-            value: 'aws',
-            label: 'Aws',
-          }, {
-            value: 'google',
-            label: 'Google',
-          }],
-          validate: [{
-            type: validatorTypes.REQUIRED,
-          }],
-        }],
-      }, {
-        name: 'step-2',
-        stepKey: 'aws-step',
-        fields: [{
-          component: componentTypes.TEXT_FIELD,
-          name: 'aws-field',
-          label: 'Aws field part',
-        }],
-      }, {
-        stepKey: 'google-step',
-        name: 'step-3',
-        fields: [{
-          component: componentTypes.TEXT_FIELD,
-          name: 'google-field',
-          label: 'Google field part',
-        }],
-      }],
-    }],
+          {
+            name: 'step-2',
+            stepKey: 'aws-step',
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD,
+                name: 'aws-field',
+                label: 'Aws field part'
+              }
+            ]
+          },
+          {
+            stepKey: 'google-step',
+            name: 'step-3',
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD,
+                name: 'google-field',
+                label: 'Google field part'
+              }
+            ]
+          }
+        ]
+      }
+    ]
   };
 
   afterEach(() => {
@@ -126,112 +149,140 @@ describe('<Wizard />', () => {
 
   it('should render Wizard correctly', () => {
     const wrapper = mount(
-      <Wizard { ...props } />
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} />
+      </RenderWithProvider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render Wizard with conditional steps correctly', () => {
     const wrapper = mount(
-      <Wizard { ...conditionalProps } />
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...conditionalProps} />
+      </RenderWithProvider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render Wizard with title correctly', () => {
     const wrapper = mount(
-      <Wizard { ...props } title={ 'Wizard title' }/>
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} title={'Wizard title'} />
+      </RenderWithProvider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render Wizard with stepsInfo correctly', () => {
     const wrapper = mount(
-      <Wizard { ...props } stepsInfo={ [{ title: 'step1' }, { title: 'step2' }] }/>
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} stepsInfo={[{ title: 'step1' }, { title: 'step2' }]} />
+      </RenderWithProvider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should call cancel', () => {
     const wrapper = mount(
-      <Wizard { ...props } />
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} />
+      </RenderWithProvider>
     );
-    wrapper.find('button').first().simulate('click');
+    wrapper
+    .find('button')
+    .first()
+    .simulate('click');
     wrapper.update();
     expect(cancelSpy).toHaveBeenCalled();
   });
 
   it('should step when clicked on next button', () => {
     const wrapper = mount(
-      <Wizard { ...props } />
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} />
+      </RenderWithProvider>
     );
-    expect(wrapper.instance().state.activeStep).toEqual(1);
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual(1);
 
     const nextButton = wrapper.find('button').last();
     nextButton.simulate('click');
+    wrapper.update();
 
-    expect(wrapper.instance().state.activeStep).toEqual('step-2');
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual('step-2');
   });
 
   it('should not step when clicked on button with false valid', () => {
     const wrapper = mount(
-      <Wizard { ...props } formOptions={{ ...props.formOptions, valid: false }}  />
+      <RenderWithProvider value={{ formOptions: { ...formOptions, valid: false } }}>
+        <Wizard {...props} />
+      </RenderWithProvider>
     );
-    expect(wrapper.instance().state.activeStep).toEqual(1);
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual(1);
 
     const nextButton = wrapper.find('button').last();
     nextButton.simulate('click');
+    wrapper.update();
 
-    expect(wrapper.instance().state.activeStep).toEqual(1);
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual(1);
   });
 
   it('should submit when clicked on next button 2x', () => {
     const wrapper = mount(
-      <Wizard { ...props } />
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} />
+      </RenderWithProvider>
     );
     expect(submitSpy).not.toHaveBeenCalled();
 
     let nextButton = wrapper.find('button').last();
     nextButton.simulate('click');
+    wrapper.update();
     nextButton = wrapper.find('button').last();
     nextButton.simulate('click');
+
+    console.log(nextButton.debug());
 
     expect(submitSpy).toHaveBeenCalled();
   });
 
   it('should stepBack when clicked on back button', () => {
     const wrapper = mount(
-      <Wizard { ...props } />
+      <RenderWithProvider value={{ formOptions }}>
+        <Wizard {...props} />
+      </RenderWithProvider>
     );
-    expect(wrapper.instance().state.activeStep).toEqual(1);
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual(1);
 
     const nextButton = wrapper.find('button').last();
     nextButton.simulate('click');
+    wrapper.update();
 
-    expect(wrapper.instance().state.activeStep).toEqual('step-2');
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual('step-2');
 
     const backButton = wrapper.find('button').at(1);
     backButton.simulate('click');
+    wrapper.update();
 
-    expect(wrapper.instance().state.activeStep).toEqual(1);
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual(1);
   });
 
   it('should step to google-step when clicked on next button in conditional schema', () => {
     const wrapper = mount(
       <FormRenderer
-        schema={ conditionalSchema }
-        formFieldsMapper={ componentMapper }
-        formTemplate={ formTemplate({showFormControls: false}) }
-        onCancel={ () => {} }
-        onSubmit={ jest.fn() }
+        schema={conditionalSchema}
+        formFieldsMapper={componentMapper}
+        formTemplate={formTemplate({ showFormControls: false })}
+        onCancel={() => {}}
+        onSubmit={jest.fn()}
         initialValues={{ 'source-type': 'google' }}
       />
     );
 
-    const wizzardField = wrapper.find(Wizard).instance();
-    expect(wizzardField.state.activeStep).toEqual(1);
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual(1);
     const nextButton = wrapper.find('button').last();
     nextButton.simulate('click');
-    expect(wizzardField.state.activeStep).toEqual('google-step');
+    wrapper.update();
+    expect(wrapper.find(WizardStep).props().stepKey).toEqual('google-step');
   });
 });

--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import { Button } from '@patternfly/react-core';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const ValidateButtons = ({ disableBack, handlePrev, buttonLabels: { back, cancel }, formOptions, renderNextButton }) => {
+const ValidateButtons = ({ disableBack, handlePrev, buttonLabels: { back, cancel }, renderNextButton }) => {
   const [ state, setState ] = useState('init');
+  const formOptions = useFormApi();
 
   const setValidating = () => {
     setState('validating');

--- a/packages/pf4-component-mapper/src/components/field-array.js
+++ b/packages/pf4-component-mapper/src/components/field-array.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid';
 import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye';
@@ -10,7 +11,9 @@ import AddCircleOIcon from '@patternfly/react-icons/dist/js/icons/add-circle-o-i
 
 import './final-form-array.scss';
 
-const ArrayItem = ({ fields, fieldIndex, name, remove, formOptions, length, minItems }) => {
+const ArrayItem = ({ fields, fieldIndex, name, remove, length, minItems }) => {
+  const { renderForm } = useFormApi();
+
   const widths = {
     label: fields[0].label ? 5 : 0,
     field: fields[0].label ? 7 : 12
@@ -40,7 +43,7 @@ const ArrayItem = ({ fields, fieldIndex, name, remove, formOptions, length, minI
                   </label>
                 </GridItem>
               )}
-              <GridItem sm={widths.field}>{formOptions.renderForm([ field ])}</GridItem>
+              <GridItem sm={widths.field}>{renderForm([field])}</GridItem>
             </Grid>
           ))}
         </GridItem>
@@ -66,9 +69,6 @@ ArrayItem.propTypes = {
   fieldIndex: PropTypes.number.isRequired,
   fields: PropTypes.arrayOf(PropTypes.object),
   remove: PropTypes.func.isRequired,
-  formOptions: PropTypes.shape({
-    renderForm: PropTypes.func.isRequired
-  }).isRequired,
   length: PropTypes.number,
   minItems: PropTypes.number
 };
@@ -79,7 +79,6 @@ const DynamicArray = ({
   description,
   fields: formFields,
   defaultItem,
-  formOptions,
   meta,
   FieldArrayProvider,
   FormSpyProvider, // eslint-disable-line react/prop-types
@@ -109,7 +108,6 @@ const DynamicArray = ({
               name={name}
               fieldIndex={index}
               remove={remove}
-              formOptions={formOptions}
               length={value.length}
               minItems={minItems}
             />
@@ -150,9 +148,6 @@ DynamicArray.propTypes = {
   minItems: PropTypes.number,
   maxItems: PropTypes.number,
   noItemsMessage: PropTypes.node,
-  formOptions: PropTypes.shape({
-    renderForm: PropTypes.func.isRequired
-  }).isRequired,
   FieldArrayProvider: PropTypes.node.isRequired,
   meta: PropTypes.object.isRequired
 };

--- a/packages/pf4-component-mapper/src/components/sub-form.js
+++ b/packages/pf4-component-mapper/src/components/sub-form.js
@@ -1,36 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { Text, TextVariants } from '@patternfly/react-core/dist/js/components/Text/Text';
 import { TextContent } from '@patternfly/react-core/dist/js/components/Text/TextContent';
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid/index';
 import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
 
-const SubForm = ({ fields, title, description, formOptions, FieldProvider: _FieldProvider, validate: _validate, ...rest }) => (
-  <Grid gutter="md" {...rest}>
-    {title && (
-      <GridItem sm={12}>
-        <Title size="xl">{title}</Title>
-      </GridItem>
-    )}
-    {description && (
-      <GridItem sm={12}>
-        <TextContent>
-          <Text component={TextVariants.small} style={{ marginBottom: 0 }}>
-            {description}
-          </Text>
-        </TextContent>
-      </GridItem>
-    )}
-    {formOptions.renderForm(fields, formOptions)}
-  </Grid>
-);
+const SubForm = ({ fields, title, description, FieldProvider: _FieldProvider, validate: _validate, ...rest }) => {
+  const formOptions = useFormApi();
+
+  return (
+    <Grid gutter="md" {...rest}>
+      {title && (
+        <GridItem sm={12}>
+          <Title size="xl">{title}</Title>
+        </GridItem>
+      )}
+      {description && (
+        <GridItem sm={12}>
+          <TextContent>
+            <Text component={TextVariants.small} style={{ marginBottom: 0 }}>
+              {description}
+            </Text>
+          </TextContent>
+        </GridItem>
+      )}
+      {formOptions.renderForm(fields, formOptions)}
+    </Grid>
+  );
+};
 
 SubForm.propTypes = {
   fields: PropTypes.array.isRequired,
-  formOptions: PropTypes.shape({
-    renderForm: PropTypes.func.isRequired
-  }).isRequired,
   name: PropTypes.string,
   title: PropTypes.string,
   description: PropTypes.string,

--- a/packages/pf4-component-mapper/src/components/tabs.js
+++ b/packages/pf4-component-mapper/src/components/tabs.js
@@ -1,45 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { Tab } from '@patternfly/react-core/dist/js/components/Tabs/Tab';
 import { Tabs } from '@patternfly/react-core/dist/js/components/Tabs/Tabs';
 
-class FormTabs extends React.Component {
-  state = {
-    activeTabKey: 0
-  };
+const FormTabs = ({ fields, dataType, FieldProvider, validate, ...rest }) => {
+  const formOptions = useFormApi();
+  const [activeTabKey, setActiveTabKey] = useState(0);
 
-  // Toggle currently active tab
-  handleTabClick = (event, tabIndex) => {
+  const handleTabClick = (event, tabIndex) => {
     event.preventDefault();
-    this.setState({
-      activeTabKey: tabIndex
-    });
+    setActiveTabKey(tabIndex);
   };
 
-  renderTabItems = (fields, formOptions) =>
+  const renderTabItems = (fields) =>
     fields.map(({ fields, title, name }, index) => (
       <Tab key={name} eventKey={index} title={title}>
         <div className="pf-c-form">{formOptions.renderForm(fields, formOptions)}</div>
       </Tab>
     ));
 
-  render() {
-    const { fields, formOptions, dataType, FieldProvider, validate, ...rest } = this.props;
-    return (
-      <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} {...rest}>
-        {this.renderTabItems(fields, formOptions)}
-      </Tabs>
-    );
-  }
-}
+  return (
+    <Tabs activeKey={activeTabKey} onSelect={handleTabClick} {...rest}>
+      {renderTabItems(fields, formOptions)}
+    </Tabs>
+  );
+};
 
 FormTabs.propTypes = {
   fields: PropTypes.array.isRequired,
-  formOptions: PropTypes.shape({
-    // not from props
-    renderForm: PropTypes.func.isRequired
-  }).isRequired,
   dataType: PropTypes.any,
   FieldProvider: PropTypes.any, // not form props
   validate: PropTypes.any

--- a/packages/pf4-component-mapper/src/components/wizard.js
+++ b/packages/pf4-component-mapper/src/components/wizard.js
@@ -1,6 +1,7 @@
 import React, { cloneElement } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { WizardHeader } from '@patternfly/react-core/dist/js/components/Wizard/WizardHeader';
 import { WizardNav } from '@patternfly/react-core/dist/js/components/Wizard/WizardNav';
@@ -15,7 +16,7 @@ import flattenDeep from 'lodash/flattenDeep';
 import handleEnter from '@data-driven-forms/common/src/wizard/enter-handler';
 import WizardNavigation from './wizard/wizard-nav';
 
-const DYNAMIC_WIZARD_TYPES = [ 'function', 'object' ];
+const DYNAMIC_WIZARD_TYPES = ['function', 'object'];
 
 const Modal = ({ children, container, inModal }) =>
   inModal
@@ -67,7 +68,7 @@ class Wizard extends React.Component {
     this.setState((prevState) => ({
       registeredFieldsHistory: { ...prevState.registeredFieldsHistory, [prevState.activeStep]: getRegisteredFields() },
       activeStep: nextStep,
-      prevSteps: shouldInsertStepIntoHistory ? prevState.prevSteps : [ ...prevState.prevSteps, prevState.activeStep ],
+      prevSteps: shouldInsertStepIntoHistory ? prevState.prevSteps : [...prevState.prevSteps, prevState.activeStep],
       activeStepIndex: newActiveIndex,
       maxStepIndex: newActiveIndex > prevState.maxStepIndex ? newActiveIndex : prevState.maxStepIndex,
       navSchema: this.state.isDynamic ? this.createSchema({ currentIndex: newActiveIndex }) : prevState.navSchema
@@ -87,7 +88,7 @@ class Wizard extends React.Component {
 
     // Find only visited fields
     flattenDeep(
-      Object.values([ ...visitedSteps, this.state.activeStep ].reduce((obj, key) => ({ ...obj, [key]: finalRegisteredFieldsHistory[key] }), {}))
+      Object.values([...visitedSteps, this.state.activeStep].reduce((obj, key) => ({ ...obj, [key]: finalRegisteredFieldsHistory[key] }), {}))
     ).forEach((key) => set(finalObject, key, get(values, key)));
 
     return finalObject;
@@ -106,7 +107,7 @@ class Wizard extends React.Component {
 
           return {
             activeStep: this.state.prevSteps[index],
-            prevSteps: includeActiveStep ? prevState.prevSteps : [ ...prevState.prevSteps, prevState.activeStep ],
+            prevSteps: includeActiveStep ? prevState.prevSteps : [...prevState.prevSteps, prevState.activeStep],
             activeStepIndex: index
           };
         },
@@ -204,7 +205,7 @@ class Wizard extends React.Component {
     this.props.formOptions.onSubmit(
       this.handleSubmit(
         this.props.formOptions.getState().values,
-        [ ...this.state.prevSteps, this.state.activeStep ],
+        [...this.state.prevSteps, this.state.activeStep],
         this.props.formOptions.getRegisteredFields
       ),
       this.props.formOptions
@@ -315,7 +316,7 @@ Wizard.propTypes = {
   }),
   fields: PropTypes.arrayOf(
     PropTypes.shape({
-      stepKey: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]).isRequired
+      stepKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
     })
   ).isRequired,
   isCompactNav: PropTypes.bool,
@@ -335,7 +336,11 @@ const defaultLabels = {
   next: 'Next'
 };
 
-const WizardFunction = ({ buttonLabels, ...props }) => <Wizard {...props} buttonLabels={{ ...defaultLabels, ...buttonLabels }} />;
+const WizardFunction = ({ buttonLabels, ...props }) => {
+  const formOptions = useFormApi();
+
+  return <Wizard {...props} buttonLabels={{ ...defaultLabels, ...buttonLabels }} formOptions={formOptions} />;
+};
 
 WizardFunction.propTypes = {
   buttonLabels: PropTypes.shape({

--- a/packages/pf4-component-mapper/src/components/wizard/step-buttons.js
+++ b/packages/pf4-component-mapper/src/components/wizard/step-buttons.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
 import selectNext from '@data-driven-forms/common/src/wizard/select-next';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 const SimpleNext = ({ nextStep, valid, handleNext, submit, nextLabel, getState }) => (
   <Button variant="primary" type="button" isDisabled={!valid} onClick={() => (valid ? handleNext(selectNext(nextStep, getState)) : submit())}>
@@ -37,56 +36,53 @@ const WizardStepButtons = ({
   FieldProvider,
   handleNext,
   buttonsClassName,
-  buttonLabels: { cancel, submit, back, next }
-}) => {
-  const formOptions = useFormApi();
-
-  return (
-    <footer className={`pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}`}>
-      {Buttons ? (
-        <Buttons
-          ConditionalNext={SimpleNext}
-          SubmitButton={SubmitButton}
-          SimpleNext={SimpleNext}
-          disableBack={disableBack}
-          handlePrev={handlePrev}
-          nextStep={nextStep}
-          FieldProvider={FieldProvider}
-          handleNext={handleNext}
-          buttonsClassName={buttonsClassName}
-          buttonLabels={{ cancel, submit, back, next }}
-          renderNextButton={(args) =>
-            renderNextButton({
-              ...formOptions,
-              handleNext,
-              nextStep,
-              nextLabel: next,
-              submitLabel: submit,
-              ...args
-            })
-          }
-          selectNext={selectNext}
-        />
-      ) : (
-        <React.Fragment>
-          {renderNextButton({
+  buttonLabels: { cancel, submit, back, next },
+  formOptions
+}) => (
+  <footer className={`pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}`}>
+    {Buttons ? (
+      <Buttons
+        ConditionalNext={SimpleNext}
+        SubmitButton={SubmitButton}
+        SimpleNext={SimpleNext}
+        disableBack={disableBack}
+        handlePrev={handlePrev}
+        nextStep={nextStep}
+        FieldProvider={FieldProvider}
+        handleNext={handleNext}
+        buttonsClassName={buttonsClassName}
+        buttonLabels={{ cancel, submit, back, next }}
+        renderNextButton={(args) =>
+          renderNextButton({
             ...formOptions,
             handleNext,
             nextStep,
             nextLabel: next,
-            submitLabel: submit
-          })}
-          <Button type="button" variant="secondary" isDisabled={disableBack} onClick={handlePrev}>
-            {back}
-          </Button>
-          <Button type="button" variant="link" onClick={() => formOptions.onCancel(formOptions.getState().values)}>
-            {cancel}
-          </Button>
-        </React.Fragment>
-      )}
-    </footer>
-  );
-};
+            submitLabel: submit,
+            ...args
+          })
+        }
+        selectNext={selectNext}
+      />
+    ) : (
+      <React.Fragment>
+        {renderNextButton({
+          ...formOptions,
+          handleNext,
+          nextStep,
+          nextLabel: next,
+          submitLabel: submit
+        })}
+        <Button type="button" variant="secondary" isDisabled={disableBack} onClick={handlePrev}>
+          {back}
+        </Button>
+        <Button type="button" variant="link" onClick={() => formOptions.onCancel(formOptions.getState().values)}>
+          {cancel}
+        </Button>
+      </React.Fragment>
+    )}
+  </footer>
+);
 
 WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
@@ -108,7 +104,11 @@ WizardStepButtons.propTypes = {
     next: PropTypes.string.isRequired
   }).isRequired,
   buttonsClassName: PropTypes.string,
-  buttons: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
+  buttons: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  formOptions: PropTypes.shape({
+    getState: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+  })
 };
 
 export default WizardStepButtons;

--- a/packages/pf4-component-mapper/src/components/wizard/step-buttons.js
+++ b/packages/pf4-component-mapper/src/components/wizard/step-buttons.js
@@ -2,22 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
 import selectNext from '@data-driven-forms/common/src/wizard/select-next';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const SimpleNext = ({
-  nextStep,
-  valid,
-  handleNext,
-  submit,
-  nextLabel,
-  getState,
-}) =>  (
-  <Button
-    variant="primary"
-    type="button"
-    isDisabled={ !valid }
-    onClick={ () => valid ? handleNext(selectNext(nextStep, getState)) : submit() }
-  >
-    { nextLabel }
+const SimpleNext = ({ nextStep, valid, handleNext, submit, nextLabel, getState }) => (
+  <Button variant="primary" type="button" isDisabled={!valid} onClick={() => (valid ? handleNext(selectNext(nextStep, getState)) : submit())}>
+    {nextLabel}
   </Button>
 );
 
@@ -28,73 +17,78 @@ SimpleNext.propTypes = {
   submit: PropTypes.func.isRequired,
   nextLabel: PropTypes.string.isRequired,
   getState: PropTypes.func.isRequired,
-  nextStep: PropTypes.oneOfType([ PropTypes.string, PropTypes.object, PropTypes.func ]).isRequired,
+  nextStep: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]).isRequired
 };
 
-const SubmitButton = ({ handleSubmit, submitLabel }) => <Button type="button" variant="primary" onClick={ handleSubmit }>{ submitLabel }</Button>;
+const SubmitButton = ({ handleSubmit, submitLabel }) => (
+  <Button type="button" variant="primary" onClick={handleSubmit}>
+    {submitLabel}
+  </Button>
+);
 
 const renderNextButton = ({ nextStep, handleSubmit, submitLabel, ...rest }) =>
-  nextStep
-    ? <SimpleNext nextStep={ nextStep } { ...rest } />
-    : <SubmitButton handleSubmit={ handleSubmit } submitLabel={ submitLabel } />;
+  nextStep ? <SimpleNext nextStep={nextStep} {...rest} /> : <SubmitButton handleSubmit={handleSubmit} submitLabel={submitLabel} />;
 
 const WizardStepButtons = ({
   buttons: Buttons,
-  formOptions,
   disableBack,
   handlePrev,
   nextStep,
   FieldProvider,
   handleNext,
   buttonsClassName,
-  buttonLabels: {
-    cancel,
-    submit,
-    back,
-    next,
-  }}) =>
-  <footer className={ `pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}` }>
-    { Buttons ? <Buttons
-      ConditionalNext={ SimpleNext }
-      SubmitButton={ SubmitButton }
-      SimpleNext={ SimpleNext }
-      formOptions={ formOptions }
-      disableBack={ disableBack }
-      handlePrev={ handlePrev }
-      nextStep={ nextStep }
-      FieldProvider={ FieldProvider }
-      handleNext={ handleNext }
-      buttonsClassName={ buttonsClassName }
-      buttonLabels={{ cancel, submit, back, next }}
-      renderNextButton={ args => renderNextButton({
-        ...formOptions,
-        handleNext,
-        nextStep,
-        nextLabel: next,
-        submitLabel: submit,
-        ...args,
-      }) }
-      selectNext={ selectNext }
-    />
-      : <React.Fragment>
-        { renderNextButton({
-          ...formOptions,
-          handleNext,
-          nextStep,
-          nextLabel: next,
-          submitLabel: submit,
-        }) }
-        <Button type="button" variant="secondary" isDisabled={ disableBack } onClick={ handlePrev }>{ back }</Button>
-        <Button type="button" variant="link" onClick={ () => formOptions.onCancel(formOptions.getState().values) }>{ cancel }</Button>
-      </React.Fragment> }
-  </footer>;
+  buttonLabels: { cancel, submit, back, next }
+}) => {
+  const formOptions = useFormApi();
+
+  return (
+    <footer className={`pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}`}>
+      {Buttons ? (
+        <Buttons
+          ConditionalNext={SimpleNext}
+          SubmitButton={SubmitButton}
+          SimpleNext={SimpleNext}
+          disableBack={disableBack}
+          handlePrev={handlePrev}
+          nextStep={nextStep}
+          FieldProvider={FieldProvider}
+          handleNext={handleNext}
+          buttonsClassName={buttonsClassName}
+          buttonLabels={{ cancel, submit, back, next }}
+          renderNextButton={(args) =>
+            renderNextButton({
+              ...formOptions,
+              handleNext,
+              nextStep,
+              nextLabel: next,
+              submitLabel: submit,
+              ...args
+            })
+          }
+          selectNext={selectNext}
+        />
+      ) : (
+        <React.Fragment>
+          {renderNextButton({
+            ...formOptions,
+            handleNext,
+            nextStep,
+            nextLabel: next,
+            submitLabel: submit
+          })}
+          <Button type="button" variant="secondary" isDisabled={disableBack} onClick={handlePrev}>
+            {back}
+          </Button>
+          <Button type="button" variant="link" onClick={() => formOptions.onCancel(formOptions.getState().values)}>
+            {cancel}
+          </Button>
+        </React.Fragment>
+      )}
+    </footer>
+  );
+};
 
 WizardStepButtons.propTypes = {
-  formOptions: PropTypes.shape({
-    onCancel: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    getState: PropTypes.func.isRequired,
-  }).isRequired,
   disableBack: PropTypes.bool,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
@@ -102,19 +96,19 @@ WizardStepButtons.propTypes = {
     PropTypes.string,
     PropTypes.shape({
       when: PropTypes.string.isRequired,
-      stepMapper: PropTypes.object.isRequired,
+      stepMapper: PropTypes.object.isRequired
     }),
-    PropTypes.func,
+    PropTypes.func
   ]),
   FieldProvider: PropTypes.func,
   buttonLabels: PropTypes.shape({
     submit: PropTypes.string.isRequired,
     cancel: PropTypes.string.isRequired,
     back: PropTypes.string.isRequired,
-    next: PropTypes.string.isRequired,
+    next: PropTypes.string.isRequired
   }).isRequired,
   buttonsClassName: PropTypes.string,
-  buttons: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
+  buttons: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
 };
 
 export default WizardStepButtons;

--- a/packages/pf4-component-mapper/src/components/wizard/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/components/wizard/wizard-nav.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { WizardNavItem } from '@patternfly/react-core/dist/js/components/Wizard/WizardNavItem';
 import { WizardNav } from '@patternfly/react-core/dist/js/components/Wizard/WizardNav';
@@ -21,9 +20,7 @@ const memoValues = (initialValue) => {
   };
 };
 
-const WizardNavigationInternal = React.memo(({ navSchema, activeStepIndex, maxStepIndex, jumpToStep }) => {
-  const { valid } = useFormApi();
-
+const WizardNavigationInternal = React.memo(({ navSchema, activeStepIndex, maxStepIndex, jumpToStep, formOptions: { valid } }) => {
   return navSchema
   .filter((field) => field.primary)
   .map((step) => {
@@ -61,7 +58,10 @@ WizardNavigationInternal.propTypes = {
   activeStepIndex: PropTypes.number.isRequired,
   maxStepIndex: PropTypes.number.isRequired,
   jumpToStep: PropTypes.func.isRequired,
-  navSchema: PropTypes.array.isRequired
+  navSchema: PropTypes.array.isRequired,
+  formOptions: PropTypes.shape({
+    valid: PropTypes.bool.isRequired
+  }).isRequired
 };
 
 class WizardNavigationClass extends React.Component {
@@ -110,13 +110,21 @@ class WizardNavigationClass extends React.Component {
   }
 
   render() {
-    const { activeStepIndex, maxStepIndex, jumpToStep, navSchema } = this.props;
+    const { activeStepIndex, maxStepIndex, jumpToStep, navSchema, formOptions } = this.props;
 
     const { maxStepIndex: maxStepIndexState } = this.state;
 
     const maxIndex = typeof maxStepIndexState === 'number' ? maxStepIndexState : maxStepIndex;
 
-    return <WizardNavigationInternal navSchema={navSchema} activeStepIndex={activeStepIndex} maxStepIndex={maxIndex} jumpToStep={jumpToStep} />;
+    return (
+      <WizardNavigationInternal
+        navSchema={navSchema}
+        activeStepIndex={activeStepIndex}
+        maxStepIndex={maxIndex}
+        jumpToStep={jumpToStep}
+        formOptions={formOptions}
+      />
+    );
   }
 }
 
@@ -127,7 +135,8 @@ WizardNavigationClass.propTypes = {
   setPrevSteps: PropTypes.func.isRequired,
   navSchema: PropTypes.array.isRequired,
   values: PropTypes.object.isRequired,
-  crossroads: PropTypes.arrayOf(PropTypes.string)
+  crossroads: PropTypes.arrayOf(PropTypes.string),
+  formOptions: PropTypes.object.isRequired
 };
 
 export default WizardNavigationClass;

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/form-template-common.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/form-template-common.test.js.snap
@@ -2,1033 +2,1053 @@
 
 exports[`FormTemplate PF4 Common should add missing buttons if not defined in button order 1`] = `
 <ContextWrapper>
-  <ReactFinalForm
-    onSubmit={[MockFunction]}
-  >
-    <Component
-      FormSpy={[Function]}
-      buttonOrder={Array []}
-      canReset={true}
-      canSubmit={true}
-      formFields={
-        <div>
-          Formfields
-        </div>
-      }
-      formOptions={
-        Object {
+  <RenderWithProvider
+    value={
+      Object {
+        "formOptions": Object {
           "canReset": true,
           "onCancel": [MockFunction],
           "onReset": [MockFunction],
           "onSubmit": [MockFunction],
           "pristine": true,
-        }
+        },
       }
-      schema={Object {}}
+    }
+  >
+    <ReactFinalForm
+      onSubmit={[MockFunction]}
     >
-      <Form>
-        <form
-          className="pf-c-form"
-          noValidate={true}
-        >
+      <Component
+        FormSpy={[Function]}
+        buttonOrder={Array []}
+        canReset={true}
+        canSubmit={true}
+        formFields={
           <div>
             Formfields
           </div>
-          <ReactFinalForm(FormSpy)>
-            <FormSpy
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {},
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
-            >
-              <FormControls
-                Button={[Function]}
-                ButtonGroup={[Function]}
-                FormSpy={[Function]}
-                buttonOrder={
-                  Array [
-                    "submit",
-                    "reset",
-                    "cancel",
-                  ]
-                }
-                canReset={false}
-                canSubmit={false}
-                cancelLabel="Cancel"
-                formSpyProps={
+        }
+        schema={Object {}}
+      >
+        <Form>
+          <form
+            className="pf-c-form"
+            noValidate={true}
+          >
+            <div>
+              Formfields
+            </div>
+            <ReactFinalForm(FormSpy)>
+              <FormSpy
+                reactFinalForm={
                   Object {
-                    "active": undefined,
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
-                    "dirty": false,
-                    "dirtyFields": Object {},
-                    "dirtyFieldsSinceLastSubmit": Object {},
-                    "dirtySinceLastSubmit": false,
-                    "error": undefined,
-                    "errors": Object {},
+                    "destroyOnUnregister": false,
                     "focus": [Function],
-                    "form": Object {
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "initialize": [Function],
+                    "isValidationPaused": [Function],
+                    "mutators": Object {},
+                    "pauseValidation": [Function],
+                    "registerField": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                  }
+                }
+              >
+                <FormControls
+                  Button={[Function]}
+                  ButtonGroup={[Function]}
+                  FormSpy={[Function]}
+                  buttonOrder={
+                    Array [
+                      "submit",
+                      "reset",
+                      "cancel",
+                    ]
+                  }
+                  canReset={false}
+                  canSubmit={false}
+                  cancelLabel="Cancel"
+                  formSpyProps={
+                    Object {
+                      "active": undefined,
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
-                      "destroyOnUnregister": false,
+                      "dirty": false,
+                      "dirtyFields": Object {},
+                      "dirtyFieldsSinceLastSubmit": Object {},
+                      "dirtySinceLastSubmit": false,
+                      "error": undefined,
+                      "errors": Object {},
                       "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
+                      "form": Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "destroyOnUnregister": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "mutators": Object {},
+                        "pauseValidation": [Function],
+                        "registerField": [Function],
+                        "reset": [Function],
+                        "resetFieldState": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                      },
+                      "hasSubmitErrors": false,
+                      "hasValidationErrors": false,
+                      "initialValues": undefined,
                       "initialize": [Function],
-                      "isValidationPaused": [Function],
+                      "invalid": false,
+                      "modified": Object {},
                       "mutators": Object {},
-                      "pauseValidation": [Function],
-                      "registerField": [Function],
+                      "pristine": true,
                       "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                    },
-                    "hasSubmitErrors": false,
-                    "hasValidationErrors": false,
-                    "initialValues": undefined,
-                    "initialize": [Function],
-                    "invalid": false,
-                    "modified": Object {},
-                    "mutators": Object {},
-                    "pristine": true,
-                    "reset": [Function],
-                    "submitError": undefined,
-                    "submitErrors": undefined,
-                    "submitFailed": false,
-                    "submitSucceeded": false,
-                    "submitting": false,
-                    "touched": Object {},
-                    "valid": true,
-                    "validating": false,
-                    "values": Object {},
-                    "visited": Object {},
+                      "submitError": undefined,
+                      "submitErrors": undefined,
+                      "submitFailed": false,
+                      "submitSucceeded": false,
+                      "submitting": false,
+                      "touched": Object {},
+                      "valid": true,
+                      "validating": false,
+                      "values": Object {},
+                      "visited": Object {},
+                    }
                   }
-                }
-                onCancel={[MockFunction]}
-                onReset={[MockFunction]}
-                resetLabel="Reset"
-                submitLabel="Submit"
-              >
-                <ButtonGroup>
-                  <ActionGroup>
-                    <div
-                      className="pf-c-form__group pf-m-action"
-                    >
+                  onCancel={[MockFunction]}
+                  onReset={[MockFunction]}
+                  resetLabel="Reset"
+                  submitLabel="Submit"
+                >
+                  <ButtonGroup>
+                    <ActionGroup>
                       <div
-                        className="pf-c-form__actions"
+                        className="pf-c-form__group pf-m-action"
                       >
-                        <Button
-                          key="form-submit"
-                          label="Submit"
-                          type="submit"
-                          variant="primary"
+                        <div
+                          className="pf-c-form__actions"
                         >
-                          <Component
+                          <Button
+                            key="form-submit"
+                            label="Submit"
                             type="submit"
                             variant="primary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Submit",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "type": "submit",
-                                  "variant": "primary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              type="submit"
+                              variant="primary"
                             >
-                              <Button
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Submit",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "type": "submit",
+                                    "variant": "primary",
                                   }
                                 }
-                                type="submit"
-                                variant="primary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-primary"
-                                  disabled={false}
-                                  tabIndex={null}
+                                <Button
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="submit"
+                                  variant="primary"
                                 >
-                                  Submit
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                        <Button
-                          key="form-cancel"
-                          label="Cancel"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <Component
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-primary"
+                                    disabled={false}
+                                    tabIndex={null}
+                                    type="submit"
+                                  >
+                                    Submit
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                          <Button
+                            key="form-cancel"
+                            label="Cancel"
                             onClick={[Function]}
                             type="button"
-                            variant="secondary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Cancel",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              onClick={[Function]}
+                              type="button"
+                              variant="secondary"
                             >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Cancel",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "onClick": [Function],
+                                    "type": "button",
+                                    "variant": "secondary",
                                   }
                                 }
-                                type="button"
-                                variant="secondary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={false}
+                                <Button
                                   onClick={[Function]}
-                                  tabIndex={null}
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="button"
+                                  variant="secondary"
                                 >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-secondary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    tabIndex={null}
+                                    type="button"
+                                  >
+                                    Cancel
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                        </div>
                       </div>
-                    </div>
-                  </ActionGroup>
-                </ButtonGroup>
-              </FormControls>
-            </FormSpy>
-          </ReactFinalForm(FormSpy)>
-        </form>
-      </Form>
-    </Component>
-  </ReactFinalForm>
+                    </ActionGroup>
+                  </ButtonGroup>
+                </FormControls>
+              </FormSpy>
+            </ReactFinalForm(FormSpy)>
+          </form>
+        </Form>
+      </Component>
+    </ReactFinalForm>
+  </RenderWithProvider>
 </ContextWrapper>
 `;
 
 exports[`FormTemplate PF4 Common should render all controls and with default labels 1`] = `
 <ContextWrapper>
-  <ReactFinalForm
-    onSubmit={[MockFunction]}
-  >
-    <Component
-      FormSpy={[Function]}
-      formFields={
-        <div>
-          Formfields
-        </div>
-      }
-      formOptions={
-        Object {
+  <RenderWithProvider
+    value={
+      Object {
+        "formOptions": Object {
           "canReset": true,
           "onCancel": [MockFunction],
           "onReset": [MockFunction],
           "onSubmit": [MockFunction],
           "pristine": true,
-        }
+        },
       }
-      schema={Object {}}
+    }
+  >
+    <ReactFinalForm
+      onSubmit={[MockFunction]}
     >
-      <Form>
-        <form
-          className="pf-c-form"
-          noValidate={true}
-        >
+      <Component
+        FormSpy={[Function]}
+        formFields={
           <div>
             Formfields
           </div>
-          <ReactFinalForm(FormSpy)>
-            <FormSpy
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {},
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
-            >
-              <FormControls
-                Button={[Function]}
-                ButtonGroup={[Function]}
-                FormSpy={[Function]}
-                buttonOrder={
-                  Array [
-                    "submit",
-                    "reset",
-                    "cancel",
-                  ]
-                }
-                canReset={false}
-                canSubmit={false}
-                cancelLabel="Cancel"
-                formSpyProps={
+        }
+        schema={Object {}}
+      >
+        <Form>
+          <form
+            className="pf-c-form"
+            noValidate={true}
+          >
+            <div>
+              Formfields
+            </div>
+            <ReactFinalForm(FormSpy)>
+              <FormSpy
+                reactFinalForm={
                   Object {
-                    "active": undefined,
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
-                    "dirty": false,
-                    "dirtyFields": Object {},
-                    "dirtyFieldsSinceLastSubmit": Object {},
-                    "dirtySinceLastSubmit": false,
-                    "error": undefined,
-                    "errors": Object {},
+                    "destroyOnUnregister": false,
                     "focus": [Function],
-                    "form": Object {
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "initialize": [Function],
+                    "isValidationPaused": [Function],
+                    "mutators": Object {},
+                    "pauseValidation": [Function],
+                    "registerField": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                  }
+                }
+              >
+                <FormControls
+                  Button={[Function]}
+                  ButtonGroup={[Function]}
+                  FormSpy={[Function]}
+                  buttonOrder={
+                    Array [
+                      "submit",
+                      "reset",
+                      "cancel",
+                    ]
+                  }
+                  canReset={false}
+                  canSubmit={false}
+                  cancelLabel="Cancel"
+                  formSpyProps={
+                    Object {
+                      "active": undefined,
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
-                      "destroyOnUnregister": false,
+                      "dirty": false,
+                      "dirtyFields": Object {},
+                      "dirtyFieldsSinceLastSubmit": Object {},
+                      "dirtySinceLastSubmit": false,
+                      "error": undefined,
+                      "errors": Object {},
                       "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
+                      "form": Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "destroyOnUnregister": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "mutators": Object {},
+                        "pauseValidation": [Function],
+                        "registerField": [Function],
+                        "reset": [Function],
+                        "resetFieldState": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                      },
+                      "hasSubmitErrors": false,
+                      "hasValidationErrors": false,
+                      "initialValues": undefined,
                       "initialize": [Function],
-                      "isValidationPaused": [Function],
+                      "invalid": false,
+                      "modified": Object {},
                       "mutators": Object {},
-                      "pauseValidation": [Function],
-                      "registerField": [Function],
+                      "pristine": true,
                       "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                    },
-                    "hasSubmitErrors": false,
-                    "hasValidationErrors": false,
-                    "initialValues": undefined,
-                    "initialize": [Function],
-                    "invalid": false,
-                    "modified": Object {},
-                    "mutators": Object {},
-                    "pristine": true,
-                    "reset": [Function],
-                    "submitError": undefined,
-                    "submitErrors": undefined,
-                    "submitFailed": false,
-                    "submitSucceeded": false,
-                    "submitting": false,
-                    "touched": Object {},
-                    "valid": true,
-                    "validating": false,
-                    "values": Object {},
-                    "visited": Object {},
+                      "submitError": undefined,
+                      "submitErrors": undefined,
+                      "submitFailed": false,
+                      "submitSucceeded": false,
+                      "submitting": false,
+                      "touched": Object {},
+                      "valid": true,
+                      "validating": false,
+                      "values": Object {},
+                      "visited": Object {},
+                    }
                   }
-                }
-                onCancel={[MockFunction]}
-                onReset={[MockFunction]}
-                resetLabel="Reset"
-                submitLabel="Submit"
-              >
-                <ButtonGroup>
-                  <ActionGroup>
-                    <div
-                      className="pf-c-form__group pf-m-action"
-                    >
+                  onCancel={[MockFunction]}
+                  onReset={[MockFunction]}
+                  resetLabel="Reset"
+                  submitLabel="Submit"
+                >
+                  <ButtonGroup>
+                    <ActionGroup>
                       <div
-                        className="pf-c-form__actions"
+                        className="pf-c-form__group pf-m-action"
                       >
-                        <Button
-                          key="form-submit"
-                          label="Submit"
-                          type="submit"
-                          variant="primary"
+                        <div
+                          className="pf-c-form__actions"
                         >
-                          <Component
+                          <Button
+                            key="form-submit"
+                            label="Submit"
                             type="submit"
                             variant="primary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Submit",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "type": "submit",
-                                  "variant": "primary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              type="submit"
+                              variant="primary"
                             >
-                              <Button
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Submit",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "type": "submit",
+                                    "variant": "primary",
                                   }
                                 }
-                                type="submit"
-                                variant="primary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-primary"
-                                  disabled={false}
-                                  tabIndex={null}
+                                <Button
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="submit"
+                                  variant="primary"
                                 >
-                                  Submit
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                        <Button
-                          key="form-cancel"
-                          label="Cancel"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <Component
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-primary"
+                                    disabled={false}
+                                    tabIndex={null}
+                                    type="submit"
+                                  >
+                                    Submit
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                          <Button
+                            key="form-cancel"
+                            label="Cancel"
                             onClick={[Function]}
                             type="button"
-                            variant="secondary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Cancel",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              onClick={[Function]}
+                              type="button"
+                              variant="secondary"
                             >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Cancel",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "onClick": [Function],
+                                    "type": "button",
+                                    "variant": "secondary",
                                   }
                                 }
-                                type="button"
-                                variant="secondary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={false}
+                                <Button
                                   onClick={[Function]}
-                                  tabIndex={null}
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="button"
+                                  variant="secondary"
                                 >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-secondary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    tabIndex={null}
+                                    type="button"
+                                  >
+                                    Cancel
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                        </div>
                       </div>
-                    </div>
-                  </ActionGroup>
-                </ButtonGroup>
-              </FormControls>
-            </FormSpy>
-          </ReactFinalForm(FormSpy)>
-        </form>
-      </Form>
-    </Component>
-  </ReactFinalForm>
+                    </ActionGroup>
+                  </ButtonGroup>
+                </FormControls>
+              </FormSpy>
+            </ReactFinalForm(FormSpy)>
+          </form>
+        </Form>
+      </Component>
+    </ReactFinalForm>
+  </RenderWithProvider>
 </ContextWrapper>
 `;
 
 exports[`FormTemplate PF4 Common should render buttons in correct order 1`] = `
 <ContextWrapper>
-  <ReactFinalForm
-    onSubmit={[MockFunction]}
-  >
-    <Component
-      FormSpy={[Function]}
-      buttonOrder={
-        Array [
-          "cancel",
-          "submit",
-          "reset",
-        ]
-      }
-      canReset={true}
-      canSubmit={true}
-      formFields={
-        <div>
-          Formfields
-        </div>
-      }
-      formOptions={
-        Object {
+  <RenderWithProvider
+    value={
+      Object {
+        "formOptions": Object {
           "canReset": true,
           "onCancel": [MockFunction],
           "onReset": [MockFunction],
           "onSubmit": [MockFunction],
           "pristine": true,
-        }
+        },
       }
-      schema={Object {}}
+    }
+  >
+    <ReactFinalForm
+      onSubmit={[MockFunction]}
     >
-      <Form>
-        <form
-          className="pf-c-form"
-          noValidate={true}
-        >
+      <Component
+        FormSpy={[Function]}
+        buttonOrder={
+          Array [
+            "cancel",
+            "submit",
+            "reset",
+          ]
+        }
+        canReset={true}
+        canSubmit={true}
+        formFields={
           <div>
             Formfields
           </div>
-          <ReactFinalForm(FormSpy)>
-            <FormSpy
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {},
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
-            >
-              <FormControls
-                Button={[Function]}
-                ButtonGroup={[Function]}
-                FormSpy={[Function]}
-                buttonOrder={
-                  Array [
-                    "submit",
-                    "reset",
-                    "cancel",
-                  ]
-                }
-                canReset={false}
-                canSubmit={false}
-                cancelLabel="Cancel"
-                formSpyProps={
+        }
+        schema={Object {}}
+      >
+        <Form>
+          <form
+            className="pf-c-form"
+            noValidate={true}
+          >
+            <div>
+              Formfields
+            </div>
+            <ReactFinalForm(FormSpy)>
+              <FormSpy
+                reactFinalForm={
                   Object {
-                    "active": undefined,
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
-                    "dirty": false,
-                    "dirtyFields": Object {},
-                    "dirtyFieldsSinceLastSubmit": Object {},
-                    "dirtySinceLastSubmit": false,
-                    "error": undefined,
-                    "errors": Object {},
+                    "destroyOnUnregister": false,
                     "focus": [Function],
-                    "form": Object {
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "initialize": [Function],
+                    "isValidationPaused": [Function],
+                    "mutators": Object {},
+                    "pauseValidation": [Function],
+                    "registerField": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                  }
+                }
+              >
+                <FormControls
+                  Button={[Function]}
+                  ButtonGroup={[Function]}
+                  FormSpy={[Function]}
+                  buttonOrder={
+                    Array [
+                      "submit",
+                      "reset",
+                      "cancel",
+                    ]
+                  }
+                  canReset={false}
+                  canSubmit={false}
+                  cancelLabel="Cancel"
+                  formSpyProps={
+                    Object {
+                      "active": undefined,
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
-                      "destroyOnUnregister": false,
+                      "dirty": false,
+                      "dirtyFields": Object {},
+                      "dirtyFieldsSinceLastSubmit": Object {},
+                      "dirtySinceLastSubmit": false,
+                      "error": undefined,
+                      "errors": Object {},
                       "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
+                      "form": Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "destroyOnUnregister": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "mutators": Object {},
+                        "pauseValidation": [Function],
+                        "registerField": [Function],
+                        "reset": [Function],
+                        "resetFieldState": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                      },
+                      "hasSubmitErrors": false,
+                      "hasValidationErrors": false,
+                      "initialValues": undefined,
                       "initialize": [Function],
-                      "isValidationPaused": [Function],
+                      "invalid": false,
+                      "modified": Object {},
                       "mutators": Object {},
-                      "pauseValidation": [Function],
-                      "registerField": [Function],
+                      "pristine": true,
                       "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                    },
-                    "hasSubmitErrors": false,
-                    "hasValidationErrors": false,
-                    "initialValues": undefined,
-                    "initialize": [Function],
-                    "invalid": false,
-                    "modified": Object {},
-                    "mutators": Object {},
-                    "pristine": true,
-                    "reset": [Function],
-                    "submitError": undefined,
-                    "submitErrors": undefined,
-                    "submitFailed": false,
-                    "submitSucceeded": false,
-                    "submitting": false,
-                    "touched": Object {},
-                    "valid": true,
-                    "validating": false,
-                    "values": Object {},
-                    "visited": Object {},
+                      "submitError": undefined,
+                      "submitErrors": undefined,
+                      "submitFailed": false,
+                      "submitSucceeded": false,
+                      "submitting": false,
+                      "touched": Object {},
+                      "valid": true,
+                      "validating": false,
+                      "values": Object {},
+                      "visited": Object {},
+                    }
                   }
-                }
-                onCancel={[MockFunction]}
-                onReset={[MockFunction]}
-                resetLabel="Reset"
-                submitLabel="Submit"
-              >
-                <ButtonGroup>
-                  <ActionGroup>
-                    <div
-                      className="pf-c-form__group pf-m-action"
-                    >
+                  onCancel={[MockFunction]}
+                  onReset={[MockFunction]}
+                  resetLabel="Reset"
+                  submitLabel="Submit"
+                >
+                  <ButtonGroup>
+                    <ActionGroup>
                       <div
-                        className="pf-c-form__actions"
+                        className="pf-c-form__group pf-m-action"
                       >
-                        <Button
-                          key="form-submit"
-                          label="Submit"
-                          type="submit"
-                          variant="primary"
+                        <div
+                          className="pf-c-form__actions"
                         >
-                          <Component
+                          <Button
+                            key="form-submit"
+                            label="Submit"
                             type="submit"
                             variant="primary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Submit",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "type": "submit",
-                                  "variant": "primary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              type="submit"
+                              variant="primary"
                             >
-                              <Button
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Submit",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "type": "submit",
+                                    "variant": "primary",
                                   }
                                 }
-                                type="submit"
-                                variant="primary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-primary"
-                                  disabled={false}
-                                  tabIndex={null}
+                                <Button
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="submit"
+                                  variant="primary"
                                 >
-                                  Submit
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                        <Button
-                          key="form-cancel"
-                          label="Cancel"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <Component
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-primary"
+                                    disabled={false}
+                                    tabIndex={null}
+                                    type="submit"
+                                  >
+                                    Submit
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                          <Button
+                            key="form-cancel"
+                            label="Cancel"
                             onClick={[Function]}
                             type="button"
-                            variant="secondary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Cancel",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              onClick={[Function]}
+                              type="button"
+                              variant="secondary"
                             >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Cancel",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "onClick": [Function],
+                                    "type": "button",
+                                    "variant": "secondary",
                                   }
                                 }
-                                type="button"
-                                variant="secondary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={false}
+                                <Button
                                   onClick={[Function]}
-                                  tabIndex={null}
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="button"
+                                  variant="secondary"
                                 >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-secondary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    tabIndex={null}
+                                    type="button"
+                                  >
+                                    Cancel
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                        </div>
                       </div>
-                    </div>
-                  </ActionGroup>
-                </ButtonGroup>
-              </FormControls>
-            </FormSpy>
-          </ReactFinalForm(FormSpy)>
-        </form>
-      </Form>
-    </Component>
-  </ReactFinalForm>
+                    </ActionGroup>
+                  </ButtonGroup>
+                </FormControls>
+              </FormSpy>
+            </ReactFinalForm(FormSpy)>
+          </form>
+        </Form>
+      </Component>
+    </ReactFinalForm>
+  </RenderWithProvider>
 </ContextWrapper>
 `;
 
 exports[`FormTemplate PF4 Common should render only submit button 1`] = `
 <ContextWrapper>
-  <ReactFinalForm
-    onSubmit={[MockFunction]}
-  >
-    <Component
-      FormSpy={[Function]}
-      canReset={false}
-      formFields={
-        <div>
-          Formfields
-        </div>
-      }
-      formOptions={
-        Object {
+  <RenderWithProvider
+    value={
+      Object {
+        "formOptions": Object {
           "canReset": true,
           "onCancel": [MockFunction],
           "onReset": [MockFunction],
           "onSubmit": [MockFunction],
           "pristine": true,
-        }
+        },
       }
-      schema={Object {}}
+    }
+  >
+    <ReactFinalForm
+      onSubmit={[MockFunction]}
     >
-      <Form>
-        <form
-          className="pf-c-form"
-          noValidate={true}
-        >
+      <Component
+        FormSpy={[Function]}
+        canReset={false}
+        formFields={
           <div>
             Formfields
           </div>
-          <ReactFinalForm(FormSpy)>
-            <FormSpy
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {},
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
-            >
-              <FormControls
-                Button={[Function]}
-                ButtonGroup={[Function]}
-                FormSpy={[Function]}
-                buttonOrder={
-                  Array [
-                    "submit",
-                    "reset",
-                    "cancel",
-                  ]
-                }
-                canReset={false}
-                canSubmit={false}
-                cancelLabel="Cancel"
-                formSpyProps={
+        }
+        schema={Object {}}
+      >
+        <Form>
+          <form
+            className="pf-c-form"
+            noValidate={true}
+          >
+            <div>
+              Formfields
+            </div>
+            <ReactFinalForm(FormSpy)>
+              <FormSpy
+                reactFinalForm={
                   Object {
-                    "active": undefined,
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
-                    "dirty": false,
-                    "dirtyFields": Object {},
-                    "dirtyFieldsSinceLastSubmit": Object {},
-                    "dirtySinceLastSubmit": false,
-                    "error": undefined,
-                    "errors": Object {},
+                    "destroyOnUnregister": false,
                     "focus": [Function],
-                    "form": Object {
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "initialize": [Function],
+                    "isValidationPaused": [Function],
+                    "mutators": Object {},
+                    "pauseValidation": [Function],
+                    "registerField": [Function],
+                    "reset": [Function],
+                    "resetFieldState": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                  }
+                }
+              >
+                <FormControls
+                  Button={[Function]}
+                  ButtonGroup={[Function]}
+                  FormSpy={[Function]}
+                  buttonOrder={
+                    Array [
+                      "submit",
+                      "reset",
+                      "cancel",
+                    ]
+                  }
+                  canReset={false}
+                  canSubmit={false}
+                  cancelLabel="Cancel"
+                  formSpyProps={
+                    Object {
+                      "active": undefined,
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
-                      "destroyOnUnregister": false,
+                      "dirty": false,
+                      "dirtyFields": Object {},
+                      "dirtyFieldsSinceLastSubmit": Object {},
+                      "dirtySinceLastSubmit": false,
+                      "error": undefined,
+                      "errors": Object {},
                       "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
+                      "form": Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "destroyOnUnregister": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "mutators": Object {},
+                        "pauseValidation": [Function],
+                        "registerField": [Function],
+                        "reset": [Function],
+                        "resetFieldState": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                      },
+                      "hasSubmitErrors": false,
+                      "hasValidationErrors": false,
+                      "initialValues": undefined,
                       "initialize": [Function],
-                      "isValidationPaused": [Function],
+                      "invalid": false,
+                      "modified": Object {},
                       "mutators": Object {},
-                      "pauseValidation": [Function],
-                      "registerField": [Function],
+                      "pristine": true,
                       "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                    },
-                    "hasSubmitErrors": false,
-                    "hasValidationErrors": false,
-                    "initialValues": undefined,
-                    "initialize": [Function],
-                    "invalid": false,
-                    "modified": Object {},
-                    "mutators": Object {},
-                    "pristine": true,
-                    "reset": [Function],
-                    "submitError": undefined,
-                    "submitErrors": undefined,
-                    "submitFailed": false,
-                    "submitSucceeded": false,
-                    "submitting": false,
-                    "touched": Object {},
-                    "valid": true,
-                    "validating": false,
-                    "values": Object {},
-                    "visited": Object {},
+                      "submitError": undefined,
+                      "submitErrors": undefined,
+                      "submitFailed": false,
+                      "submitSucceeded": false,
+                      "submitting": false,
+                      "touched": Object {},
+                      "valid": true,
+                      "validating": false,
+                      "values": Object {},
+                      "visited": Object {},
+                    }
                   }
-                }
-                onCancel={[MockFunction]}
-                onReset={[MockFunction]}
-                resetLabel="Reset"
-                submitLabel="Submit"
-              >
-                <ButtonGroup>
-                  <ActionGroup>
-                    <div
-                      className="pf-c-form__group pf-m-action"
-                    >
+                  onCancel={[MockFunction]}
+                  onReset={[MockFunction]}
+                  resetLabel="Reset"
+                  submitLabel="Submit"
+                >
+                  <ButtonGroup>
+                    <ActionGroup>
                       <div
-                        className="pf-c-form__actions"
+                        className="pf-c-form__group pf-m-action"
                       >
-                        <Button
-                          key="form-submit"
-                          label="Submit"
-                          type="submit"
-                          variant="primary"
+                        <div
+                          className="pf-c-form__actions"
                         >
-                          <Component
+                          <Button
+                            key="form-submit"
+                            label="Submit"
                             type="submit"
                             variant="primary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Submit",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "type": "submit",
-                                  "variant": "primary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              type="submit"
+                              variant="primary"
                             >
-                              <Button
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Submit",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "type": "submit",
+                                    "variant": "primary",
                                   }
                                 }
-                                type="submit"
-                                variant="primary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-primary"
-                                  disabled={false}
-                                  tabIndex={null}
+                                <Button
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="submit"
+                                  variant="primary"
                                 >
-                                  Submit
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                        <Button
-                          key="form-cancel"
-                          label="Cancel"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <Component
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-primary"
+                                    disabled={false}
+                                    tabIndex={null}
+                                    type="submit"
+                                  >
+                                    Submit
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                          <Button
+                            key="form-cancel"
+                            label="Cancel"
                             onClick={[Function]}
                             type="button"
-                            variant="secondary"
                           >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Cancel",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
+                            <Component
+                              onClick={[Function]}
+                              type="button"
+                              variant="secondary"
                             >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
+                              <ComponentWithOuia
+                                component={[Function]}
+                                componentProps={
                                   Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
+                                    "children": Array [
+                                      "Cancel",
+                                      undefined,
+                                    ],
+                                    "isDisabled": undefined,
+                                    "onClick": [Function],
+                                    "type": "button",
+                                    "variant": "secondary",
                                   }
                                 }
-                                type="button"
-                                variant="secondary"
+                                consumerContext={null}
                               >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={false}
+                                <Button
                                   onClick={[Function]}
-                                  tabIndex={null}
+                                  ouiaContext={
+                                    Object {
+                                      "isOuia": false,
+                                      "ouiaId": null,
+                                    }
+                                  }
                                   type="button"
+                                  variant="secondary"
                                 >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
+                                  <button
+                                    aria-disabled={null}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-secondary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    tabIndex={null}
+                                    type="button"
+                                  >
+                                    Cancel
+                                  </button>
+                                </Button>
+                              </ComponentWithOuia>
+                            </Component>
+                          </Button>
+                        </div>
                       </div>
-                    </div>
-                  </ActionGroup>
-                </ButtonGroup>
-              </FormControls>
-            </FormSpy>
-          </ReactFinalForm(FormSpy)>
-        </form>
-      </Form>
-    </Component>
-  </ReactFinalForm>
+                    </ActionGroup>
+                  </ButtonGroup>
+                </FormControls>
+              </FormSpy>
+            </ReactFinalForm(FormSpy)>
+          </form>
+        </Form>
+      </Component>
+    </ReactFinalForm>
+  </RenderWithProvider>
 </ContextWrapper>
 `;

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/sub-form.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/sub-form.test.js.snap
@@ -1,68 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SubForm component should render SubForm correctly 1`] = `
-<Grid
-  gutter="md"
+<SubForm
+  fields={Array []}
   name="cosiName"
->
-  <GridItem
-    sm={12}
-  >
-    <Title
-      size="xl"
-    >
-      cosiTitle
-    </Title>
-  </GridItem>
-  <div>
-    Here would be form
-  </div>
-</Grid>
+  title="cosiTitle"
+/>
 `;
 
 exports[`SubForm component should render SubForm with description correctly 1`] = `
-<Grid
-  gutter="md"
+<SubForm
+  description="description here!"
+  fields={Array []}
   name="cosiName"
->
-  <GridItem
-    sm={12}
-  >
-    <Title
-      size="xl"
-    >
-      cosiTitle
-    </Title>
-  </GridItem>
-  <GridItem
-    sm={12}
-  >
-    <TextContent>
-      <Text
-        component="small"
-        style={
-          Object {
-            "marginBottom": 0,
-          }
-        }
-      >
-        description here!
-      </Text>
-    </TextContent>
-  </GridItem>
-  <div>
-    Here would be form
-  </div>
-</Grid>
+  title="cosiTitle"
+/>
 `;
 
 exports[`SubForm component should render SubForm without title correctly 1`] = `
-<Grid
-  gutter="md"
+<SubForm
+  fields={Array []}
   name="cosiName"
->
-  <div>
-    Here would be form
-  </div>
-</Grid>
+/>
 `;

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/tabs.test.js.snap
@@ -1,35 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs component should render tabs correctly 1`] = `
-<Component
-  activeKey={0}
-  onSelect={[Function]}
->
-  <Tab
-    eventKey={0}
-    key="cosiName"
-    title="cosiTitle"
-  >
-    <div
-      className="pf-c-form"
-    >
-      <div>
-        Here would be form
-      </div>
-    </div>
-  </Tab>
-  <Tab
-    eventKey={1}
-    key="cosiName2"
-    title="cosiTitle2"
-  >
-    <div
-      className="pf-c-form"
-    >
-      <div>
-        Here would be form
-      </div>
-    </div>
-  </Tab>
-</Component>
+<FormTabs
+  fields={
+    Array [
+      Object {
+        "fields": Array [],
+        "name": "cosiName",
+        "title": "cosiTitle",
+      },
+      Object {
+        "fields": Array [],
+        "name": "cosiName2",
+        "title": "cosiTitle2",
+      },
+    ]
+  }
+/>
 `;

--- a/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
@@ -103,48 +103,6 @@ exports[`FieldArray should render array field correctly 1`] = `
             </React.Fragment>,
           ]
         }
-        formOptions={
-          Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": undefined,
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          }
-        }
         schema={
           Object {
             "fields": Array [

--- a/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
@@ -187,48 +187,6 @@ exports[`FieldArray should render array field correctly 1`] = `
                       },
                     ]
                   }
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": undefined,
-                      "onReset": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
-                  }
                   name="foo"
                   validate={
                     Array [
@@ -236,7 +194,7 @@ exports[`FieldArray should render array field correctly 1`] = `
                     ]
                   }
                 >
-                  <FieldProvider
+                  <TemporaryWrapper
                     FieldArrayProvider={[Function]}
                     FieldProvider={[Function]}
                     arrayValidator={[Function]}
@@ -250,54 +208,13 @@ exports[`FieldArray should render array field correctly 1`] = `
                         },
                       ]
                     }
-                    formOptions={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "clearOnUnmount": false,
-                        "clearedValue": undefined,
-                        "concat": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "handleSubmit": [Function],
-                        "initialize": [Function],
-                        "insert": [Function],
-                        "isValidationPaused": [Function],
-                        "move": [Function],
-                        "onCancel": undefined,
-                        "onReset": undefined,
-                        "onSubmit": [MockFunction],
-                        "pauseValidation": [Function],
-                        "pop": [Function],
-                        "pristine": true,
-                        "push": [Function],
-                        "registerField": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "renderForm": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "shift": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                        "valid": true,
-                      }
-                    }
                     name="foo"
                   >
-                    <ReactFinalForm(Field)
+                    <FieldProvider
                       FieldArrayProvider={[Function]}
                       FieldProvider={[Function]}
                       arrayValidator={[Function]}
+                      component={[Function]}
                       fields={
                         Array [
                           Object {
@@ -350,9 +267,8 @@ exports[`FieldArray should render array field correctly 1`] = `
                         }
                       }
                       name="foo"
-                      render={[Function]}
                     >
-                      <Field
+                      <ReactFinalForm(Field)
                         FieldArrayProvider={[Function]}
                         FieldProvider={[Function]}
                         arrayValidator={[Function]}
@@ -407,47 +323,10 @@ exports[`FieldArray should render array field correctly 1`] = `
                             "valid": true,
                           }
                         }
-                        format={[Function]}
                         name="foo"
-                        parse={[Function]}
-                        reactFinalForm={
-                          Object {
-                            "batch": [Function],
-                            "blur": [Function],
-                            "change": [Function],
-                            "destroyOnUnregister": false,
-                            "focus": [Function],
-                            "getFieldState": [Function],
-                            "getRegisteredFields": [Function],
-                            "getState": [Function],
-                            "initialize": [Function],
-                            "isValidationPaused": [Function],
-                            "mutators": Object {
-                              "concat": [Function],
-                              "insert": [Function],
-                              "move": [Function],
-                              "pop": [Function],
-                              "push": [Function],
-                              "remove": [Function],
-                              "removeBatch": [Function],
-                              "shift": [Function],
-                              "swap": [Function],
-                              "unshift": [Function],
-                              "update": [Function],
-                            },
-                            "pauseValidation": [Function],
-                            "registerField": [Function],
-                            "reset": [Function],
-                            "resetFieldState": [Function],
-                            "resumeValidation": [Function],
-                            "setConfig": [Function],
-                            "submit": [Function],
-                            "subscribe": [Function],
-                          }
-                        }
                         render={[Function]}
                       >
-                        <DynamicArray
+                        <Field
                           FieldArrayProvider={[Function]}
                           FieldProvider={[Function]}
                           arrayValidator={[Function]}
@@ -502,162 +381,258 @@ exports[`FieldArray should render array field correctly 1`] = `
                               "valid": true,
                             }
                           }
-                          input={
+                          format={[Function]}
+                          name="foo"
+                          parse={[Function]}
+                          reactFinalForm={
                             Object {
-                              "name": "foo",
-                              "onBlur": [Function],
-                              "onChange": [Function],
-                              "onFocus": [Function],
-                              "value": "",
+                              "batch": [Function],
+                              "blur": [Function],
+                              "change": [Function],
+                              "destroyOnUnregister": false,
+                              "focus": [Function],
+                              "getFieldState": [Function],
+                              "getRegisteredFields": [Function],
+                              "getState": [Function],
+                              "initialize": [Function],
+                              "isValidationPaused": [Function],
+                              "mutators": Object {
+                                "concat": [Function],
+                                "insert": [Function],
+                                "move": [Function],
+                                "pop": [Function],
+                                "push": [Function],
+                                "remove": [Function],
+                                "removeBatch": [Function],
+                                "shift": [Function],
+                                "swap": [Function],
+                                "unshift": [Function],
+                                "update": [Function],
+                              },
+                              "pauseValidation": [Function],
+                              "registerField": [Function],
+                              "reset": [Function],
+                              "resetFieldState": [Function],
+                              "resumeValidation": [Function],
+                              "setConfig": [Function],
+                              "submit": [Function],
+                              "subscribe": [Function],
                             }
                           }
-                          maxItems={Infinity}
-                          meta={
-                            Object {
-                              "active": false,
-                              "data": Object {},
-                              "dirty": false,
-                              "dirtySinceLastSubmit": false,
-                              "error": undefined,
-                              "initial": undefined,
-                              "invalid": false,
-                              "modified": false,
-                              "pristine": true,
-                              "submitError": undefined,
-                              "submitFailed": false,
-                              "submitSucceeded": false,
-                              "submitting": false,
-                              "touched": false,
-                              "valid": true,
-                              "visited": false,
-                            }
-                          }
-                          minItems={0}
-                          noItemsMessage="No items added"
+                          render={[Function]}
                         >
-                          <ReactFinalForm(ReactFinalFormFieldArray(4.18.6)(2.0.1))
-                            key="foo"
-                            name="foo"
-                            validate={[Function]}
-                          >
-                            <ReactFinalFormFieldArray(4.18.6)(2.0.1)
-                              name="foo"
-                              reactFinalForm={
+                          <DynamicArray
+                            FieldArrayProvider={[Function]}
+                            FieldProvider={[Function]}
+                            arrayValidator={[Function]}
+                            fields={
+                              Array [
                                 Object {
-                                  "batch": [Function],
-                                  "blur": [Function],
-                                  "change": [Function],
-                                  "destroyOnUnregister": false,
-                                  "focus": [Function],
-                                  "getFieldState": [Function],
-                                  "getRegisteredFields": [Function],
-                                  "getState": [Function],
-                                  "initialize": [Function],
-                                  "isValidationPaused": [Function],
-                                  "mutators": Object {
-                                    "concat": [Function],
-                                    "insert": [Function],
-                                    "move": [Function],
-                                    "pop": [Function],
-                                    "push": [Function],
-                                    "remove": [Function],
-                                    "removeBatch": [Function],
-                                    "shift": [Function],
-                                    "swap": [Function],
-                                    "unshift": [Function],
-                                    "update": [Function],
-                                  },
-                                  "pauseValidation": [Function],
-                                  "registerField": [Function],
-                                  "reset": [Function],
-                                  "resetFieldState": [Function],
-                                  "resumeValidation": [Function],
-                                  "setConfig": [Function],
-                                  "submit": [Function],
-                                  "subscribe": [Function],
-                                }
+                                  "component": "text-field",
+                                  "label": "foo",
+                                  "name": "nested component",
+                                },
+                              ]
+                            }
+                            formOptions={
+                              Object {
+                                "batch": [Function],
+                                "blur": [Function],
+                                "change": [Function],
+                                "clearOnUnmount": false,
+                                "clearedValue": undefined,
+                                "concat": [Function],
+                                "destroyOnUnregister": false,
+                                "focus": [Function],
+                                "getFieldState": [Function],
+                                "getRegisteredFields": [Function],
+                                "getState": [Function],
+                                "handleSubmit": [Function],
+                                "initialize": [Function],
+                                "insert": [Function],
+                                "isValidationPaused": [Function],
+                                "move": [Function],
+                                "onCancel": undefined,
+                                "onReset": undefined,
+                                "onSubmit": [MockFunction],
+                                "pauseValidation": [Function],
+                                "pop": [Function],
+                                "pristine": true,
+                                "push": [Function],
+                                "registerField": [Function],
+                                "remove": [Function],
+                                "removeBatch": [Function],
+                                "renderForm": [Function],
+                                "reset": [Function],
+                                "resetFieldState": [Function],
+                                "resumeValidation": [Function],
+                                "setConfig": [Function],
+                                "shift": [Function],
+                                "submit": [Function],
+                                "subscribe": [Function],
+                                "swap": [Function],
+                                "unshift": [Function],
+                                "update": [Function],
+                                "valid": true,
                               }
+                            }
+                            input={
+                              Object {
+                                "name": "foo",
+                                "onBlur": [Function],
+                                "onChange": [Function],
+                                "onFocus": [Function],
+                                "value": "",
+                              }
+                            }
+                            maxItems={Infinity}
+                            meta={
+                              Object {
+                                "active": false,
+                                "data": Object {},
+                                "dirty": false,
+                                "dirtySinceLastSubmit": false,
+                                "error": undefined,
+                                "initial": undefined,
+                                "invalid": false,
+                                "modified": false,
+                                "pristine": true,
+                                "submitError": undefined,
+                                "submitFailed": false,
+                                "submitSucceeded": false,
+                                "submitting": false,
+                                "touched": false,
+                                "valid": true,
+                                "visited": false,
+                              }
+                            }
+                            minItems={0}
+                            noItemsMessage="No items added"
+                          >
+                            <ReactFinalForm(ReactFinalFormFieldArray(4.18.6)(2.0.1))
+                              key="foo"
+                              name="foo"
                               validate={[Function]}
                             >
-                              <Bullseye>
-                                <div
-                                  className="pf-l-bullseye"
-                                >
-                                  <GridItem
-                                    sm={12}
+                              <ReactFinalFormFieldArray(4.18.6)(2.0.1)
+                                name="foo"
+                                reactFinalForm={
+                                  Object {
+                                    "batch": [Function],
+                                    "blur": [Function],
+                                    "change": [Function],
+                                    "destroyOnUnregister": false,
+                                    "focus": [Function],
+                                    "getFieldState": [Function],
+                                    "getRegisteredFields": [Function],
+                                    "getState": [Function],
+                                    "initialize": [Function],
+                                    "isValidationPaused": [Function],
+                                    "mutators": Object {
+                                      "concat": [Function],
+                                      "insert": [Function],
+                                      "move": [Function],
+                                      "pop": [Function],
+                                      "push": [Function],
+                                      "remove": [Function],
+                                      "removeBatch": [Function],
+                                      "shift": [Function],
+                                      "swap": [Function],
+                                      "unshift": [Function],
+                                      "update": [Function],
+                                    },
+                                    "pauseValidation": [Function],
+                                    "registerField": [Function],
+                                    "reset": [Function],
+                                    "resetFieldState": [Function],
+                                    "resumeValidation": [Function],
+                                    "setConfig": [Function],
+                                    "submit": [Function],
+                                    "subscribe": [Function],
+                                  }
+                                }
+                                validate={[Function]}
+                              >
+                                <Bullseye>
+                                  <div
+                                    className="pf-l-bullseye"
                                   >
-                                    <div
-                                      className="pf-l-grid__item pf-m-12-col-on-sm"
+                                    <GridItem
+                                      sm={12}
                                     >
-                                      No items added
-                                    </div>
-                                  </GridItem>
-                                </div>
-                              </Bullseye>
-                              <Grid>
-                                <div
-                                  className="pf-l-grid"
-                                >
-                                  <GridItem
-                                    sm={11}
+                                      <div
+                                        className="pf-l-grid__item pf-m-12-col-on-sm"
+                                      >
+                                        No items added
+                                      </div>
+                                    </GridItem>
+                                  </div>
+                                </Bullseye>
+                                <Grid>
+                                  <div
+                                    className="pf-l-grid"
                                   >
-                                    <div
-                                      className="pf-l-grid__item pf-m-11-col-on-sm"
-                                    />
-                                  </GridItem>
-                                  <GridItem
-                                    className="final-form-array-add-container"
-                                    sm={1}
-                                  >
-                                    <div
-                                      className="pf-l-grid__item pf-m-1-col-on-sm final-form-array-add-container"
+                                    <GridItem
+                                      sm={11}
                                     >
-                                      <Bullseye>
-                                        <div
-                                          className="pf-l-bullseye"
-                                        >
-                                          <AddCircleOIcon
-                                            className="ddf-final-form-group-add-icon"
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            onClick={[Function]}
-                                            size="sm"
-                                            title={null}
+                                      <div
+                                        className="pf-l-grid__item pf-m-11-col-on-sm"
+                                      />
+                                    </GridItem>
+                                    <GridItem
+                                      className="final-form-array-add-container"
+                                      sm={1}
+                                    >
+                                      <div
+                                        className="pf-l-grid__item pf-m-1-col-on-sm final-form-array-add-container"
+                                      >
+                                        <Bullseye>
+                                          <div
+                                            className="pf-l-bullseye"
                                           >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
+                                            <AddCircleOIcon
                                               className="ddf-final-form-group-add-icon"
-                                              fill="currentColor"
-                                              height="1em"
+                                              color="currentColor"
+                                              noVerticalAlign={false}
                                               onClick={[Function]}
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 64 1024 1024"
-                                              width="1em"
+                                              size="sm"
+                                              title={null}
                                             >
-                                              <path
-                                                d="M512.059-73.143c-282.338 0-512.059 229.673-512.059 512.025 0 282.238 229.721 511.975 512.059 511.975 282.283 0 511.941-229.735 511.941-511.975 0.005-282.352-229.659-512.025-511.941-512.025zM512.059 826.523c-213.826 0-387.728-173.856-387.728-387.643 0-213.888 173.904-387.691 387.728-387.691 213.717 0 387.671 173.803 387.671 387.691 0.005 213.785-173.957 387.643-387.671 387.643zM726.283 506.777c-3.429 3.477-7.803 5.223-13.138 5.223h-128.005v128.007c0 5.333-1.739 9.71-5.218 13.138s-7.936 5.141-13.351 5.141h-109.143c-5.417 0-9.863-1.714-13.351-5.141-3.481-3.429-5.221-7.808-5.221-13.141v-128.005l-128.007-0.002c-5.333 0-9.71-1.737-13.138-5.218-3.426-3.477-5.141-7.934-5.141-13.351v-109.143c0-5.417 1.714-9.856 5.141-13.351 3.429-3.481 7.808-5.221 13.141-5.221l128.005 0.002v-128.009c0-5.335 1.744-9.707 5.225-13.134 3.477-3.429 7.927-5.145 13.344-5.145h109.143c5.417 0 9.858 1.717 13.351 5.145 3.477 3.429 5.223 7.803 5.223 13.138v128.002h128.007c5.335 0 9.707 1.742 13.134 5.225 3.429 3.477 5.145 7.927 5.145 13.344v109.143c0 5.417-1.717 9.863-5.145 13.351z"
-                                                transform="rotate(180 0 512) scale(-1 1)"
-                                              />
-                                            </svg>
-                                          </AddCircleOIcon>
-                                        </div>
-                                      </Bullseye>
-                                    </div>
-                                  </GridItem>
-                                </div>
-                              </Grid>
-                            </ReactFinalFormFieldArray(4.18.6)(2.0.1)>
-                          </ReactFinalForm(ReactFinalFormFieldArray(4.18.6)(2.0.1))>
-                        </DynamicArray>
-                      </Field>
-                    </ReactFinalForm(Field)>
-                  </FieldProvider>
+                                              <svg
+                                                aria-hidden={true}
+                                                aria-labelledby={null}
+                                                className="ddf-final-form-group-add-icon"
+                                                fill="currentColor"
+                                                height="1em"
+                                                onClick={[Function]}
+                                                role="img"
+                                                style={
+                                                  Object {
+                                                    "verticalAlign": "-0.125em",
+                                                  }
+                                                }
+                                                viewBox="0 64 1024 1024"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M512.059-73.143c-282.338 0-512.059 229.673-512.059 512.025 0 282.238 229.721 511.975 512.059 511.975 282.283 0 511.941-229.735 511.941-511.975 0.005-282.352-229.659-512.025-511.941-512.025zM512.059 826.523c-213.826 0-387.728-173.856-387.728-387.643 0-213.888 173.904-387.691 387.728-387.691 213.717 0 387.671 173.803 387.671 387.691 0.005 213.785-173.957 387.643-387.671 387.643zM726.283 506.777c-3.429 3.477-7.803 5.223-13.138 5.223h-128.005v128.007c0 5.333-1.739 9.71-5.218 13.138s-7.936 5.141-13.351 5.141h-109.143c-5.417 0-9.863-1.714-13.351-5.141-3.481-3.429-5.221-7.808-5.221-13.141v-128.005l-128.007-0.002c-5.333 0-9.71-1.737-13.138-5.218-3.426-3.477-5.141-7.934-5.141-13.351v-109.143c0-5.417 1.714-9.856 5.141-13.351 3.429-3.481 7.808-5.221 13.141-5.221l128.005 0.002v-128.009c0-5.335 1.744-9.707 5.225-13.134 3.477-3.429 7.927-5.145 13.344-5.145h109.143c5.417 0 9.858 1.717 13.351 5.145 3.477 3.429 5.223 7.803 5.223 13.138v128.002h128.007c5.335 0 9.707 1.742 13.134 5.225 3.429 3.477 5.145 7.927 5.145 13.344v109.143c0 5.417-1.717 9.863-5.145 13.351z"
+                                                  transform="rotate(180 0 512) scale(-1 1)"
+                                                />
+                                              </svg>
+                                            </AddCircleOIcon>
+                                          </div>
+                                        </Bullseye>
+                                      </div>
+                                    </GridItem>
+                                  </div>
+                                </Grid>
+                              </ReactFinalFormFieldArray(4.18.6)(2.0.1)>
+                            </ReactFinalForm(ReactFinalFormFieldArray(4.18.6)(2.0.1))>
+                          </DynamicArray>
+                        </Field>
+                      </ReactFinalForm(Field)>
+                    </FieldProvider>
+                  </TemporaryWrapper>
                 </FieldWrapper>
               </FormFieldHideWrapper>
             </FormConditionWrapper>

--- a/packages/pf4-component-mapper/src/tests/form-template-common.test.js
+++ b/packages/pf4-component-mapper/src/tests/form-template-common.test.js
@@ -4,16 +4,22 @@ import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { formTemplate } from '../index';
 import { Title, Description, Button } from '../components/form-template';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('FormTemplate PF4 Common', () => {
   let initialProps;
   let ContextWrapper;
   let FormTemplate;
+  let formOptions;
 
   beforeEach(() => {
-    ContextWrapper = ({ children, ...props }) => <Form onSubmit={jest.fn()}>{() => children}</Form>;
+    formOptions = { onSubmit: jest.fn(), onReset: jest.fn(), onCancel: jest.fn(), canReset: true, pristine: true };
+    ContextWrapper = ({ children, ...props }) => (
+      <RenderWithProvider value={{ formOptions }}>
+        <Form onSubmit={jest.fn()}>{() => children}</Form>
+      </RenderWithProvider>
+    );
     initialProps = {
-      formOptions: { onSubmit: jest.fn(), onReset: jest.fn(), onCancel: jest.fn(), canReset: true, pristine: true },
       formFields: <div>Formfields</div>,
       schema: {},
       FormSpy
@@ -105,9 +111,9 @@ describe('FormTemplate PF4 Common', () => {
     .last()
     .simulate('click');
 
-    expect(initialProps.formOptions.onSubmit).not.toHaveBeenCalled();
-    expect(initialProps.formOptions.onReset).not.toHaveBeenCalled();
-    expect(initialProps.formOptions.onCancel).toHaveBeenCalled();
+    expect(formOptions.onSubmit).not.toHaveBeenCalled();
+    expect(formOptions.onReset).not.toHaveBeenCalled();
+    expect(formOptions.onCancel).toHaveBeenCalled();
   });
 
   it('should render only submit button', () => {
@@ -173,6 +179,6 @@ describe('FormTemplate PF4 Common', () => {
     .at(CANCEL_INDEX)
     .simulate('click');
 
-    expect(initialProps.formOptions.onCancel).toHaveBeenCalledWith(expectedValues);
+    expect(formOptions.onCancel).toHaveBeenCalledWith(expectedValues);
   });
 });

--- a/packages/pf4-component-mapper/src/tests/sub-form.test.js
+++ b/packages/pf4-component-mapper/src/tests/sub-form.test.js
@@ -2,32 +2,46 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import SubForm from '../components/sub-form';
 import { shallow } from 'enzyme';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
 
 describe('SubForm component', () => {
   const props = {
     title: 'cosiTitle',
     name: 'cosiName',
-    fields: [],
-    formOptions: {
-      renderForm: () => <div>Here would be form</div>
-    }
+    fields: []
+  };
+
+  const formOptions = {
+    renderForm: () => <div>Here would be form</div>
   };
 
   it('should render SubForm correctly', () => {
-    const wrapper = shallow(<SubForm {...props} />);
+    const wrapper = shallow(
+      <RenderWithProvider value={{ formOptions }}>
+        <SubForm {...props} />
+      </RenderWithProvider>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render SubForm with description correctly', () => {
     const propsDescription = { ...props, description: 'description here!' };
-    const wrapper = shallow(<SubForm {...propsDescription} />);
+    const wrapper = shallow(
+      <RenderWithProvider value={{ formOptions }}>
+        <SubForm {...propsDescription} />
+      </RenderWithProvider>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render SubForm without title correctly', () => {
     const { name, fields, formOptions } = props;
     const propsWithoutTitle = { name, fields, formOptions };
-    const wrapper = shallow(<SubForm {...propsWithoutTitle} />);
+    const wrapper = shallow(
+      <RenderWithProvider value={{ formOptions }}>
+        <SubForm {...propsWithoutTitle} />
+      </RenderWithProvider>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/packages/pf4-component-mapper/src/tests/tabs.test.js
+++ b/packages/pf4-component-mapper/src/tests/tabs.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import Tabs from '../components/tabs';
 import { mount, shallow } from 'enzyme';
+import RenderWithProvider from '../../../../__mocks__/with-provider';
+import { Tabs as PF4Tabs } from '@patternfly/react-core/dist/js/components/Tabs/Tabs';
 
 describe('Tabs component', () => {
   const props = {
@@ -16,24 +18,42 @@ describe('Tabs component', () => {
         name: 'cosiName2',
         fields: []
       }
-    ],
-    formOptions: {
-      renderForm: (fields, formOptions) => <div>{'Here would be form'}</div>
-    }
+    ]
   };
 
   it('should render tabs correctly', () => {
-    const wrapper = shallow(<Tabs {...props}></Tabs>);
-    expect(toJson(wrapper)).toMatchSnapshot();
+    const wrapper = shallow(
+      <RenderWithProvider
+        value={{
+          formOptions: {
+            renderForm: (fields, formOptions) => <div>{'Here would be form'}</div>
+          }
+        }}
+      >
+        <Tabs {...props}></Tabs>
+      </RenderWithProvider>
+    );
+    expect(toJson(wrapper.dive())).toMatchSnapshot();
   });
 
   it('should switch tabs correctly', () => {
-    const wrapper = mount(<Tabs {...props} />);
-    expect(wrapper.instance().state.activeTabKey).toEqual(0);
+    const wrapper = mount(
+      <RenderWithProvider
+        value={{
+          formOptions: {
+            renderForm: (fields, formOptions) => <div>{'Here would be form'}</div>
+          }
+        }}
+      >
+        <Tabs {...props}></Tabs>
+      </RenderWithProvider>
+    );
+
+    expect(wrapper.find(PF4Tabs).props().activeKey).toEqual(0);
 
     const secondTabButton = wrapper.find('.pf-c-tabs__button').at(6);
     secondTabButton.simulate('click');
 
-    expect(wrapper.instance().state.activeTabKey).toEqual(1);
+    expect(wrapper.find(PF4Tabs).props().activeKey).toEqual(1);
   });
 });

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -59,7 +59,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
       ],
     }
   }
-  showFormControls={false}
 >
   <ReactFinalForm
     decorators={
@@ -224,48 +223,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                     },
                   ]
                 }
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": [MockFunction],
-                    "onReset": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
                 name="wizard"
                 validate={
                   Array [
@@ -303,48 +260,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                         "title": "bar-step",
                       },
                     ]
-                  }
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": [MockFunction],
-                      "onReset": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
                   }
                   name="wizard"
                   validate={[Function]}
@@ -752,48 +667,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                         <FieldWrapper
                                           component={[Function]}
                                           componentType="text-field"
-                                          formOptions={
-                                            Object {
-                                              "batch": [Function],
-                                              "blur": [Function],
-                                              "change": [Function],
-                                              "clearOnUnmount": false,
-                                              "clearedValue": undefined,
-                                              "concat": [Function],
-                                              "destroyOnUnregister": false,
-                                              "focus": [Function],
-                                              "getFieldState": [Function],
-                                              "getRegisteredFields": [Function],
-                                              "getState": [Function],
-                                              "handleSubmit": [Function],
-                                              "initialize": [Function],
-                                              "insert": [Function],
-                                              "isValidationPaused": [Function],
-                                              "move": [Function],
-                                              "onCancel": [MockFunction],
-                                              "onReset": undefined,
-                                              "onSubmit": [MockFunction],
-                                              "pauseValidation": [Function],
-                                              "pop": [Function],
-                                              "pristine": true,
-                                              "push": [Function],
-                                              "registerField": [Function],
-                                              "remove": [Function],
-                                              "removeBatch": [Function],
-                                              "renderForm": [Function],
-                                              "reset": [Function],
-                                              "resetFieldState": [Function],
-                                              "resumeValidation": [Function],
-                                              "setConfig": [Function],
-                                              "shift": [Function],
-                                              "submit": [Function],
-                                              "subscribe": [Function],
-                                              "swap": [Function],
-                                              "unshift": [Function],
-                                              "update": [Function],
-                                              "valid": true,
-                                            }
-                                          }
                                           name="foo-field"
                                           validate={
                                             Array [
@@ -801,58 +674,17 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                             ]
                                           }
                                         >
-                                          <FieldProvider
+                                          <TemporaryWrapper
                                             FieldArrayProvider={[Function]}
                                             FieldProvider={[Function]}
                                             component={[Function]}
-                                            formOptions={
-                                              Object {
-                                                "batch": [Function],
-                                                "blur": [Function],
-                                                "change": [Function],
-                                                "clearOnUnmount": false,
-                                                "clearedValue": undefined,
-                                                "concat": [Function],
-                                                "destroyOnUnregister": false,
-                                                "focus": [Function],
-                                                "getFieldState": [Function],
-                                                "getRegisteredFields": [Function],
-                                                "getState": [Function],
-                                                "handleSubmit": [Function],
-                                                "initialize": [Function],
-                                                "insert": [Function],
-                                                "isValidationPaused": [Function],
-                                                "move": [Function],
-                                                "onCancel": [MockFunction],
-                                                "onReset": undefined,
-                                                "onSubmit": [MockFunction],
-                                                "pauseValidation": [Function],
-                                                "pop": [Function],
-                                                "pristine": true,
-                                                "push": [Function],
-                                                "registerField": [Function],
-                                                "remove": [Function],
-                                                "removeBatch": [Function],
-                                                "renderForm": [Function],
-                                                "reset": [Function],
-                                                "resetFieldState": [Function],
-                                                "resumeValidation": [Function],
-                                                "setConfig": [Function],
-                                                "shift": [Function],
-                                                "submit": [Function],
-                                                "subscribe": [Function],
-                                                "swap": [Function],
-                                                "unshift": [Function],
-                                                "update": [Function],
-                                                "valid": true,
-                                              }
-                                            }
                                             name="foo-field"
                                             validate={[Function]}
                                           >
-                                            <ReactFinalForm(Field)
+                                            <FieldProvider
                                               FieldArrayProvider={[Function]}
                                               FieldProvider={[Function]}
+                                              component={[Function]}
                                               formOptions={
                                                 Object {
                                                   "batch": [Function],
@@ -896,10 +728,9 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 }
                                               }
                                               name="foo-field"
-                                              render={[Function]}
                                               validate={[Function]}
                                             >
-                                              <Field
+                                              <ReactFinalForm(Field)
                                                 FieldArrayProvider={[Function]}
                                                 FieldProvider={[Function]}
                                                 formOptions={
@@ -944,48 +775,11 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                     "valid": true,
                                                   }
                                                 }
-                                                format={[Function]}
                                                 name="foo-field"
-                                                parse={[Function]}
-                                                reactFinalForm={
-                                                  Object {
-                                                    "batch": [Function],
-                                                    "blur": [Function],
-                                                    "change": [Function],
-                                                    "destroyOnUnregister": false,
-                                                    "focus": [Function],
-                                                    "getFieldState": [Function],
-                                                    "getRegisteredFields": [Function],
-                                                    "getState": [Function],
-                                                    "initialize": [Function],
-                                                    "isValidationPaused": [Function],
-                                                    "mutators": Object {
-                                                      "concat": [Function],
-                                                      "insert": [Function],
-                                                      "move": [Function],
-                                                      "pop": [Function],
-                                                      "push": [Function],
-                                                      "remove": [Function],
-                                                      "removeBatch": [Function],
-                                                      "shift": [Function],
-                                                      "swap": [Function],
-                                                      "unshift": [Function],
-                                                      "update": [Function],
-                                                    },
-                                                    "pauseValidation": [Function],
-                                                    "registerField": [Function],
-                                                    "reset": [Function],
-                                                    "resetFieldState": [Function],
-                                                    "resumeValidation": [Function],
-                                                    "setConfig": [Function],
-                                                    "submit": [Function],
-                                                    "subscribe": [Function],
-                                                  }
-                                                }
                                                 render={[Function]}
                                                 validate={[Function]}
                                               >
-                                                <TextField
+                                                <Field
                                                   FieldArrayProvider={[Function]}
                                                   FieldProvider={[Function]}
                                                   formOptions={
@@ -1030,39 +824,101 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                       "valid": true,
                                                     }
                                                   }
-                                                  input={
+                                                  format={[Function]}
+                                                  name="foo-field"
+                                                  parse={[Function]}
+                                                  reactFinalForm={
                                                     Object {
-                                                      "name": "foo-field",
-                                                      "onBlur": [Function],
-                                                      "onChange": [Function],
-                                                      "onFocus": [Function],
-                                                      "value": "",
+                                                      "batch": [Function],
+                                                      "blur": [Function],
+                                                      "change": [Function],
+                                                      "destroyOnUnregister": false,
+                                                      "focus": [Function],
+                                                      "getFieldState": [Function],
+                                                      "getRegisteredFields": [Function],
+                                                      "getState": [Function],
+                                                      "initialize": [Function],
+                                                      "isValidationPaused": [Function],
+                                                      "mutators": Object {
+                                                        "concat": [Function],
+                                                        "insert": [Function],
+                                                        "move": [Function],
+                                                        "pop": [Function],
+                                                        "push": [Function],
+                                                        "remove": [Function],
+                                                        "removeBatch": [Function],
+                                                        "shift": [Function],
+                                                        "swap": [Function],
+                                                        "unshift": [Function],
+                                                        "update": [Function],
+                                                      },
+                                                      "pauseValidation": [Function],
+                                                      "registerField": [Function],
+                                                      "reset": [Function],
+                                                      "resetFieldState": [Function],
+                                                      "resumeValidation": [Function],
+                                                      "setConfig": [Function],
+                                                      "submit": [Function],
+                                                      "subscribe": [Function],
                                                     }
                                                   }
-                                                  meta={
-                                                    Object {
-                                                      "active": false,
-                                                      "data": Object {},
-                                                      "dirty": false,
-                                                      "dirtySinceLastSubmit": false,
-                                                      "error": undefined,
-                                                      "initial": undefined,
-                                                      "invalid": false,
-                                                      "modified": false,
-                                                      "pristine": true,
-                                                      "submitError": undefined,
-                                                      "submitFailed": false,
-                                                      "submitSucceeded": false,
-                                                      "submitting": false,
-                                                      "touched": false,
-                                                      "valid": true,
-                                                      "visited": false,
-                                                    }
-                                                  }
+                                                  render={[Function]}
+                                                  validate={[Function]}
                                                 >
-                                                  <FormGroup
-                                                    id="foo-field"
-                                                    isRequired={false}
+                                                  <TextField
+                                                    FieldArrayProvider={[Function]}
+                                                    FieldProvider={[Function]}
+                                                    formOptions={
+                                                      Object {
+                                                        "batch": [Function],
+                                                        "blur": [Function],
+                                                        "change": [Function],
+                                                        "clearOnUnmount": false,
+                                                        "clearedValue": undefined,
+                                                        "concat": [Function],
+                                                        "destroyOnUnregister": false,
+                                                        "focus": [Function],
+                                                        "getFieldState": [Function],
+                                                        "getRegisteredFields": [Function],
+                                                        "getState": [Function],
+                                                        "handleSubmit": [Function],
+                                                        "initialize": [Function],
+                                                        "insert": [Function],
+                                                        "isValidationPaused": [Function],
+                                                        "move": [Function],
+                                                        "onCancel": [MockFunction],
+                                                        "onReset": undefined,
+                                                        "onSubmit": [MockFunction],
+                                                        "pauseValidation": [Function],
+                                                        "pop": [Function],
+                                                        "pristine": true,
+                                                        "push": [Function],
+                                                        "registerField": [Function],
+                                                        "remove": [Function],
+                                                        "removeBatch": [Function],
+                                                        "renderForm": [Function],
+                                                        "reset": [Function],
+                                                        "resetFieldState": [Function],
+                                                        "resumeValidation": [Function],
+                                                        "setConfig": [Function],
+                                                        "shift": [Function],
+                                                        "submit": [Function],
+                                                        "subscribe": [Function],
+                                                        "swap": [Function],
+                                                        "unshift": [Function],
+                                                        "update": [Function],
+                                                        "valid": true,
+                                                      }
+                                                    }
+                                                    input={
+                                                      Object {
+                                                        "name": "foo-field",
+                                                        "onBlur": [Function],
+                                                        "onChange": [Function],
+                                                        "onFocus": [Function],
+                                                        "value": "",
+                                                      }
+                                                    }
                                                     meta={
                                                       Object {
                                                         "active": false,
@@ -1085,70 +941,40 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                     }
                                                   >
                                                     <FormGroup
-                                                      fieldId="foo-field"
+                                                      id="foo-field"
                                                       isRequired={false}
-                                                      isValid={true}
+                                                      meta={
+                                                        Object {
+                                                          "active": false,
+                                                          "data": Object {},
+                                                          "dirty": false,
+                                                          "dirtySinceLastSubmit": false,
+                                                          "error": undefined,
+                                                          "initial": undefined,
+                                                          "invalid": false,
+                                                          "modified": false,
+                                                          "pristine": true,
+                                                          "submitError": undefined,
+                                                          "submitFailed": false,
+                                                          "submitSucceeded": false,
+                                                          "submitting": false,
+                                                          "touched": false,
+                                                          "valid": true,
+                                                          "visited": false,
+                                                        }
+                                                      }
                                                     >
-                                                      <div
-                                                        className="pf-c-form__group"
+                                                      <FormGroup
+                                                        fieldId="foo-field"
+                                                        isRequired={false}
+                                                        isValid={true}
                                                       >
-                                                        <ForwardRef
-                                                          FieldArrayProvider={[Function]}
-                                                          FieldProvider={[Function]}
-                                                          formOptions={
-                                                            Object {
-                                                              "batch": [Function],
-                                                              "blur": [Function],
-                                                              "change": [Function],
-                                                              "clearOnUnmount": false,
-                                                              "clearedValue": undefined,
-                                                              "concat": [Function],
-                                                              "destroyOnUnregister": false,
-                                                              "focus": [Function],
-                                                              "getFieldState": [Function],
-                                                              "getRegisteredFields": [Function],
-                                                              "getState": [Function],
-                                                              "handleSubmit": [Function],
-                                                              "initialize": [Function],
-                                                              "insert": [Function],
-                                                              "isValidationPaused": [Function],
-                                                              "move": [Function],
-                                                              "onCancel": [MockFunction],
-                                                              "onReset": undefined,
-                                                              "onSubmit": [MockFunction],
-                                                              "pauseValidation": [Function],
-                                                              "pop": [Function],
-                                                              "pristine": true,
-                                                              "push": [Function],
-                                                              "registerField": [Function],
-                                                              "remove": [Function],
-                                                              "removeBatch": [Function],
-                                                              "renderForm": [Function],
-                                                              "reset": [Function],
-                                                              "resetFieldState": [Function],
-                                                              "resumeValidation": [Function],
-                                                              "setConfig": [Function],
-                                                              "shift": [Function],
-                                                              "submit": [Function],
-                                                              "subscribe": [Function],
-                                                              "swap": [Function],
-                                                              "unshift": [Function],
-                                                              "update": [Function],
-                                                              "valid": true,
-                                                            }
-                                                          }
-                                                          id="foo-field"
-                                                          name="foo-field"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          onFocus={[Function]}
-                                                          value=""
+                                                        <div
+                                                          className="pf-c-form__group"
                                                         >
-                                                          <TextInputBase
+                                                          <ForwardRef
                                                             FieldArrayProvider={[Function]}
                                                             FieldProvider={[Function]}
-                                                            aria-label={null}
-                                                            className=""
                                                             formOptions={
                                                               Object {
                                                                 "batch": [Function],
@@ -1192,26 +1018,17 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                               }
                                                             }
                                                             id="foo-field"
-                                                            innerRef={null}
-                                                            isDisabled={false}
-                                                            isReadOnly={false}
-                                                            isRequired={false}
-                                                            isValid={true}
                                                             name="foo-field"
                                                             onBlur={[Function]}
                                                             onChange={[Function]}
                                                             onFocus={[Function]}
-                                                            type="text"
-                                                            validated="default"
                                                             value=""
                                                           >
-                                                            <input
+                                                            <TextInputBase
                                                               FieldArrayProvider={[Function]}
                                                               FieldProvider={[Function]}
-                                                              aria-invalid={false}
                                                               aria-label={null}
-                                                              className="pf-c-form-control"
-                                                              disabled={false}
+                                                              className=""
                                                               formOptions={
                                                                 Object {
                                                                   "batch": [Function],
@@ -1255,24 +1072,88 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                                 }
                                                               }
                                                               id="foo-field"
+                                                              innerRef={null}
+                                                              isDisabled={false}
+                                                              isReadOnly={false}
+                                                              isRequired={false}
+                                                              isValid={true}
                                                               name="foo-field"
                                                               onBlur={[Function]}
                                                               onChange={[Function]}
                                                               onFocus={[Function]}
-                                                              readOnly={false}
-                                                              required={false}
                                                               type="text"
+                                                              validated="default"
                                                               value=""
-                                                            />
-                                                          </TextInputBase>
-                                                        </ForwardRef>
-                                                      </div>
+                                                            >
+                                                              <input
+                                                                FieldArrayProvider={[Function]}
+                                                                FieldProvider={[Function]}
+                                                                aria-invalid={false}
+                                                                aria-label={null}
+                                                                className="pf-c-form-control"
+                                                                disabled={false}
+                                                                formOptions={
+                                                                  Object {
+                                                                    "batch": [Function],
+                                                                    "blur": [Function],
+                                                                    "change": [Function],
+                                                                    "clearOnUnmount": false,
+                                                                    "clearedValue": undefined,
+                                                                    "concat": [Function],
+                                                                    "destroyOnUnregister": false,
+                                                                    "focus": [Function],
+                                                                    "getFieldState": [Function],
+                                                                    "getRegisteredFields": [Function],
+                                                                    "getState": [Function],
+                                                                    "handleSubmit": [Function],
+                                                                    "initialize": [Function],
+                                                                    "insert": [Function],
+                                                                    "isValidationPaused": [Function],
+                                                                    "move": [Function],
+                                                                    "onCancel": [MockFunction],
+                                                                    "onReset": undefined,
+                                                                    "onSubmit": [MockFunction],
+                                                                    "pauseValidation": [Function],
+                                                                    "pop": [Function],
+                                                                    "pristine": true,
+                                                                    "push": [Function],
+                                                                    "registerField": [Function],
+                                                                    "remove": [Function],
+                                                                    "removeBatch": [Function],
+                                                                    "renderForm": [Function],
+                                                                    "reset": [Function],
+                                                                    "resetFieldState": [Function],
+                                                                    "resumeValidation": [Function],
+                                                                    "setConfig": [Function],
+                                                                    "shift": [Function],
+                                                                    "submit": [Function],
+                                                                    "subscribe": [Function],
+                                                                    "swap": [Function],
+                                                                    "unshift": [Function],
+                                                                    "update": [Function],
+                                                                    "valid": true,
+                                                                  }
+                                                                }
+                                                                id="foo-field"
+                                                                name="foo-field"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                onFocus={[Function]}
+                                                                readOnly={false}
+                                                                required={false}
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </TextInputBase>
+                                                          </ForwardRef>
+                                                        </div>
+                                                      </FormGroup>
                                                     </FormGroup>
-                                                  </FormGroup>
-                                                </TextField>
-                                              </Field>
-                                            </ReactFinalForm(Field)>
-                                          </FieldProvider>
+                                                  </TextField>
+                                                </Field>
+                                              </ReactFinalForm(Field)>
+                                            </FieldProvider>
+                                          </TemporaryWrapper>
                                         </FieldWrapper>
                                       </FormFieldHideWrapper>
                                     </FormConditionWrapper>
@@ -1526,264 +1407,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
               </FieldWrapper>
             </FormFieldHideWrapper>
           </FormConditionWrapper>
-          <ReactFinalForm(FormSpy)>
-            <FormSpy
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {
-                    "concat": [Function],
-                    "insert": [Function],
-                    "move": [Function],
-                    "pop": [Function],
-                    "push": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "shift": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                  },
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
-            >
-              <FormControls
-                Button={[Function]}
-                ButtonGroup={[Function]}
-                FormSpy={[Function]}
-                buttonOrder={
-                  Array [
-                    "submit",
-                    "reset",
-                    "cancel",
-                  ]
-                }
-                canReset={false}
-                canSubmit={false}
-                cancelLabel="Cancel"
-                formSpyProps={
-                  Object {
-                    "active": undefined,
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "dirty": false,
-                    "dirtyFields": Object {},
-                    "dirtyFieldsSinceLastSubmit": Object {},
-                    "dirtySinceLastSubmit": false,
-                    "error": undefined,
-                    "errors": Object {},
-                    "focus": [Function],
-                    "form": Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "initialize": [Function],
-                      "isValidationPaused": [Function],
-                      "mutators": Object {
-                        "concat": [Function],
-                        "insert": [Function],
-                        "move": [Function],
-                        "pop": [Function],
-                        "push": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "shift": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                      },
-                      "pauseValidation": [Function],
-                      "registerField": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                    },
-                    "hasSubmitErrors": false,
-                    "hasValidationErrors": false,
-                    "initialValues": Object {},
-                    "initialize": [Function],
-                    "invalid": false,
-                    "modified": Object {
-                      "foo-field": false,
-                    },
-                    "mutators": Object {
-                      "concat": [Function],
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pristine": true,
-                    "reset": [Function],
-                    "submitError": undefined,
-                    "submitErrors": undefined,
-                    "submitFailed": false,
-                    "submitSucceeded": false,
-                    "submitting": false,
-                    "touched": Object {
-                      "foo-field": false,
-                    },
-                    "valid": true,
-                    "validating": false,
-                    "values": Object {},
-                    "visited": Object {
-                      "foo-field": false,
-                    },
-                  }
-                }
-                onCancel={[MockFunction]}
-                resetLabel="Reset"
-                submitLabel="Submit"
-              >
-                <ButtonGroup>
-                  <ActionGroup>
-                    <div
-                      className="pf-c-form__group pf-m-action"
-                    >
-                      <div
-                        className="pf-c-form__actions"
-                      >
-                        <Button
-                          key="form-submit"
-                          label="Submit"
-                          type="submit"
-                          variant="primary"
-                        >
-                          <Component
-                            type="submit"
-                            variant="primary"
-                          >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Submit",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "type": "submit",
-                                  "variant": "primary",
-                                }
-                              }
-                              consumerContext={null}
-                            >
-                              <Button
-                                ouiaContext={
-                                  Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
-                                  }
-                                }
-                                type="submit"
-                                variant="primary"
-                              >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-primary"
-                                  disabled={false}
-                                  tabIndex={null}
-                                  type="submit"
-                                >
-                                  Submit
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                        <Button
-                          key="form-cancel"
-                          label="Cancel"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <Component
-                            onClick={[Function]}
-                            type="button"
-                            variant="secondary"
-                          >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Cancel",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
-                            >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
-                                  Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
-                                  }
-                                }
-                                type="button"
-                                variant="secondary"
-                              >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={null}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                      </div>
-                    </div>
-                  </ActionGroup>
-                </ButtonGroup>
-              </FormControls>
-            </FormSpy>
-          </ReactFinalForm(FormSpy)>
         </form>
       </Form>
     </Component>
@@ -1853,7 +1476,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
       ],
     }
   }
-  showFormControls={false}
 >
   <ReactFinalForm
     decorators={
@@ -2019,48 +1641,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                     },
                   ]
                 }
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": [MockFunction],
-                    "onReset": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
                 inModal={true}
                 name="wizard"
                 validate={
@@ -2099,48 +1679,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                         "title": "bar-step",
                       },
                     ]
-                  }
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": [MockFunction],
-                      "onReset": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
                   }
                   inModal={true}
                   name="wizard"
@@ -2767,48 +2305,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                   <FieldWrapper
                                                     component={[Function]}
                                                     componentType="text-field"
-                                                    formOptions={
-                                                      Object {
-                                                        "batch": [Function],
-                                                        "blur": [Function],
-                                                        "change": [Function],
-                                                        "clearOnUnmount": false,
-                                                        "clearedValue": undefined,
-                                                        "concat": [Function],
-                                                        "destroyOnUnregister": false,
-                                                        "focus": [Function],
-                                                        "getFieldState": [Function],
-                                                        "getRegisteredFields": [Function],
-                                                        "getState": [Function],
-                                                        "handleSubmit": [Function],
-                                                        "initialize": [Function],
-                                                        "insert": [Function],
-                                                        "isValidationPaused": [Function],
-                                                        "move": [Function],
-                                                        "onCancel": [MockFunction],
-                                                        "onReset": undefined,
-                                                        "onSubmit": [MockFunction],
-                                                        "pauseValidation": [Function],
-                                                        "pop": [Function],
-                                                        "pristine": true,
-                                                        "push": [Function],
-                                                        "registerField": [Function],
-                                                        "remove": [Function],
-                                                        "removeBatch": [Function],
-                                                        "renderForm": [Function],
-                                                        "reset": [Function],
-                                                        "resetFieldState": [Function],
-                                                        "resumeValidation": [Function],
-                                                        "setConfig": [Function],
-                                                        "shift": [Function],
-                                                        "submit": [Function],
-                                                        "subscribe": [Function],
-                                                        "swap": [Function],
-                                                        "unshift": [Function],
-                                                        "update": [Function],
-                                                        "valid": true,
-                                                      }
-                                                    }
                                                     name="foo-field"
                                                     validate={
                                                       Array [
@@ -2816,58 +2312,17 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                       ]
                                                     }
                                                   >
-                                                    <FieldProvider
+                                                    <TemporaryWrapper
                                                       FieldArrayProvider={[Function]}
                                                       FieldProvider={[Function]}
                                                       component={[Function]}
-                                                      formOptions={
-                                                        Object {
-                                                          "batch": [Function],
-                                                          "blur": [Function],
-                                                          "change": [Function],
-                                                          "clearOnUnmount": false,
-                                                          "clearedValue": undefined,
-                                                          "concat": [Function],
-                                                          "destroyOnUnregister": false,
-                                                          "focus": [Function],
-                                                          "getFieldState": [Function],
-                                                          "getRegisteredFields": [Function],
-                                                          "getState": [Function],
-                                                          "handleSubmit": [Function],
-                                                          "initialize": [Function],
-                                                          "insert": [Function],
-                                                          "isValidationPaused": [Function],
-                                                          "move": [Function],
-                                                          "onCancel": [MockFunction],
-                                                          "onReset": undefined,
-                                                          "onSubmit": [MockFunction],
-                                                          "pauseValidation": [Function],
-                                                          "pop": [Function],
-                                                          "pristine": true,
-                                                          "push": [Function],
-                                                          "registerField": [Function],
-                                                          "remove": [Function],
-                                                          "removeBatch": [Function],
-                                                          "renderForm": [Function],
-                                                          "reset": [Function],
-                                                          "resetFieldState": [Function],
-                                                          "resumeValidation": [Function],
-                                                          "setConfig": [Function],
-                                                          "shift": [Function],
-                                                          "submit": [Function],
-                                                          "subscribe": [Function],
-                                                          "swap": [Function],
-                                                          "unshift": [Function],
-                                                          "update": [Function],
-                                                          "valid": true,
-                                                        }
-                                                      }
                                                       name="foo-field"
                                                       validate={[Function]}
                                                     >
-                                                      <ReactFinalForm(Field)
+                                                      <FieldProvider
                                                         FieldArrayProvider={[Function]}
                                                         FieldProvider={[Function]}
+                                                        component={[Function]}
                                                         formOptions={
                                                           Object {
                                                             "batch": [Function],
@@ -2911,10 +2366,9 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                           }
                                                         }
                                                         name="foo-field"
-                                                        render={[Function]}
                                                         validate={[Function]}
                                                       >
-                                                        <Field
+                                                        <ReactFinalForm(Field)
                                                           FieldArrayProvider={[Function]}
                                                           FieldProvider={[Function]}
                                                           formOptions={
@@ -2959,48 +2413,11 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                               "valid": true,
                                                             }
                                                           }
-                                                          format={[Function]}
                                                           name="foo-field"
-                                                          parse={[Function]}
-                                                          reactFinalForm={
-                                                            Object {
-                                                              "batch": [Function],
-                                                              "blur": [Function],
-                                                              "change": [Function],
-                                                              "destroyOnUnregister": false,
-                                                              "focus": [Function],
-                                                              "getFieldState": [Function],
-                                                              "getRegisteredFields": [Function],
-                                                              "getState": [Function],
-                                                              "initialize": [Function],
-                                                              "isValidationPaused": [Function],
-                                                              "mutators": Object {
-                                                                "concat": [Function],
-                                                                "insert": [Function],
-                                                                "move": [Function],
-                                                                "pop": [Function],
-                                                                "push": [Function],
-                                                                "remove": [Function],
-                                                                "removeBatch": [Function],
-                                                                "shift": [Function],
-                                                                "swap": [Function],
-                                                                "unshift": [Function],
-                                                                "update": [Function],
-                                                              },
-                                                              "pauseValidation": [Function],
-                                                              "registerField": [Function],
-                                                              "reset": [Function],
-                                                              "resetFieldState": [Function],
-                                                              "resumeValidation": [Function],
-                                                              "setConfig": [Function],
-                                                              "submit": [Function],
-                                                              "subscribe": [Function],
-                                                            }
-                                                          }
                                                           render={[Function]}
                                                           validate={[Function]}
                                                         >
-                                                          <TextField
+                                                          <Field
                                                             FieldArrayProvider={[Function]}
                                                             FieldProvider={[Function]}
                                                             formOptions={
@@ -3045,39 +2462,101 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                 "valid": true,
                                                               }
                                                             }
-                                                            input={
+                                                            format={[Function]}
+                                                            name="foo-field"
+                                                            parse={[Function]}
+                                                            reactFinalForm={
                                                               Object {
-                                                                "name": "foo-field",
-                                                                "onBlur": [Function],
-                                                                "onChange": [Function],
-                                                                "onFocus": [Function],
-                                                                "value": "",
+                                                                "batch": [Function],
+                                                                "blur": [Function],
+                                                                "change": [Function],
+                                                                "destroyOnUnregister": false,
+                                                                "focus": [Function],
+                                                                "getFieldState": [Function],
+                                                                "getRegisteredFields": [Function],
+                                                                "getState": [Function],
+                                                                "initialize": [Function],
+                                                                "isValidationPaused": [Function],
+                                                                "mutators": Object {
+                                                                  "concat": [Function],
+                                                                  "insert": [Function],
+                                                                  "move": [Function],
+                                                                  "pop": [Function],
+                                                                  "push": [Function],
+                                                                  "remove": [Function],
+                                                                  "removeBatch": [Function],
+                                                                  "shift": [Function],
+                                                                  "swap": [Function],
+                                                                  "unshift": [Function],
+                                                                  "update": [Function],
+                                                                },
+                                                                "pauseValidation": [Function],
+                                                                "registerField": [Function],
+                                                                "reset": [Function],
+                                                                "resetFieldState": [Function],
+                                                                "resumeValidation": [Function],
+                                                                "setConfig": [Function],
+                                                                "submit": [Function],
+                                                                "subscribe": [Function],
                                                               }
                                                             }
-                                                            meta={
-                                                              Object {
-                                                                "active": false,
-                                                                "data": Object {},
-                                                                "dirty": false,
-                                                                "dirtySinceLastSubmit": false,
-                                                                "error": undefined,
-                                                                "initial": undefined,
-                                                                "invalid": false,
-                                                                "modified": false,
-                                                                "pristine": true,
-                                                                "submitError": undefined,
-                                                                "submitFailed": false,
-                                                                "submitSucceeded": false,
-                                                                "submitting": false,
-                                                                "touched": false,
-                                                                "valid": true,
-                                                                "visited": false,
-                                                              }
-                                                            }
+                                                            render={[Function]}
+                                                            validate={[Function]}
                                                           >
-                                                            <FormGroup
-                                                              id="foo-field"
-                                                              isRequired={false}
+                                                            <TextField
+                                                              FieldArrayProvider={[Function]}
+                                                              FieldProvider={[Function]}
+                                                              formOptions={
+                                                                Object {
+                                                                  "batch": [Function],
+                                                                  "blur": [Function],
+                                                                  "change": [Function],
+                                                                  "clearOnUnmount": false,
+                                                                  "clearedValue": undefined,
+                                                                  "concat": [Function],
+                                                                  "destroyOnUnregister": false,
+                                                                  "focus": [Function],
+                                                                  "getFieldState": [Function],
+                                                                  "getRegisteredFields": [Function],
+                                                                  "getState": [Function],
+                                                                  "handleSubmit": [Function],
+                                                                  "initialize": [Function],
+                                                                  "insert": [Function],
+                                                                  "isValidationPaused": [Function],
+                                                                  "move": [Function],
+                                                                  "onCancel": [MockFunction],
+                                                                  "onReset": undefined,
+                                                                  "onSubmit": [MockFunction],
+                                                                  "pauseValidation": [Function],
+                                                                  "pop": [Function],
+                                                                  "pristine": true,
+                                                                  "push": [Function],
+                                                                  "registerField": [Function],
+                                                                  "remove": [Function],
+                                                                  "removeBatch": [Function],
+                                                                  "renderForm": [Function],
+                                                                  "reset": [Function],
+                                                                  "resetFieldState": [Function],
+                                                                  "resumeValidation": [Function],
+                                                                  "setConfig": [Function],
+                                                                  "shift": [Function],
+                                                                  "submit": [Function],
+                                                                  "subscribe": [Function],
+                                                                  "swap": [Function],
+                                                                  "unshift": [Function],
+                                                                  "update": [Function],
+                                                                  "valid": true,
+                                                                }
+                                                              }
+                                                              input={
+                                                                Object {
+                                                                  "name": "foo-field",
+                                                                  "onBlur": [Function],
+                                                                  "onChange": [Function],
+                                                                  "onFocus": [Function],
+                                                                  "value": "",
+                                                                }
+                                                              }
                                                               meta={
                                                                 Object {
                                                                   "active": false,
@@ -3100,70 +2579,40 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                               }
                                                             >
                                                               <FormGroup
-                                                                fieldId="foo-field"
+                                                                id="foo-field"
                                                                 isRequired={false}
-                                                                isValid={true}
+                                                                meta={
+                                                                  Object {
+                                                                    "active": false,
+                                                                    "data": Object {},
+                                                                    "dirty": false,
+                                                                    "dirtySinceLastSubmit": false,
+                                                                    "error": undefined,
+                                                                    "initial": undefined,
+                                                                    "invalid": false,
+                                                                    "modified": false,
+                                                                    "pristine": true,
+                                                                    "submitError": undefined,
+                                                                    "submitFailed": false,
+                                                                    "submitSucceeded": false,
+                                                                    "submitting": false,
+                                                                    "touched": false,
+                                                                    "valid": true,
+                                                                    "visited": false,
+                                                                  }
+                                                                }
                                                               >
-                                                                <div
-                                                                  className="pf-c-form__group"
+                                                                <FormGroup
+                                                                  fieldId="foo-field"
+                                                                  isRequired={false}
+                                                                  isValid={true}
                                                                 >
-                                                                  <ForwardRef
-                                                                    FieldArrayProvider={[Function]}
-                                                                    FieldProvider={[Function]}
-                                                                    formOptions={
-                                                                      Object {
-                                                                        "batch": [Function],
-                                                                        "blur": [Function],
-                                                                        "change": [Function],
-                                                                        "clearOnUnmount": false,
-                                                                        "clearedValue": undefined,
-                                                                        "concat": [Function],
-                                                                        "destroyOnUnregister": false,
-                                                                        "focus": [Function],
-                                                                        "getFieldState": [Function],
-                                                                        "getRegisteredFields": [Function],
-                                                                        "getState": [Function],
-                                                                        "handleSubmit": [Function],
-                                                                        "initialize": [Function],
-                                                                        "insert": [Function],
-                                                                        "isValidationPaused": [Function],
-                                                                        "move": [Function],
-                                                                        "onCancel": [MockFunction],
-                                                                        "onReset": undefined,
-                                                                        "onSubmit": [MockFunction],
-                                                                        "pauseValidation": [Function],
-                                                                        "pop": [Function],
-                                                                        "pristine": true,
-                                                                        "push": [Function],
-                                                                        "registerField": [Function],
-                                                                        "remove": [Function],
-                                                                        "removeBatch": [Function],
-                                                                        "renderForm": [Function],
-                                                                        "reset": [Function],
-                                                                        "resetFieldState": [Function],
-                                                                        "resumeValidation": [Function],
-                                                                        "setConfig": [Function],
-                                                                        "shift": [Function],
-                                                                        "submit": [Function],
-                                                                        "subscribe": [Function],
-                                                                        "swap": [Function],
-                                                                        "unshift": [Function],
-                                                                        "update": [Function],
-                                                                        "valid": true,
-                                                                      }
-                                                                    }
-                                                                    id="foo-field"
-                                                                    name="foo-field"
-                                                                    onBlur={[Function]}
-                                                                    onChange={[Function]}
-                                                                    onFocus={[Function]}
-                                                                    value=""
+                                                                  <div
+                                                                    className="pf-c-form__group"
                                                                   >
-                                                                    <TextInputBase
+                                                                    <ForwardRef
                                                                       FieldArrayProvider={[Function]}
                                                                       FieldProvider={[Function]}
-                                                                      aria-label={null}
-                                                                      className=""
                                                                       formOptions={
                                                                         Object {
                                                                           "batch": [Function],
@@ -3207,26 +2656,17 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                         }
                                                                       }
                                                                       id="foo-field"
-                                                                      innerRef={null}
-                                                                      isDisabled={false}
-                                                                      isReadOnly={false}
-                                                                      isRequired={false}
-                                                                      isValid={true}
                                                                       name="foo-field"
                                                                       onBlur={[Function]}
                                                                       onChange={[Function]}
                                                                       onFocus={[Function]}
-                                                                      type="text"
-                                                                      validated="default"
                                                                       value=""
                                                                     >
-                                                                      <input
+                                                                      <TextInputBase
                                                                         FieldArrayProvider={[Function]}
                                                                         FieldProvider={[Function]}
-                                                                        aria-invalid={false}
                                                                         aria-label={null}
-                                                                        className="pf-c-form-control"
-                                                                        disabled={false}
+                                                                        className=""
                                                                         formOptions={
                                                                           Object {
                                                                             "batch": [Function],
@@ -3270,24 +2710,88 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                           }
                                                                         }
                                                                         id="foo-field"
+                                                                        innerRef={null}
+                                                                        isDisabled={false}
+                                                                        isReadOnly={false}
+                                                                        isRequired={false}
+                                                                        isValid={true}
                                                                         name="foo-field"
                                                                         onBlur={[Function]}
                                                                         onChange={[Function]}
                                                                         onFocus={[Function]}
-                                                                        readOnly={false}
-                                                                        required={false}
                                                                         type="text"
+                                                                        validated="default"
                                                                         value=""
-                                                                      />
-                                                                    </TextInputBase>
-                                                                  </ForwardRef>
-                                                                </div>
+                                                                      >
+                                                                        <input
+                                                                          FieldArrayProvider={[Function]}
+                                                                          FieldProvider={[Function]}
+                                                                          aria-invalid={false}
+                                                                          aria-label={null}
+                                                                          className="pf-c-form-control"
+                                                                          disabled={false}
+                                                                          formOptions={
+                                                                            Object {
+                                                                              "batch": [Function],
+                                                                              "blur": [Function],
+                                                                              "change": [Function],
+                                                                              "clearOnUnmount": false,
+                                                                              "clearedValue": undefined,
+                                                                              "concat": [Function],
+                                                                              "destroyOnUnregister": false,
+                                                                              "focus": [Function],
+                                                                              "getFieldState": [Function],
+                                                                              "getRegisteredFields": [Function],
+                                                                              "getState": [Function],
+                                                                              "handleSubmit": [Function],
+                                                                              "initialize": [Function],
+                                                                              "insert": [Function],
+                                                                              "isValidationPaused": [Function],
+                                                                              "move": [Function],
+                                                                              "onCancel": [MockFunction],
+                                                                              "onReset": undefined,
+                                                                              "onSubmit": [MockFunction],
+                                                                              "pauseValidation": [Function],
+                                                                              "pop": [Function],
+                                                                              "pristine": true,
+                                                                              "push": [Function],
+                                                                              "registerField": [Function],
+                                                                              "remove": [Function],
+                                                                              "removeBatch": [Function],
+                                                                              "renderForm": [Function],
+                                                                              "reset": [Function],
+                                                                              "resetFieldState": [Function],
+                                                                              "resumeValidation": [Function],
+                                                                              "setConfig": [Function],
+                                                                              "shift": [Function],
+                                                                              "submit": [Function],
+                                                                              "subscribe": [Function],
+                                                                              "swap": [Function],
+                                                                              "unshift": [Function],
+                                                                              "update": [Function],
+                                                                              "valid": true,
+                                                                            }
+                                                                          }
+                                                                          id="foo-field"
+                                                                          name="foo-field"
+                                                                          onBlur={[Function]}
+                                                                          onChange={[Function]}
+                                                                          onFocus={[Function]}
+                                                                          readOnly={false}
+                                                                          required={false}
+                                                                          type="text"
+                                                                          value=""
+                                                                        />
+                                                                      </TextInputBase>
+                                                                    </ForwardRef>
+                                                                  </div>
+                                                                </FormGroup>
                                                               </FormGroup>
-                                                            </FormGroup>
-                                                          </TextField>
-                                                        </Field>
-                                                      </ReactFinalForm(Field)>
-                                                    </FieldProvider>
+                                                            </TextField>
+                                                          </Field>
+                                                        </ReactFinalForm(Field)>
+                                                      </FieldProvider>
+                                                    </TemporaryWrapper>
                                                   </FieldWrapper>
                                                 </FormFieldHideWrapper>
                                               </FormConditionWrapper>
@@ -3546,264 +3050,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
               </FieldWrapper>
             </FormFieldHideWrapper>
           </FormConditionWrapper>
-          <ReactFinalForm(FormSpy)>
-            <FormSpy
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {
-                    "concat": [Function],
-                    "insert": [Function],
-                    "move": [Function],
-                    "pop": [Function],
-                    "push": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "shift": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                  },
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
-            >
-              <FormControls
-                Button={[Function]}
-                ButtonGroup={[Function]}
-                FormSpy={[Function]}
-                buttonOrder={
-                  Array [
-                    "submit",
-                    "reset",
-                    "cancel",
-                  ]
-                }
-                canReset={false}
-                canSubmit={false}
-                cancelLabel="Cancel"
-                formSpyProps={
-                  Object {
-                    "active": undefined,
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "dirty": false,
-                    "dirtyFields": Object {},
-                    "dirtyFieldsSinceLastSubmit": Object {},
-                    "dirtySinceLastSubmit": false,
-                    "error": undefined,
-                    "errors": Object {},
-                    "focus": [Function],
-                    "form": Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "initialize": [Function],
-                      "isValidationPaused": [Function],
-                      "mutators": Object {
-                        "concat": [Function],
-                        "insert": [Function],
-                        "move": [Function],
-                        "pop": [Function],
-                        "push": [Function],
-                        "remove": [Function],
-                        "removeBatch": [Function],
-                        "shift": [Function],
-                        "swap": [Function],
-                        "unshift": [Function],
-                        "update": [Function],
-                      },
-                      "pauseValidation": [Function],
-                      "registerField": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                    },
-                    "hasSubmitErrors": false,
-                    "hasValidationErrors": false,
-                    "initialValues": Object {},
-                    "initialize": [Function],
-                    "invalid": false,
-                    "modified": Object {
-                      "foo-field": false,
-                    },
-                    "mutators": Object {
-                      "concat": [Function],
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pristine": true,
-                    "reset": [Function],
-                    "submitError": undefined,
-                    "submitErrors": undefined,
-                    "submitFailed": false,
-                    "submitSucceeded": false,
-                    "submitting": false,
-                    "touched": Object {
-                      "foo-field": false,
-                    },
-                    "valid": true,
-                    "validating": false,
-                    "values": Object {},
-                    "visited": Object {
-                      "foo-field": false,
-                    },
-                  }
-                }
-                onCancel={[MockFunction]}
-                resetLabel="Reset"
-                submitLabel="Submit"
-              >
-                <ButtonGroup>
-                  <ActionGroup>
-                    <div
-                      className="pf-c-form__group pf-m-action"
-                    >
-                      <div
-                        className="pf-c-form__actions"
-                      >
-                        <Button
-                          key="form-submit"
-                          label="Submit"
-                          type="submit"
-                          variant="primary"
-                        >
-                          <Component
-                            type="submit"
-                            variant="primary"
-                          >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Submit",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "type": "submit",
-                                  "variant": "primary",
-                                }
-                              }
-                              consumerContext={null}
-                            >
-                              <Button
-                                ouiaContext={
-                                  Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
-                                  }
-                                }
-                                type="submit"
-                                variant="primary"
-                              >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-primary"
-                                  disabled={false}
-                                  tabIndex={null}
-                                  type="submit"
-                                >
-                                  Submit
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                        <Button
-                          key="form-cancel"
-                          label="Cancel"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <Component
-                            onClick={[Function]}
-                            type="button"
-                            variant="secondary"
-                          >
-                            <ComponentWithOuia
-                              component={[Function]}
-                              componentProps={
-                                Object {
-                                  "children": Array [
-                                    "Cancel",
-                                    undefined,
-                                  ],
-                                  "isDisabled": undefined,
-                                  "onClick": [Function],
-                                  "type": "button",
-                                  "variant": "secondary",
-                                }
-                              }
-                              consumerContext={null}
-                            >
-                              <Button
-                                onClick={[Function]}
-                                ouiaContext={
-                                  Object {
-                                    "isOuia": false,
-                                    "ouiaId": null,
-                                  }
-                                }
-                                type="button"
-                                variant="secondary"
-                              >
-                                <button
-                                  aria-disabled={null}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-secondary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={null}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </ComponentWithOuia>
-                          </Component>
-                        </Button>
-                      </div>
-                    </div>
-                  </ActionGroup>
-                </ButtonGroup>
-              </FormControls>
-            </FormSpy>
-          </ReactFinalForm(FormSpy)>
         </form>
       </Form>
     </Component>

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -103,48 +103,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
           </React.Fragment>,
         ]
       }
-      formOptions={
-        Object {
-          "batch": [Function],
-          "blur": [Function],
-          "change": [Function],
-          "clearOnUnmount": false,
-          "clearedValue": undefined,
-          "concat": [Function],
-          "destroyOnUnregister": false,
-          "focus": [Function],
-          "getFieldState": [Function],
-          "getRegisteredFields": [Function],
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "initialize": [Function],
-          "insert": [Function],
-          "isValidationPaused": [Function],
-          "move": [Function],
-          "onCancel": [MockFunction],
-          "onReset": undefined,
-          "onSubmit": [MockFunction],
-          "pauseValidation": [Function],
-          "pop": [Function],
-          "pristine": true,
-          "push": [Function],
-          "registerField": [Function],
-          "remove": [Function],
-          "removeBatch": [Function],
-          "renderForm": [Function],
-          "reset": [Function],
-          "resetFieldState": [Function],
-          "resumeValidation": [Function],
-          "setConfig": [Function],
-          "shift": [Function],
-          "submit": [Function],
-          "subscribe": [Function],
-          "swap": [Function],
-          "unshift": [Function],
-          "update": [Function],
-          "valid": true,
-        }
-      }
       schema={
         Object {
           "fields": Array [
@@ -1519,48 +1477,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
             </Context.Consumer>
           </React.Fragment>,
         ]
-      }
-      formOptions={
-        Object {
-          "batch": [Function],
-          "blur": [Function],
-          "change": [Function],
-          "clearOnUnmount": false,
-          "clearedValue": undefined,
-          "concat": [Function],
-          "destroyOnUnregister": false,
-          "focus": [Function],
-          "getFieldState": [Function],
-          "getRegisteredFields": [Function],
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "initialize": [Function],
-          "insert": [Function],
-          "isValidationPaused": [Function],
-          "move": [Function],
-          "onCancel": [MockFunction],
-          "onReset": undefined,
-          "onSubmit": [MockFunction],
-          "pauseValidation": [Function],
-          "pop": [Function],
-          "pristine": true,
-          "push": [Function],
-          "registerField": [Function],
-          "remove": [Function],
-          "removeBatch": [Function],
-          "renderForm": [Function],
-          "reset": [Function],
-          "resetFieldState": [Function],
-          "resumeValidation": [Function],
-          "setConfig": [Function],
-          "shift": [Function],
-          "submit": [Function],
-          "subscribe": [Function],
-          "swap": [Function],
-          "unshift": [Function],
-          "update": [Function],
-          "valid": true,
-        }
       }
       schema={
         Object {

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -101,10 +101,9 @@ describe('<Wizard />', () => {
     initialProps = {
       schema,
       formFieldsMapper: componentMapper,
-      formTemplate: formTemplate(),
+      formTemplate: formTemplate({ showFormControls: false }),
       onSubmit: jest.fn(),
-      onCancel: jest.fn(),
-      showFormControls: false
+      onCancel: jest.fn()
     };
 
     nestedSchema = {

--- a/packages/react-form-renderer/demo/form-fields-mapper.js
+++ b/packages/react-form-renderer/demo/form-fields-mapper.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { componentTypes } from '../src';
 
-const TextField = ({ FieldProvider, isVisible, input, meta, label, formOptions, helperText, isRequired, dataType, isDisabled, isReadOnly, ...rest }) => (
+const TextField = ({ FieldProvider, isVisible, input, meta, label, helperText, isRequired, dataType, isDisabled, isReadOnly, ...rest }) => (
   <div>
     <label>{ label } &nbsp;</label>
     <input { ...input } { ...rest } />
@@ -9,7 +9,7 @@ const TextField = ({ FieldProvider, isVisible, input, meta, label, formOptions, 
   </div>
 );
 
-const SelectField = ({ FieldProvider, isVisible, input, meta, label, formOptions, helperText, isRequired, dataType, isDisabled, isReadOnly, options, ...rest }) => (
+const SelectField = ({ FieldProvider, isVisible, input, meta, label, helperText, isRequired, dataType, isDisabled, isReadOnly, options, ...rest }) => (
   <div>
     <label>{ label } &nbsp;</label>
     <select { ...input } { ...rest }>

--- a/packages/react-form-renderer/demo/form-template.js
+++ b/packages/react-form-renderer/demo/form-template.js
@@ -1,47 +1,43 @@
 import React from 'react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const isDisabled = (disableStates, getState) => disableStates.map(item => getState()[item]).find(item => !!item);
+const isDisabled = (disableStates, getState) => disableStates.map((item) => getState()[item]).find((item) => !!item);
 
-const FormTemplate = ({ schema: { title, description }, formFields, formOptions, FormSpy }) => {
+const FormTemplate = ({ schema: { title, description }, formFields, FormSpy }) => {
   console.log('render of the form');
 
+  const { handleSubmit, getState, onReset, onCancel } = useFormApi();
+
   return (
-    <form onSubmit={ formOptions.handleSubmit }>
-      { title && <h1>{ title }</h1> }
-      { description && <h2>{ description }</h2> }
-      { formFields }
+    <form onSubmit={handleSubmit}>
+      {title && <h1>{title}</h1>}
+      {description && <h2>{description}</h2>}
+      {formFields}
       <FormSpy>
-        { ({ submitting, pristine, validating, form: { reset }, values }) => (
+        {({ submitting, pristine, validating, form: { reset }, values }) => (
           <React.Fragment>
-            <button
-              key="form-submit"
-              type="submit"
-              disabled={ submitting || validating || isDisabled([ 'invalid' ], formOptions.getState) }
-            >
-            Submit
+            <button key="form-submit" type="submit" disabled={submitting || validating || isDisabled(['invalid'], getState)}>
+              Submit
             </button>
             <button
               key="form-reset"
               type="button"
-              disabled={ pristine }
-              onClick={ () => {
-                formOptions.onReset && formOptions.onReset();
+              disabled={pristine}
+              onClick={() => {
+                onReset && onReset();
                 reset();
-              } }
+              }}
             >
-            Reset
+              Reset
             </button>
-            <button
-              key="form-cancel"
-              type="button"
-              disabled={ pristine }
-              onClick={ () => formOptions.onCancel(values) }
-            >
-            Cancel
+            <button key="form-cancel" type="button" disabled={pristine} onClick={() => onCancel(values)}>
+              Cancel
             </button>
-          </React.Fragment>) }
+          </React.Fragment>
+        )}
       </FormSpy>
     </form>
-  );};
+  );
+};
 
 export default FormTemplate;

--- a/packages/react-form-renderer/src/components/field-provider.js
+++ b/packages/react-form-renderer/src/components/field-provider.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import enhancedOnChange from '../form-renderer/enhanced-on-change';
 import dataTypes from './data-types';
+import useFormApi from '../hooks/useFormApi';
 
 class FieldProvider extends Component{
   componentDidMount() {
@@ -101,5 +102,10 @@ FieldProvider.defaultProps = {
   formOptions: {},
 };
 
-export default FieldProvider;
+const TemporaryWrapper = (props) => {
+  const formOptions = useFormApi();
 
+  return <FieldProvider {...props} formOptions={formOptions} />;
+};
+
+export default TemporaryWrapper;

--- a/packages/react-form-renderer/src/components/form-renderer.js
+++ b/packages/react-form-renderer/src/components/form-renderer.js
@@ -40,7 +40,7 @@ const FormRenderer = ({
     ? formTemplate
     : () => (
       <div>{`FormRenderer is missing 'formTemplate' prop:
-  ({formFields, formOptions, formSpy, schema}) => <FormTemplate {...} />`}</div>
+  ({formFields, formSpy, schema}) => <FormTemplate {...} />`}</div>
     );
 
   return (
@@ -76,7 +76,7 @@ const FormRenderer = ({
               formOptions
             }}
           >
-            <FormTemplate formFields={renderForm(schema.fields)} formOptions={formOptions} FormSpy={FormSpy} schema={schema} />
+            <FormTemplate formFields={renderForm(schema.fields)} FormSpy={FormSpy} schema={schema} />
             {onStateUpdate && <FormSpy onChange={onStateUpdate} />}
           </RendererContext.Provider>
         );

--- a/packages/react-form-renderer/src/components/form-renderer.js
+++ b/packages/react-form-renderer/src/components/form-renderer.js
@@ -21,7 +21,7 @@ const FormRenderer = ({
   onStateUpdate,
   subscription,
   clearedValue,
-  schema,
+  schema
 }) => {
   let schemaError;
   try {
@@ -33,21 +33,25 @@ const FormRenderer = ({
   }
 
   if (schemaError) {
-    return <SchemaErrorComponent name={ schemaError.name } message={ schemaError.message } />;
+    return <SchemaErrorComponent name={schemaError.name} message={schemaError.message} />;
   }
 
-  const FormTemplate = formTemplate ? formTemplate : () => <div>{ `FormRenderer is missing 'formTemplate' prop:
-  ({formFields, formOptions, formSpy, schema}) => <FormTemplate {...} />` }</div>;
+  const FormTemplate = formTemplate
+    ? formTemplate
+    : () => (
+      <div>{`FormRenderer is missing 'formTemplate' prop:
+  ({formFields, formOptions, formSpy, schema}) => <FormTemplate {...} />`}</div>
+    );
 
   return (
     <Form
-      onSubmit={ onSubmit }
+      onSubmit={onSubmit}
       mutators={{ ...arrayMutators }}
-      decorators={ [ createFocusDecorator() ] }
-      initialValues={ initialValues }
-      validate={ validate }
+      decorators={[createFocusDecorator()]}
+      initialValues={initialValues}
+      validate={validate}
       subscription={{ pristine: true, submitting: true, valid: true, ...subscription }}
-      render={ ({ handleSubmit, pristine, valid, form: { reset, mutators, getState, submit, ...form }, ...state }) => {
+      render={({ handleSubmit, pristine, valid, form: { reset, mutators, getState, submit, ...form }, ...state }) => {
         const formOptions = {
           pristine,
           onSubmit,
@@ -62,25 +66,24 @@ const FormRenderer = ({
           clearOnUnmount,
           renderForm,
           ...mutators,
-          ...form,
+          ...form
         };
 
         return (
-          <RendererContext.Provider value={{
-            formFieldsMapper,
-            formOptions,
-          }}>
-            <FormTemplate
-              formFields={ renderForm(schema.fields) }
-              formOptions={ formOptions }
-              FormSpy={ FormSpy }
-              schema={ schema }
-            />
-            { onStateUpdate && <FormSpy onChange={ onStateUpdate } /> }
+          <RendererContext.Provider
+            value={{
+              formFieldsMapper,
+              formOptions
+            }}
+          >
+            <FormTemplate formFields={renderForm(schema.fields)} formOptions={formOptions} FormSpy={FormSpy} schema={schema} />
+            {onStateUpdate && <FormSpy onChange={onStateUpdate} />}
           </RendererContext.Provider>
-        );} }
+        );
+      }}
     />
-  );};
+  );
+};
 
 FormRenderer.propTypes = {
   onSubmit: PropTypes.func.isRequired,
@@ -92,12 +95,12 @@ FormRenderer.propTypes = {
   validate: PropTypes.func,
   onStateUpdate: PropTypes.func,
   subscription: PropTypes.shape({ [PropTypes.string]: PropTypes.bool }),
-  clearedValue: PropTypes.any,
+  clearedValue: PropTypes.any
 };
 
 FormRenderer.defaultProps = {
   initialValues: {},
-  clearOnUnmount: false,
+  clearOnUnmount: false
 };
 
 export default FormRenderer;

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -7,67 +7,46 @@ import Condition from './condition';
 import { memoize } from '../validators/helpers';
 import FieldWrapper from './field-wrapper';
 
-const FormFieldHideWrapper = ({ hideField, children }) => hideField ? (
-  <div hidden>{ children }</div>
-) : children;
+const FormFieldHideWrapper = ({ hideField, children }) => (hideField ? <div hidden>{children}</div> : children);
 
 FormFieldHideWrapper.propTypes = {
   hideField: PropTypes.bool,
-  children: PropTypes.oneOfType([ PropTypes.node, PropTypes.arrayOf(PropTypes.node) ]).isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired
 };
 
 FormFieldHideWrapper.defaultProps = {
-  hideField: false,
+  hideField: false
 };
 
-const FormConditionWrapper = ({ condition, children }) => (condition ? (
-  <Condition condition={ condition }>
-    { children }
-  </Condition>
-) : children);
+const FormConditionWrapper = ({ condition, children }) => (condition ? <Condition condition={condition}>{children}</Condition> : children);
 
 const renderSingleField = ({ component, condition, hideField, ...rest }) => (
-  <Fragment key={ rest.key || rest.name }>
+  <Fragment key={rest.key || rest.name}>
     <RendererContext.Consumer>
-      { ({ formFieldsMapper, formOptions }) => (
-        <FormConditionWrapper condition={ condition }>
-          <FormFieldHideWrapper hideField={ hideField }>
-            <FieldWrapper
-              componentType={ component }
-              component={ formFieldsMapper[component] }
-              formOptions={ formOptions }
-              name={ rest.name || rest.key }
-              { ...rest }
-            />
+      {({ formFieldsMapper }) => (
+        <FormConditionWrapper condition={condition}>
+          <FormFieldHideWrapper hideField={hideField}>
+            <FieldWrapper componentType={component} component={formFieldsMapper[component]} name={rest.name || rest.key} {...rest} />
           </FormFieldHideWrapper>
         </FormConditionWrapper>
-      ) }
+      )}
     </RendererContext.Consumer>
   </Fragment>
 );
 
 renderSingleField.propTypes = {
-  component: PropTypes.string.isRequired,
+  component: PropTypes.string.isRequired
 };
 
-const prepareValidator = (validator) => ((typeof validator === 'function')
-  ? memoize(validator)
-  : validatorMapper(validator.type)({ ...validator }));
+const prepareValidator = (validator) => (typeof validator === 'function' ? memoize(validator) : validatorMapper(validator.type)({ ...validator }));
 
-const prepareFieldProps = field => ({
+const prepareFieldProps = (field) => ({
   ...field,
   validate: field.validate
-    ? [
-      ...field.validate.map((validator) => prepareValidator(validator)),
-      field.dataType && dataTypeValidator(field.dataType)(),
-    ]
-    : [
-      field.dataType && dataTypeValidator(field.dataType)(),
-    ],
+    ? [...field.validate.map((validator) => prepareValidator(validator)), field.dataType && dataTypeValidator(field.dataType)()]
+    : [field.dataType && dataTypeValidator(field.dataType)()]
 });
 
-const renderForm = (fields) => fields.map(field => (Array.isArray(field)
-  ? renderForm(field)
-  : renderSingleField(prepareFieldProps(field))));
+const renderForm = (fields) => fields.map((field) => (Array.isArray(field) ? renderForm(field) : renderSingleField(prepareFieldProps(field))));
 
 export default renderForm;

--- a/packages/react-form-renderer/src/hooks/useFormApi.js
+++ b/packages/react-form-renderer/src/hooks/useFormApi.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import RendererContext from '../components/renderer-context';
+
+const useFormApi = () => {
+  const { formOptions } = useContext(RendererContext);
+
+  return formOptions;
+};
+
+export default useFormApi;

--- a/packages/react-form-renderer/src/index.js
+++ b/packages/react-form-renderer/src/index.js
@@ -8,8 +8,9 @@ export { default as validatorTypes } from './components/validator-types';
 export { default as composeValidators } from './components/compose-validators';
 export { default as Validators } from './validators/validators';
 export { default as defaultSchemaValidator } from './parsers/default-schema-validator';
+export { default as useFormApi } from './hooks/useFormApi';
 
 export const schemaParsers = {
   mozillaParser,
-  miqParser,
+  miqParser
 };

--- a/packages/react-form-renderer/src/index.js
+++ b/packages/react-form-renderer/src/index.js
@@ -9,6 +9,7 @@ export { default as composeValidators } from './components/compose-validators';
 export { default as Validators } from './validators/validators';
 export { default as defaultSchemaValidator } from './parsers/default-schema-validator';
 export { default as useFormApi } from './hooks/useFormApi';
+export { default as RendererContext } from './components/renderer-context';
 
 export const schemaParsers = {
   mozillaParser,

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -149,48 +149,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             <FieldWrapper
               component={[Function]}
               componentType="text-field"
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onReset": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
               name="component1"
               validate={
                 Array [
@@ -198,58 +156,17 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 ]
               }
             >
-              <FieldProvider
+              <TemporaryWrapper
                 FieldArrayProvider={[Function]}
                 FieldProvider={[Function]}
                 component={[Function]}
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onReset": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
                 name="component1"
                 validate={[Function]}
               >
-                <ReactFinalForm(Field)
+                <FieldProvider
                   FieldArrayProvider={[Function]}
                   FieldProvider={[Function]}
+                  component={[Function]}
                   formOptions={
                     Object {
                       "batch": [Function],
@@ -293,10 +210,9 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     }
                   }
                   name="component1"
-                  render={[Function]}
                   validate={[Function]}
                 >
-                  <Field
+                  <ReactFinalForm(Field)
                     FieldArrayProvider={[Function]}
                     FieldProvider={[Function]}
                     formOptions={
@@ -341,48 +257,11 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                         "valid": true,
                       }
                     }
-                    format={[Function]}
                     name="component1"
-                    parse={[Function]}
-                    reactFinalForm={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "initialize": [Function],
-                        "isValidationPaused": [Function],
-                        "mutators": Object {
-                          "concat": [Function],
-                          "insert": [Function],
-                          "move": [Function],
-                          "pop": [Function],
-                          "push": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "shift": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                        },
-                        "pauseValidation": [Function],
-                        "registerField": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                      }
-                    }
                     render={[Function]}
                     validate={[Function]}
                   >
-                    <Component
+                    <Field
                       FieldArrayProvider={[Function]}
                       FieldProvider={[Function]}
                       formOptions={
@@ -427,45 +306,132 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                           "valid": true,
                         }
                       }
-                      input={
+                      format={[Function]}
+                      name="component1"
+                      parse={[Function]}
+                      reactFinalForm={
                         Object {
-                          "name": "component1",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onFocus": [Function],
-                          "value": "",
+                          "batch": [Function],
+                          "blur": [Function],
+                          "change": [Function],
+                          "destroyOnUnregister": false,
+                          "focus": [Function],
+                          "getFieldState": [Function],
+                          "getRegisteredFields": [Function],
+                          "getState": [Function],
+                          "initialize": [Function],
+                          "isValidationPaused": [Function],
+                          "mutators": Object {
+                            "concat": [Function],
+                            "insert": [Function],
+                            "move": [Function],
+                            "pop": [Function],
+                            "push": [Function],
+                            "remove": [Function],
+                            "removeBatch": [Function],
+                            "shift": [Function],
+                            "swap": [Function],
+                            "unshift": [Function],
+                            "update": [Function],
+                          },
+                          "pauseValidation": [Function],
+                          "registerField": [Function],
+                          "reset": [Function],
+                          "resetFieldState": [Function],
+                          "resumeValidation": [Function],
+                          "setConfig": [Function],
+                          "submit": [Function],
+                          "subscribe": [Function],
                         }
                       }
-                      meta={
-                        Object {
-                          "active": false,
-                          "data": Object {},
-                          "dirty": false,
-                          "dirtySinceLastSubmit": false,
-                          "error": undefined,
-                          "initial": undefined,
-                          "invalid": false,
-                          "modified": false,
-                          "pristine": true,
-                          "submitError": undefined,
-                          "submitFailed": false,
-                          "submitSucceeded": false,
-                          "submitting": false,
-                          "touched": false,
-                          "valid": true,
-                          "visited": false,
-                        }
-                      }
+                      render={[Function]}
+                      validate={[Function]}
                     >
-                      <div
-                        className="nested-item"
+                      <Component
+                        FieldArrayProvider={[Function]}
+                        FieldProvider={[Function]}
+                        formOptions={
+                          Object {
+                            "batch": [Function],
+                            "blur": [Function],
+                            "change": [Function],
+                            "clearOnUnmount": false,
+                            "clearedValue": undefined,
+                            "concat": [Function],
+                            "destroyOnUnregister": false,
+                            "focus": [Function],
+                            "getFieldState": [Function],
+                            "getRegisteredFields": [Function],
+                            "getState": [Function],
+                            "handleSubmit": [Function],
+                            "initialize": [Function],
+                            "insert": [Function],
+                            "isValidationPaused": [Function],
+                            "move": [Function],
+                            "onCancel": undefined,
+                            "onReset": undefined,
+                            "onSubmit": [MockFunction],
+                            "pauseValidation": [Function],
+                            "pop": [Function],
+                            "pristine": true,
+                            "push": [Function],
+                            "registerField": [Function],
+                            "remove": [Function],
+                            "removeBatch": [Function],
+                            "renderForm": [Function],
+                            "reset": [Function],
+                            "resetFieldState": [Function],
+                            "resumeValidation": [Function],
+                            "setConfig": [Function],
+                            "shift": [Function],
+                            "submit": [Function],
+                            "subscribe": [Function],
+                            "swap": [Function],
+                            "unshift": [Function],
+                            "update": [Function],
+                            "valid": true,
+                          }
+                        }
+                        input={
+                          Object {
+                            "name": "component1",
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "value": "",
+                          }
+                        }
+                        meta={
+                          Object {
+                            "active": false,
+                            "data": Object {},
+                            "dirty": false,
+                            "dirtySinceLastSubmit": false,
+                            "error": undefined,
+                            "initial": undefined,
+                            "invalid": false,
+                            "modified": false,
+                            "pristine": true,
+                            "submitError": undefined,
+                            "submitFailed": false,
+                            "submitSucceeded": false,
+                            "submitting": false,
+                            "touched": false,
+                            "valid": true,
+                            "visited": false,
+                          }
+                        }
                       >
-                        Text field
-                      </div>
-                    </Component>
-                  </Field>
-                </ReactFinalForm(Field)>
-              </FieldProvider>
+                        <div
+                          className="nested-item"
+                        >
+                          Text field
+                        </div>
+                      </Component>
+                    </Field>
+                  </ReactFinalForm(Field)>
+                </FieldProvider>
+              </TemporaryWrapper>
             </FieldWrapper>
           </FormFieldHideWrapper>
         </FormConditionWrapper>
@@ -476,48 +442,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
             <FieldWrapper
               component={[Function]}
               componentType="select-field"
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onReset": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
               name="secret"
               validate={
                 Array [
@@ -525,58 +449,17 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 ]
               }
             >
-              <FieldProvider
+              <TemporaryWrapper
                 FieldArrayProvider={[Function]}
                 FieldProvider={[Function]}
                 component={[Function]}
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onReset": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
                 name="secret"
                 validate={[Function]}
               >
-                <ReactFinalForm(Field)
+                <FieldProvider
                   FieldArrayProvider={[Function]}
                   FieldProvider={[Function]}
+                  component={[Function]}
                   formOptions={
                     Object {
                       "batch": [Function],
@@ -620,10 +503,9 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     }
                   }
                   name="secret"
-                  render={[Function]}
                   validate={[Function]}
                 >
-                  <Field
+                  <ReactFinalForm(Field)
                     FieldArrayProvider={[Function]}
                     FieldProvider={[Function]}
                     formOptions={
@@ -668,48 +550,11 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                         "valid": true,
                       }
                     }
-                    format={[Function]}
                     name="secret"
-                    parse={[Function]}
-                    reactFinalForm={
-                      Object {
-                        "batch": [Function],
-                        "blur": [Function],
-                        "change": [Function],
-                        "destroyOnUnregister": false,
-                        "focus": [Function],
-                        "getFieldState": [Function],
-                        "getRegisteredFields": [Function],
-                        "getState": [Function],
-                        "initialize": [Function],
-                        "isValidationPaused": [Function],
-                        "mutators": Object {
-                          "concat": [Function],
-                          "insert": [Function],
-                          "move": [Function],
-                          "pop": [Function],
-                          "push": [Function],
-                          "remove": [Function],
-                          "removeBatch": [Function],
-                          "shift": [Function],
-                          "swap": [Function],
-                          "unshift": [Function],
-                          "update": [Function],
-                        },
-                        "pauseValidation": [Function],
-                        "registerField": [Function],
-                        "reset": [Function],
-                        "resetFieldState": [Function],
-                        "resumeValidation": [Function],
-                        "setConfig": [Function],
-                        "submit": [Function],
-                        "subscribe": [Function],
-                      }
-                    }
                     render={[Function]}
                     validate={[Function]}
                   >
-                    <Component
+                    <Field
                       FieldArrayProvider={[Function]}
                       FieldProvider={[Function]}
                       formOptions={
@@ -754,45 +599,132 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                           "valid": true,
                         }
                       }
-                      input={
+                      format={[Function]}
+                      name="secret"
+                      parse={[Function]}
+                      reactFinalForm={
                         Object {
-                          "name": "secret",
-                          "onBlur": [Function],
-                          "onChange": [Function],
-                          "onFocus": [Function],
-                          "value": "",
+                          "batch": [Function],
+                          "blur": [Function],
+                          "change": [Function],
+                          "destroyOnUnregister": false,
+                          "focus": [Function],
+                          "getFieldState": [Function],
+                          "getRegisteredFields": [Function],
+                          "getState": [Function],
+                          "initialize": [Function],
+                          "isValidationPaused": [Function],
+                          "mutators": Object {
+                            "concat": [Function],
+                            "insert": [Function],
+                            "move": [Function],
+                            "pop": [Function],
+                            "push": [Function],
+                            "remove": [Function],
+                            "removeBatch": [Function],
+                            "shift": [Function],
+                            "swap": [Function],
+                            "unshift": [Function],
+                            "update": [Function],
+                          },
+                          "pauseValidation": [Function],
+                          "registerField": [Function],
+                          "reset": [Function],
+                          "resetFieldState": [Function],
+                          "resumeValidation": [Function],
+                          "setConfig": [Function],
+                          "submit": [Function],
+                          "subscribe": [Function],
                         }
                       }
-                      meta={
-                        Object {
-                          "active": false,
-                          "data": Object {},
-                          "dirty": false,
-                          "dirtySinceLastSubmit": false,
-                          "error": undefined,
-                          "initial": undefined,
-                          "invalid": false,
-                          "modified": false,
-                          "pristine": true,
-                          "submitError": undefined,
-                          "submitFailed": false,
-                          "submitSucceeded": false,
-                          "submitting": false,
-                          "touched": false,
-                          "valid": true,
-                          "visited": false,
-                        }
-                      }
+                      render={[Function]}
+                      validate={[Function]}
                     >
-                      <div
-                        className="nested-item"
+                      <Component
+                        FieldArrayProvider={[Function]}
+                        FieldProvider={[Function]}
+                        formOptions={
+                          Object {
+                            "batch": [Function],
+                            "blur": [Function],
+                            "change": [Function],
+                            "clearOnUnmount": false,
+                            "clearedValue": undefined,
+                            "concat": [Function],
+                            "destroyOnUnregister": false,
+                            "focus": [Function],
+                            "getFieldState": [Function],
+                            "getRegisteredFields": [Function],
+                            "getState": [Function],
+                            "handleSubmit": [Function],
+                            "initialize": [Function],
+                            "insert": [Function],
+                            "isValidationPaused": [Function],
+                            "move": [Function],
+                            "onCancel": undefined,
+                            "onReset": undefined,
+                            "onSubmit": [MockFunction],
+                            "pauseValidation": [Function],
+                            "pop": [Function],
+                            "pristine": true,
+                            "push": [Function],
+                            "registerField": [Function],
+                            "remove": [Function],
+                            "removeBatch": [Function],
+                            "renderForm": [Function],
+                            "reset": [Function],
+                            "resetFieldState": [Function],
+                            "resumeValidation": [Function],
+                            "setConfig": [Function],
+                            "shift": [Function],
+                            "submit": [Function],
+                            "subscribe": [Function],
+                            "swap": [Function],
+                            "unshift": [Function],
+                            "update": [Function],
+                            "valid": true,
+                          }
+                        }
+                        input={
+                          Object {
+                            "name": "secret",
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "value": "",
+                          }
+                        }
+                        meta={
+                          Object {
+                            "active": false,
+                            "data": Object {},
+                            "dirty": false,
+                            "dirtySinceLastSubmit": false,
+                            "error": undefined,
+                            "initial": undefined,
+                            "invalid": false,
+                            "modified": false,
+                            "pristine": true,
+                            "submitError": undefined,
+                            "submitFailed": false,
+                            "submitSucceeded": false,
+                            "submitting": false,
+                            "touched": false,
+                            "valid": true,
+                            "visited": false,
+                          }
+                        }
                       >
-                        Select field
-                      </div>
-                    </Component>
-                  </Field>
-                </ReactFinalForm(Field)>
-              </FieldProvider>
+                        <div
+                          className="nested-item"
+                        >
+                          Select field
+                        </div>
+                      </Component>
+                    </Field>
+                  </ReactFinalForm(Field)>
+                </FieldProvider>
+              </TemporaryWrapper>
             </FieldWrapper>
           </FormFieldHideWrapper>
         </FormConditionWrapper>
@@ -1029,48 +961,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                   "text-field",
                 ]
               }
-              formOptions={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "clearOnUnmount": false,
-                  "clearedValue": undefined,
-                  "concat": [Function],
-                  "destroyOnUnregister": false,
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "handleSubmit": [Function],
-                  "initialize": [Function],
-                  "insert": [Function],
-                  "isValidationPaused": [Function],
-                  "move": [Function],
-                  "onCancel": undefined,
-                  "onReset": undefined,
-                  "onSubmit": [MockFunction],
-                  "pauseValidation": [Function],
-                  "pop": [Function],
-                  "pristine": true,
-                  "push": [Function],
-                  "registerField": [Function],
-                  "remove": [Function],
-                  "removeBatch": [Function],
-                  "renderForm": [Function],
-                  "reset": [Function],
-                  "resetFieldState": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "shift": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                  "valid": true,
-                }
-              }
               label="Visible"
               name="visible"
               validate={
@@ -1082,48 +972,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
               <Component
                 FieldProvider={[Function]}
                 FormSpyProvider={[Function]}
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onReset": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
                 label="Visible"
                 name="visible"
                 validate={[Function]}
@@ -1151,48 +999,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                     "text-field",
                   ]
                 }
-                formOptions={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "clearOnUnmount": false,
-                    "clearedValue": undefined,
-                    "concat": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "handleSubmit": [Function],
-                    "initialize": [Function],
-                    "insert": [Function],
-                    "isValidationPaused": [Function],
-                    "move": [Function],
-                    "onCancel": undefined,
-                    "onReset": undefined,
-                    "onSubmit": [MockFunction],
-                    "pauseValidation": [Function],
-                    "pop": [Function],
-                    "pristine": true,
-                    "push": [Function],
-                    "registerField": [Function],
-                    "remove": [Function],
-                    "removeBatch": [Function],
-                    "renderForm": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "shift": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                    "valid": true,
-                  }
-                }
                 label="Hidden"
                 name="hidden"
                 validate={
@@ -1204,48 +1010,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                 <Component
                   FieldProvider={[Function]}
                   FormSpyProvider={[Function]}
-                  formOptions={
-                    Object {
-                      "batch": [Function],
-                      "blur": [Function],
-                      "change": [Function],
-                      "clearOnUnmount": false,
-                      "clearedValue": undefined,
-                      "concat": [Function],
-                      "destroyOnUnregister": false,
-                      "focus": [Function],
-                      "getFieldState": [Function],
-                      "getRegisteredFields": [Function],
-                      "getState": [Function],
-                      "handleSubmit": [Function],
-                      "initialize": [Function],
-                      "insert": [Function],
-                      "isValidationPaused": [Function],
-                      "move": [Function],
-                      "onCancel": undefined,
-                      "onReset": undefined,
-                      "onSubmit": [MockFunction],
-                      "pauseValidation": [Function],
-                      "pop": [Function],
-                      "pristine": true,
-                      "push": [Function],
-                      "registerField": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "renderForm": [Function],
-                      "reset": [Function],
-                      "resetFieldState": [Function],
-                      "resumeValidation": [Function],
-                      "setConfig": [Function],
-                      "shift": [Function],
-                      "submit": [Function],
-                      "subscribe": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                      "valid": true,
-                    }
-                  }
                   label="Hidden"
                   name="hidden"
                   validate={[Function]}

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -82,48 +82,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
           </React.Fragment>,
         ]
       }
-      formOptions={
-        Object {
-          "batch": [Function],
-          "blur": [Function],
-          "change": [Function],
-          "clearOnUnmount": false,
-          "clearedValue": undefined,
-          "concat": [Function],
-          "destroyOnUnregister": false,
-          "focus": [Function],
-          "getFieldState": [Function],
-          "getRegisteredFields": [Function],
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "initialize": [Function],
-          "insert": [Function],
-          "isValidationPaused": [Function],
-          "move": [Function],
-          "onCancel": undefined,
-          "onReset": undefined,
-          "onSubmit": [MockFunction],
-          "pauseValidation": [Function],
-          "pop": [Function],
-          "pristine": true,
-          "push": [Function],
-          "registerField": [Function],
-          "remove": [Function],
-          "removeBatch": [Function],
-          "renderForm": [Function],
-          "reset": [Function],
-          "resetFieldState": [Function],
-          "resumeValidation": [Function],
-          "setConfig": [Function],
-          "shift": [Function],
-          "submit": [Function],
-          "subscribe": [Function],
-          "swap": [Function],
-          "unshift": [Function],
-          "update": [Function],
-          "valid": true,
-        }
-      }
       schema={
         Object {
           "fields": Array [
@@ -882,48 +840,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
             </Context.Consumer>
           </React.Fragment>,
         ]
-      }
-      formOptions={
-        Object {
-          "batch": [Function],
-          "blur": [Function],
-          "change": [Function],
-          "clearOnUnmount": false,
-          "clearedValue": undefined,
-          "concat": [Function],
-          "destroyOnUnregister": false,
-          "focus": [Function],
-          "getFieldState": [Function],
-          "getRegisteredFields": [Function],
-          "getState": [Function],
-          "handleSubmit": [Function],
-          "initialize": [Function],
-          "insert": [Function],
-          "isValidationPaused": [Function],
-          "move": [Function],
-          "onCancel": undefined,
-          "onReset": undefined,
-          "onSubmit": [MockFunction],
-          "pauseValidation": [Function],
-          "pop": [Function],
-          "pristine": true,
-          "push": [Function],
-          "registerField": [Function],
-          "remove": [Function],
-          "removeBatch": [Function],
-          "renderForm": [Function],
-          "reset": [Function],
-          "resetFieldState": [Function],
-          "resumeValidation": [Function],
-          "setConfig": [Function],
-          "shift": [Function],
-          "submit": [Function],
-          "subscribe": [Function],
-          "swap": [Function],
-          "unshift": [Function],
-          "update": [Function],
-          "valid": true,
-        }
       }
       schema={
         Object {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -231,11 +231,6 @@ exports[`renderForm function should render single field from defined componentTy
         <FieldWrapper
           component={[Function]}
           componentType="text-field"
-          formOptions={
-            Object {
-              "renderForm": [Function],
-            }
-          }
           name="foo"
           validate={
             Array [
@@ -243,31 +238,26 @@ exports[`renderForm function should render single field from defined componentTy
             ]
           }
         >
-          <FieldProvider
+          <TemporaryWrapper
             FieldArrayProvider={[Function]}
             FieldProvider={[Function]}
             component={[Function]}
-            formOptions={
-              Object {
-                "renderForm": [Function],
-              }
-            }
             name="foo"
             validate={[Function]}
           >
-            <ReactFinalForm(Field)
+            <FieldProvider
               FieldArrayProvider={[Function]}
               FieldProvider={[Function]}
+              component={[Function]}
               formOptions={
                 Object {
                   "renderForm": [Function],
                 }
               }
               name="foo"
-              render={[Function]}
               validate={[Function]}
             >
-              <Field
+              <ReactFinalForm(Field)
                 FieldArrayProvider={[Function]}
                 FieldProvider={[Function]}
                 formOptions={
@@ -275,48 +265,11 @@ exports[`renderForm function should render single field from defined componentTy
                     "renderForm": [Function],
                   }
                 }
-                format={[Function]}
                 name="foo"
-                parse={[Function]}
-                reactFinalForm={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "destroyOnUnregister": false,
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "initialize": [Function],
-                    "isValidationPaused": [Function],
-                    "mutators": Object {
-                      "concat": [Function],
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "removeBatch": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pauseValidation": [Function],
-                    "registerField": [Function],
-                    "reset": [Function],
-                    "resetFieldState": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                  }
-                }
                 render={[Function]}
                 validate={[Function]}
               >
-                <Component
+                <Field
                   FieldArrayProvider={[Function]}
                   FieldProvider={[Function]}
                   formOptions={
@@ -324,38 +277,50 @@ exports[`renderForm function should render single field from defined componentTy
                       "renderForm": [Function],
                     }
                   }
-                  input={
+                  format={[Function]}
+                  name="foo"
+                  parse={[Function]}
+                  reactFinalForm={
                     Object {
-                      "name": "foo",
-                      "onBlur": [Function],
-                      "onChange": [Function],
-                      "onFocus": [Function],
-                      "value": "",
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "destroyOnUnregister": false,
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "initialize": [Function],
+                      "isValidationPaused": [Function],
+                      "mutators": Object {
+                        "concat": [Function],
+                        "insert": [Function],
+                        "move": [Function],
+                        "pop": [Function],
+                        "push": [Function],
+                        "remove": [Function],
+                        "removeBatch": [Function],
+                        "shift": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                      },
+                      "pauseValidation": [Function],
+                      "registerField": [Function],
+                      "reset": [Function],
+                      "resetFieldState": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
                     }
                   }
-                  meta={
-                    Object {
-                      "active": false,
-                      "data": Object {},
-                      "dirty": false,
-                      "dirtySinceLastSubmit": false,
-                      "error": undefined,
-                      "initial": undefined,
-                      "invalid": false,
-                      "modified": false,
-                      "pristine": true,
-                      "submitError": undefined,
-                      "submitFailed": false,
-                      "submitSucceeded": false,
-                      "submitting": false,
-                      "touched": false,
-                      "valid": true,
-                      "visited": false,
-                    }
-                  }
+                  render={[Function]}
+                  validate={[Function]}
                 >
-                  <div
+                  <Component
                     FieldArrayProvider={[Function]}
+                    FieldProvider={[Function]}
                     formOptions={
                       Object {
                         "renderForm": [Function],
@@ -391,12 +356,50 @@ exports[`renderForm function should render single field from defined componentTy
                       }
                     }
                   >
-                    TextField
-                  </div>
-                </Component>
-              </Field>
-            </ReactFinalForm(Field)>
-          </FieldProvider>
+                    <div
+                      FieldArrayProvider={[Function]}
+                      formOptions={
+                        Object {
+                          "renderForm": [Function],
+                        }
+                      }
+                      input={
+                        Object {
+                          "name": "foo",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": undefined,
+                          "invalid": false,
+                          "modified": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "submitting": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                    >
+                      TextField
+                    </div>
+                  </Component>
+                </Field>
+              </ReactFinalForm(Field)>
+            </FieldProvider>
+          </TemporaryWrapper>
         </FieldWrapper>
       </FormFieldHideWrapper>
     </FormConditionWrapper>
@@ -437,11 +440,6 @@ exports[`renderForm function should render single field from with custom compone
         <FieldWrapper
           component={[Function]}
           componentType="custom-component"
-          formOptions={
-            Object {
-              "renderForm": [Function],
-            }
-          }
           name="foo"
           validate={
             Array [
@@ -452,11 +450,6 @@ exports[`renderForm function should render single field from with custom compone
           <CustomComponent
             FieldProvider={[Function]}
             FormSpyProvider={[Function]}
-            formOptions={
-              Object {
-                "renderForm": [Function],
-              }
-            }
             name="foo"
             validate={[Function]}
           >

--- a/packages/react-renderer-demo/src/app/src/components/missing-demo-fields/mui-wizard/mui-wizard.js
+++ b/packages/react-renderer-demo/src/app/src/components/missing-demo-fields/mui-wizard/mui-wizard.js
@@ -2,6 +2,7 @@ import React, { cloneElement } from 'react';
 import WizardStep from './wizard-step';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
+import useFormApi from '../../../../../../../react-form-renderer/src/hooks/useFormApi';
 
 class Wizard extends React.Component {
   state = {
@@ -58,4 +59,7 @@ class Wizard extends React.Component {
   }
 }
 
-export default Wizard;
+export default (props) => {
+  const formOptions = useFormApi();
+  return <Wizard { ...props } formOptions={ formOptions }/>;
+};

--- a/packages/react-renderer-demo/src/app/src/doc-components/component-mapper/form-fields-mapper.js
+++ b/packages/react-renderer-demo/src/app/src/doc-components/component-mapper/form-fields-mapper.js
@@ -28,7 +28,7 @@ const getButtonStyle = variant => ({
 
 const Button = ({ children, label, variant, ...props }) => <button style={ getButtonStyle(variant) } { ...props }>{ label }</button>;
 
-const TextField = ({ formOptions, customProp, label, input, isRequired, meta: { error, touched }, FieldProvider, FieldArrayProvider, dataType, ...props }) => (
+const TextField = ({ customProp, label, input, isRequired, meta: { error, touched }, FieldProvider, FieldArrayProvider, dataType, ...props }) => (
   <div className={ `ddorg__demo-formGroup ${isRequired ? 'required' : ''} ${error ? 'error' : ''}` }>
     <label htmlFor={ input.name }>{ label }</label>
     <input id={ input.name } { ...input } { ...props } />

--- a/packages/react-renderer-demo/src/app/src/doc-components/field-array/form-fields-mapper.js
+++ b/packages/react-renderer-demo/src/app/src/doc-components/field-array/form-fields-mapper.js
@@ -1,14 +1,12 @@
 /* eslint react/prop-types: "off" */
 import React, { Fragment, useState } from 'react';
-import FormRender, { componentTypes } from '@data-driven-forms/react-form-renderer';
+import FormRender, { componentTypes, useFormApi } from '@data-driven-forms/react-form-renderer';
 
 const wrapperStyles = {
   padding: 16,
   borderRadius: 4,
   fontFamily: 'Roboto',
 };
-
-const FormWrapper = ({ children, ...props }) => (<form style={ wrapperStyles } { ...props }>{ children }</form>);
 
 const getBackgroundColor = variant => ({
   primary: 'RebeccaPurple',
@@ -28,7 +26,7 @@ const getButtonStyle = variant => ({
 
 const Button = ({ children, label, variant, ...props }) => <button style={ getButtonStyle(variant) } { ...props }>{ label }</button>;
 
-const TextField = ({ formOptions, label, input, isRequired, meta: { error, touched }, FieldProvider, dataType, FieldArrayProvider, ...props }) => (
+const TextField = ({ label, input, isRequired, meta: { error, touched }, FieldProvider, dataType, FieldArrayProvider, ...props }) => (
   <div className={ `ddorg__demo-formGroup ${isRequired ? 'required' : ''} ${error ? 'error' : ''}` }>
     <label htmlFor={ input.name }>{ label }</label>
     <br />
@@ -43,13 +41,13 @@ const ArrayItem = ({
   fieldIndex,
   name,
   remove,
-  formOptions,
 }) => {
+  const {renderForm} = useFormApi();
   const editedFields = fields.map((field) => ({ ...field, name: `${name}.${field.name}` }));
 
   return (
     <React.Fragment>
-      { formOptions.renderForm(editedFields) }
+      { renderForm(editedFields) }
       <br />
       <Button
         onClick={ () => remove(fieldIndex) }
@@ -71,7 +69,6 @@ const FieldArray = ({
   description,
   fields,
   itemDefault,
-  formOptions,
   meta,
   FieldArrayProvider,
   ...rest
@@ -93,7 +90,6 @@ const FieldArray = ({
               fieldKey={ fieldKey }
               fieldIndex={ index }
               remove={ cosi.fields.remove }
-              formOptions={ formOptions }
             />)) }
           { isError && error }
           <br />


### PR DESCRIPTION
Usage

```jsx
import { useFormApi } from '@data-driven-forms/react-form-renderer';

const Component = (props) => {
     const formOptions = useFormApi();
     ...
}
```

TODO:
- [x] export context as well
- [ ] update FieldProvider after https://github.com/data-driven-forms/react-forms/pull/316 is merged
**FieldProvider is temporarily wrapped in a function, so it would be easier to rebase**

- [x] convert Wizard components to functions
  - MUI wizard is just wrapped, it used only in demo, it needs full implementation
  - PF3 wizard converted
  - PF4 wizard still class, useFormApi is used in the wrapper (huge task to refactor it, will do it in separate PR)
- [x] FREAKIN' TESTS :bomb: :boom: :boom: 