### PR TITLE
feat(FormSpy): export formSpy instead of passing it as a prop

### DIFF
--- a/__mocks__/mock-form-template.js
+++ b/__mocks__/mock-form-template.js
@@ -1,20 +1,21 @@
 import React from 'react';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
-import { useFormApi as useFormApiInternal } from '../packages/react-form-renderer/src';
+import { useFormApi, FormSpy } from '@data-driven-forms/react-form-renderer';
+import { useFormApi as useFormApiInternal, FormSpy as FormSpyInternal } from '../packages/react-form-renderer/src';
 const path = require('path')
 
-const FormTemplate = ({ schema: { title, label, description }, formFields, FormSpy }) => {
+const FormTemplate = ({ schema: { title, label, description }, formFields }) => {
   // When testing inside the renderer package, it cannot import things from itself!
   const isInternal = path.dirname(module.parent.filename).includes('/react-form-renderer/');
 
   const formOptions = isInternal ? useFormApiInternal() : useFormApi();
+  const FormSpyFinal = isInternal ? FormSpyInternal : FormSpy;
 
   return (
     <form onSubmit={ formOptions.handleSubmit }>
       { title || label && <h1>{ title || label }</h1> }
       { description && <h2>{ description }</h2> }
       { formFields }
-      <FormSpy>
+      <FormSpyFinal>
         { ({ submitting, pristine, validating, form: { reset }, values }) => (
           <React.Fragment>
             <button
@@ -41,7 +42,7 @@ const FormTemplate = ({ schema: { title, label, description }, formFields, FormS
             Cancel
             </button>
           </React.Fragment>) }
-      </FormSpy>
+      </FormSpyFinal>
     </form>
   );
 };

--- a/packages/common/src/form-template.js
+++ b/packages/common/src/form-template.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { useFormApi, FormSpy } from '@data-driven-forms/react-form-renderer';
 
 export const isDisabled = (disableStates, getState) => disableStates.map((item) => getState()[item]).find((item) => !!item);
 
@@ -105,7 +105,7 @@ const formTemplate = ({
   showFormControls = true,
   disableSubmit = [],
   ...options
-}) => ({ schema: { title, description, label }, formFields, FormSpy }) => {
+}) => ({ schema: { title, description, label }, formFields }) => {
   const { onReset, onCancel, getState, handleSubmit } = useFormApi();
 
   return (

--- a/packages/pf4-component-mapper/src/components/wizard.js
+++ b/packages/pf4-component-mapper/src/components/wizard.js
@@ -1,7 +1,7 @@
 import React, { cloneElement } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { useFormApi, FormSpy } from '@data-driven-forms/react-form-renderer';
 
 import { WizardHeader } from '@patternfly/react-core/dist/js/components/Wizard/WizardHeader';
 import { WizardNav } from '@patternfly/react-core/dist/js/components/Wizard/WizardNav';
@@ -235,7 +235,6 @@ class Wizard extends React.Component {
       setFullHeight,
       isCompactNav,
       showTitles,
-      FormSpyProvider,
       crossroads
     } = this.props;
     const { activeStepIndex, navSchema, maxStepIndex, isDynamic } = this.state;
@@ -267,7 +266,7 @@ class Wizard extends React.Component {
           {title && <WizardHeader title={title} description={description} onClose={() => formOptions.onCancel(formOptions.getState().values)} />}
           <div className="pf-c-wizard__outer-wrap">
             <WizardNav>
-              <FormSpyProvider>
+              <FormSpy>
                 {({ values }) => (
                   <WizardNavigation
                     navSchema={navSchema}
@@ -281,7 +280,7 @@ class Wizard extends React.Component {
                     setPrevSteps={this.setPrevSteps}
                   />
                 )}
-              </FormSpyProvider>
+              </FormSpy>
             </WizardNav>
             {cloneElement(currentStep, {
               handleNext: (nextStep) => this.handleNext(nextStep, formOptions.getRegisteredFields),
@@ -306,7 +305,6 @@ Wizard.propTypes = {
   title: PropTypes.any,
   description: PropTypes.any,
   FieldProvider: PropTypes.PropTypes.oneOfType([ PropTypes.object, PropTypes.func ]).isRequired,
-  FormSpyProvider: PropTypes.PropTypes.oneOfType([ PropTypes.object, PropTypes.func ]).isRequired,
   formOptions: PropTypes.shape({
     getState: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/form-template-common.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/form-template-common.test.js.snap
@@ -19,7 +19,6 @@ exports[`FormTemplate PF4 Common should add missing buttons if not defined in bu
       onSubmit={[MockFunction]}
     >
       <Component
-        FormSpy={[Function]}
         buttonOrder={Array []}
         canReset={true}
         canSubmit={true}
@@ -282,7 +281,6 @@ exports[`FormTemplate PF4 Common should render all controls and with default lab
       onSubmit={[MockFunction]}
     >
       <Component
-        FormSpy={[Function]}
         formFields={
           <div>
             Formfields
@@ -542,7 +540,6 @@ exports[`FormTemplate PF4 Common should render buttons in correct order 1`] = `
       onSubmit={[MockFunction]}
     >
       <Component
-        FormSpy={[Function]}
         buttonOrder={
           Array [
             "cancel",
@@ -811,7 +808,6 @@ exports[`FormTemplate PF4 Common should render only submit button 1`] = `
       onSubmit={[MockFunction]}
     >
       <Component
-        FormSpy={[Function]}
         canReset={false}
         formFields={
           <div>

--- a/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/field-array/__snapshots__/field-array.test.js.snap
@@ -93,7 +93,6 @@ exports[`FieldArray should render array field correctly 1`] = `
       }
     >
       <Component
-        FormSpy={[Function]}
         formFields={
           Array [
             <React.Fragment>

--- a/packages/pf4-component-mapper/src/tests/form-template-common.test.js
+++ b/packages/pf4-component-mapper/src/tests/form-template-common.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, FormSpy } from 'react-final-form';
+import { Form } from '@data-driven-forms/react-form-renderer';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { formTemplate } from '../index';
@@ -21,8 +21,7 @@ describe('FormTemplate PF4 Common', () => {
     );
     initialProps = {
       formFields: <div>Formfields</div>,
-      schema: {},
-      FormSpy
+      schema: {}
     };
   });
 

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -93,7 +93,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
     }
   >
     <Component
-      FormSpy={[Function]}
       formFields={
         Array [
           <React.Fragment>
@@ -190,7 +189,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
               >
                 <WizardFunction
                   FieldProvider={[Function]}
-                  FormSpyProvider={[Function]}
                   buttonLabels={Object {}}
                   fields={
                     Array [
@@ -224,7 +222,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                 >
                   <Wizard
                     FieldProvider={[Function]}
-                    FormSpyProvider={[Function]}
                     buttonLabels={
                       Object {
                         "back": "Back",
@@ -1468,7 +1465,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
     }
   >
     <Component
-      FormSpy={[Function]}
       formFields={
         Array [
           <React.Fragment>
@@ -1567,7 +1563,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
               >
                 <WizardFunction
                   FieldProvider={[Function]}
-                  FormSpyProvider={[Function]}
                   buttonLabels={Object {}}
                   fields={
                     Array [
@@ -1602,7 +1597,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                 >
                   <Wizard
                     FieldProvider={[Function]}
-                    FormSpyProvider={[Function]}
                     buttonLabels={
                       Object {
                         "back": "Back",

--- a/packages/react-form-renderer/demo/form-template.js
+++ b/packages/react-form-renderer/demo/form-template.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { useFormApi, FormSpy } from '@data-driven-forms/react-form-renderer';
 
 const isDisabled = (disableStates, getState) => disableStates.map((item) => getState()[item]).find((item) => !!item);
 
-const FormTemplate = ({ schema: { title, description }, formFields, FormSpy }) => {
+const FormTemplate = ({ schema: { title, description }, formFields }) => {
   console.log('render of the form');
 
   const { handleSubmit, getState, onReset, onCancel } = useFormApi();

--- a/packages/react-form-renderer/src/components/form-renderer.js
+++ b/packages/react-form-renderer/src/components/form-renderer.js
@@ -39,8 +39,7 @@ const FormRenderer = ({
   const FormTemplate = formTemplate
     ? formTemplate
     : () => (
-      <div>{`FormRenderer is missing 'formTemplate' prop:
-  ({formFields, formSpy, schema}) => <FormTemplate {...} />`}</div>
+      <div>{`FormRenderer is missing 'formTemplate' prop: ({formFields, schema}) => <FormTemplate {...} />`}</div>
     );
 
   return (
@@ -76,7 +75,7 @@ const FormRenderer = ({
               formOptions
             }}
           >
-            <FormTemplate formFields={renderForm(schema.fields)} FormSpy={FormSpy} schema={schema} />
+            <FormTemplate formFields={renderForm(schema.fields)} schema={schema} />
             {onStateUpdate && <FormSpy onChange={onStateUpdate} />}
           </RendererContext.Provider>
         );

--- a/packages/react-form-renderer/src/components/form-spy.js
+++ b/packages/react-form-renderer/src/components/form-spy.js
@@ -1,0 +1,3 @@
+import { FormSpy } from 'react-final-form';
+
+export default FormSpy;

--- a/packages/react-form-renderer/src/components/form.js
+++ b/packages/react-form-renderer/src/components/form.js
@@ -1,0 +1,3 @@
+import { Form } from 'react-final-form';
+
+export default Form;

--- a/packages/react-form-renderer/src/form-renderer/field-wrapper.js
+++ b/packages/react-form-renderer/src/form-renderer/field-wrapper.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormSpy } from 'react-final-form';
 
 import { FieldArray } from 'react-final-form-arrays';
 import { shouldWrapInField } from './helpers';
@@ -40,7 +39,7 @@ const FieldWrapper = ({ componentType, validate, component, ...rest }) => {
   const Component = component;
   return shouldWrapInField(componentType)
     ? <FieldProvider { ...componentProps } />
-    : <Component validate={ composeValidators(validate) } { ...rest } FieldProvider={ FieldProvider } FormSpyProvider={ FormSpy } />;
+    : <Component validate={ composeValidators(validate) } { ...rest } FieldProvider={ FieldProvider } />;
 };
 
 FieldWrapper.propTypes = {

--- a/packages/react-form-renderer/src/index.js
+++ b/packages/react-form-renderer/src/index.js
@@ -10,6 +10,8 @@ export { default as Validators } from './validators/validators';
 export { default as defaultSchemaValidator } from './parsers/default-schema-validator';
 export { default as useFormApi } from './hooks/useFormApi';
 export { default as RendererContext } from './components/renderer-context';
+export { default as FormSpy } from './components/form-spy';
+export { default as Form } from './components/form';
 
 export const schemaParsers = {
   mozillaParser,

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -67,7 +67,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
     }
   >
     <FormTemplate
-      FormSpy={[Function]}
       formFields={
         Array [
           <React.Fragment>
@@ -826,7 +825,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
     }
   >
     <FormTemplate
-      FormSpy={[Function]}
       formFields={
         Array [
           <React.Fragment>
@@ -887,7 +885,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
             >
               <Component
                 FieldProvider={[Function]}
-                FormSpyProvider={[Function]}
                 label="Visible"
                 name="visible"
                 validate={[Function]}
@@ -925,7 +922,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
               >
                 <Component
                   FieldProvider={[Function]}
-                  FormSpyProvider={[Function]}
                   label="Hidden"
                   name="hidden"
                   validate={[Function]}

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -449,12 +449,10 @@ exports[`renderForm function should render single field from with custom compone
         >
           <CustomComponent
             FieldProvider={[Function]}
-            FormSpyProvider={[Function]}
             name="foo"
             validate={[Function]}
           >
             <div
-              FormSpyProvider={[Function]}
               name="foo"
               validate={[Function]}
             >


### PR DESCRIPTION
```jsx
import { FormSpy } from '@data-driven-forms/react-form-renderer';
```