### PR TITLE
[V2] feat(renderer): remove onStateUpdate prop

### DIFF
--- a/packages/common/src/form-template.js
+++ b/packages/common/src/form-template.js
@@ -104,6 +104,7 @@ const formTemplate = ({
   formWrapperProps,
   showFormControls = true,
   disableSubmit = [],
+  onStateUpdate,
   ...options
 }) => ({ schema: { title, description, label }, formFields }) => {
   const { onReset, onCancel, getState, handleSubmit } = useFormApi();
@@ -113,6 +114,7 @@ const formTemplate = ({
       {(title || label) && <Title>{title || label}</Title>}
       {description && <Description>{description}</Description>}
       {formFields}
+      {onStateUpdate && <FormSpy onChange={onStateUpdate} />}
       {showFormControls && (
         <FormSpy>
           {(formSpyProps) => (

--- a/packages/pf4-component-mapper/src/tests/form-template-common.test.js
+++ b/packages/pf4-component-mapper/src/tests/form-template-common.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form } from '@data-driven-forms/react-form-renderer';
+import { Form, FormSpy } from '@data-driven-forms/react-form-renderer';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { formTemplate } from '../index';
@@ -42,6 +42,7 @@ describe('FormTemplate PF4 Common', () => {
     expect(wrapper.find(Title)).toHaveLength(1);
     expect(wrapper.find(Description)).toHaveLength(0);
     expect(wrapper.find(Button)).toHaveLength(2);
+    expect(wrapper.find(FormSpy)).toHaveLength(1);
   });
 
   it('should hide buttons', () => {
@@ -54,6 +55,22 @@ describe('FormTemplate PF4 Common', () => {
     );
 
     expect(wrapper.find(Button)).toHaveLength(0);
+    expect(wrapper.find(FormSpy)).toHaveLength(0);
+  });
+
+  it('should render formSpy with onChange', () => {
+    const onStateUpdate = jest.fn();
+
+    FormTemplate = formTemplate({ showFormControls: false, onStateUpdate });
+
+    const wrapper = mount(
+      <ContextWrapper>
+        <FormTemplate {...initialProps} />
+      </ContextWrapper>
+    );
+
+    expect(wrapper.find(FormSpy)).toHaveLength(1);
+    expect(wrapper.find(FormSpy).props().onChange).toEqual(onStateUpdate);
   });
 
   it('should render description', () => {

--- a/packages/react-form-renderer/src/components/form-renderer.js
+++ b/packages/react-form-renderer/src/components/form-renderer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, FormSpy } from 'react-final-form';
+import { Form } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
 import PropTypes from 'prop-types';
 import createFocusDecorator from 'final-form-focus';
@@ -18,7 +18,6 @@ const FormRenderer = ({
   initialValues,
   clearOnUnmount,
   validate,
-  onStateUpdate,
   subscription,
   clearedValue,
   schema
@@ -76,7 +75,6 @@ const FormRenderer = ({
             }}
           >
             <FormTemplate formFields={renderForm(schema.fields)} schema={schema} />
-            {onStateUpdate && <FormSpy onChange={onStateUpdate} />}
           </RendererContext.Provider>
         );
       }}
@@ -92,7 +90,6 @@ FormRenderer.propTypes = {
   initialValues: PropTypes.object,
   clearOnUnmount: PropTypes.bool,
   validate: PropTypes.func,
-  onStateUpdate: PropTypes.func,
   subscription: PropTypes.shape({ [PropTypes.string]: PropTypes.bool }),
   clearedValue: PropTypes.any
 };

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -735,39 +735,6 @@ describe('renderForm function', () => {
     });
   });
 
-  describe('#formSpy', () => {
-    const TextField = ({ input, meta, label, formOptions, helperText, isRequired, dataType, isDisabled, isReadOnly, ...rest }) => (
-      <div>
-        <label>{ label }</label>
-        <input { ...input } { ...rest } />
-        { meta.error && <div><span>{ meta.error }</span></div> }
-      </div>
-    );
-
-    it('should add formSpy and call update function on each state change', () => {
-      const onStateUpdate = jest.fn();
-      const wrapper = mount(
-        <FormRenderer
-          onStateUpdate={ onStateUpdate }
-          formTemplate={ formTemplate }
-          formFieldsMapper={{
-            [componentTypes.TEXT_FIELD]: TextField,
-          }}
-          schema={{ fields: [{ component: componentTypes.TEXT_FIELD, name: 'foo', label: 'bar' }]}}
-          onSubmit={ jest.fn() }
-          clearOnUnmount
-        />
-      );
-      /**
-       * there is one FormSpy for form controls
-       */
-      expect(wrapper.find(FormSpy)).toHaveLength(2);
-      wrapper.find('input').first().simulate('change', { target: { value: 'bar' }});
-      wrapper.find('input').last().simulate('change', { target: { value: 'foovalue' }});
-      expect(onStateUpdate).toHaveBeenCalledTimes(4);
-    });
-  });
-
   describe('#initializeOnMount', () => {
     const SHOWER_FIELD = 'shower_FIELD';
     const INITIALIZED_FIELD = 'initialized_FIELD';


### PR DESCRIPTION
user can do it in formTemplate (all mappers' default formTemplates support it)

Custom implementation in formTemplates:
```jsx
import { FormSpy } from '@data-driven-forms/react-form-renderer';

{onStateUpdate && <FormSpy onChange={onStateUpdate} />}
```