### PR TITLE
Add fallback for releases

### DIFF
--- a/packages/react-renderer-demo/src/app/pages/releases.js
+++ b/packages/react-renderer-demo/src/app/pages/releases.js
@@ -25,7 +25,12 @@ const ReleasesPage = () => {
       setData(parseData(data));
     })
     .catch(() => {
-      setData('Something wrong happened :(');
+      setData(<React.Fragment>
+        Cannot obtain data from GitHub, please visit
+        <a href="https://github.com/data-driven-forms/react-forms/releases" rel="noopener noreferrer" target="_blank">
+          GitHub page.
+        </a>
+      </React.Fragment>);
     });
   }, []);
 


### PR DESCRIPTION
- GitHub's API has limit for request from one IP address