### PR TITLE
[V2] Validator mapper

### DIFF
--- a/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
@@ -127,11 +127,6 @@ exports[`<Input Addon> should render group button before input addon correctly 1
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -318,11 +313,6 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -481,11 +471,6 @@ exports[`<Input Addon> should render single after input addon correctly 1`] = `
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -627,11 +612,6 @@ exports[`<Input Addon> should render single before input addon correctly 1`] = `
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -771,11 +751,6 @@ exports[`<Input Addon> should render single button after input addon correctly 1
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -926,11 +901,6 @@ exports[`<Input Addon> should render single button before input addon correctly 
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -1153,11 +1123,6 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
             label="Text Box With Input Addon"
             name="text_box_21"
             title="Text Box With Input Addon"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -125,11 +125,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
               ]
             }
             name="wizard"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -207,11 +202,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
               ]
             }
             name="wizard"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           >
             <FormConditionWrapper>
               <FormFieldHideWrapper
@@ -248,11 +238,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                     ]
                   }
                   name="wizard"
-                  validate={
-                    Array [
-                      undefined,
-                    ]
-                  }
                 >
                   <WizardFunction
                     FieldProvider={[Function]}
@@ -605,11 +590,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                       <SingleField
                                         component="text-field"
                                         name="foo-field"
-                                        validate={
-                                          Array [
-                                            undefined,
-                                          ]
-                                        }
                                       >
                                         <FormConditionWrapper>
                                           <FormFieldHideWrapper
@@ -619,11 +599,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                               component={[Function]}
                                               componentType="text-field"
                                               name="foo-field"
-                                              validate={
-                                                Array [
-                                                  undefined,
-                                                ]
-                                              }
                                             >
                                               <TextField
                                                 FieldProvider={[Function]}
@@ -1276,11 +1251,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
             }
             inModal={true}
             name="wizard"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -1360,11 +1330,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
             }
             inModal={true}
             name="wizard"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           >
             <FormConditionWrapper>
               <FormFieldHideWrapper
@@ -1402,11 +1367,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                   }
                   inModal={true}
                   name="wizard"
-                  validate={
-                    Array [
-                      undefined,
-                    ]
-                  }
                 >
                   <WizardFunction
                     FieldProvider={[Function]}
@@ -1978,11 +1938,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                 <SingleField
                                                   component="text-field"
                                                   name="foo-field"
-                                                  validate={
-                                                    Array [
-                                                      undefined,
-                                                    ]
-                                                  }
                                                 >
                                                   <FormConditionWrapper>
                                                     <FormFieldHideWrapper
@@ -1992,11 +1947,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                         component={[Function]}
                                                         componentType="text-field"
                                                         name="foo-field"
-                                                        validate={
-                                                          Array [
-                                                            undefined,
-                                                          ]
-                                                        }
                                                       >
                                                         <TextField
                                                           FieldProvider={[Function]}

--- a/packages/react-form-renderer/demo/form-fields-mapper.js
+++ b/packages/react-form-renderer/demo/form-fields-mapper.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { componentTypes } from '../src';
 import FieldProvider from '../src/components/field-provider';
-import useFieldApi from '../src/components/useFieldApi';
+import useFieldApi from '../src/hooks/use-field-api';
 
 const TextField = (props) => (
   <FieldProvider

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -1,8 +1,7 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { childrenPropTypes } from '@data-driven-forms/common/src/prop-types-templates';
 import { dataTypeValidator } from '../validators';
-import validatorMapper from '../validators/validator-mapper';
 import RendererContext from '../components/renderer-context';
 import Condition from './condition';
 import { memoize } from '../validators/helpers';
@@ -26,36 +25,43 @@ FormConditionWrapper.propTypes = {
   children: childrenPropTypes.isRequired
 };
 
-const SingleField = ({ component, condition, hideField, ...rest }) => (
-  <Fragment key={rest.key || rest.name}>
-    <RendererContext.Consumer>
-      {({ formFieldsMapper }) => (
-        <FormConditionWrapper condition={condition}>
-          <FormFieldHideWrapper hideField={hideField}>
-            <FieldWrapper componentType={component} component={formFieldsMapper[component]} name={rest.name || rest.key} {...rest} />
-          </FormFieldHideWrapper>
-        </FormConditionWrapper>
-      )}
-    </RendererContext.Consumer>
-  </Fragment>
-);
+const prepareValidator = (validator, mapper) => (typeof validator === 'function' ? memoize(validator) : mapper[validator.type]({ ...validator }));
+
+const getValidate = (validate, dataType, mapper) => ({
+  validate: validate
+    ? [...validate.map((validator) => prepareValidator(validator, mapper)), dataType && dataTypeValidator(dataType)()]
+    : [dataType && dataTypeValidator(dataType)()]
+});
+
+const SingleField = ({ component, condition, hideField, validate, dataType, ...rest }) => {
+  const { formFieldsMapper, validatorMapper } = useContext(RendererContext);
+
+  return (
+    <Fragment key={rest.key || rest.name}>
+      <FormConditionWrapper condition={condition}>
+        <FormFieldHideWrapper hideField={hideField}>
+          <FieldWrapper
+            componentType={component}
+            component={formFieldsMapper[component]}
+            name={rest.name || rest.key}
+            dataType={dataType}
+            {...rest}
+            {...(validate || dataType ? getValidate(validate, dataType, validatorMapper) : {})}
+          />
+        </FormFieldHideWrapper>
+      </FormConditionWrapper>
+    </Fragment>
+  );
+};
 
 SingleField.propTypes = {
   component: PropTypes.string.isRequired,
   condition: PropTypes.object,
-  hideField: PropTypes.bool
+  hideField: PropTypes.bool,
+  dataType: PropTypes.string,
+  validate: PropTypes.array
 };
 
-const prepareValidator = (validator) => (typeof validator === 'function' ? memoize(validator) : validatorMapper(validator.type)({ ...validator }));
-
-const prepareFieldProps = (field) => ({
-  ...field,
-  validate: field.validate
-    ? [...field.validate.map((validator) => prepareValidator(validator)), field.dataType && dataTypeValidator(field.dataType)()]
-    : [field.dataType && dataTypeValidator(field.dataType)()]
-});
-
-const renderForm = (fields) =>
-  fields.map((field) => (Array.isArray(field) ? renderForm(field) : <SingleField key={fields.name} {...prepareFieldProps(field)} />));
+const renderForm = (fields) => fields.map((field) => (Array.isArray(field) ? renderForm(field) : <SingleField key={fields.name} {...field} />));
 
 export default renderForm;

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -72,20 +72,10 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
           <SingleField
             component="text-field"
             name="component1"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
           <SingleField
             component="select-field"
             name="secret"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -110,11 +100,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
         <SingleField
           component="text-field"
           name="component1"
-          validate={
-            Array [
-              undefined,
-            ]
-          }
         >
           <FormConditionWrapper>
             <FormFieldHideWrapper
@@ -124,11 +109,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 component={[Function]}
                 componentType="text-field"
                 name="component1"
-                validate={
-                  Array [
-                    undefined,
-                  ]
-                }
               >
                 <TextField
                   FieldProvider={[Function]}
@@ -155,11 +135,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
         <SingleField
           component="select-field"
           name="secret"
-          validate={
-            Array [
-              undefined,
-            ]
-          }
         >
           <FormConditionWrapper>
             <FormFieldHideWrapper
@@ -169,11 +144,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 component={[Function]}
                 componentType="select-field"
                 name="secret"
-                validate={
-                  Array [
-                    undefined,
-                  ]
-                }
               >
                 <Component
                   FieldProvider={[Function]}
@@ -294,22 +264,12 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
             component="text-field"
             label="Visible"
             name="visible"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
           <SingleField
             component="text-field"
             hideField={true}
             label="Hidden"
             name="hidden"
-            validate={
-              Array [
-                undefined,
-              ]
-            }
           />,
         ]
       }
@@ -338,11 +298,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
           component="text-field"
           label="Visible"
           name="visible"
-          validate={
-            Array [
-              undefined,
-            ]
-          }
         >
           <FormConditionWrapper>
             <FormFieldHideWrapper
@@ -353,11 +308,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                 componentType="text-field"
                 label="Visible"
                 name="visible"
-                validate={
-                  Array [
-                    undefined,
-                  ]
-                }
               >
                 <TextField
                   FieldProvider={[Function]}
@@ -387,11 +337,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
           hideField={true}
           label="Hidden"
           name="hidden"
-          validate={
-            Array [
-              undefined,
-            ]
-          }
         >
           <FormConditionWrapper>
             <FormFieldHideWrapper
@@ -405,11 +350,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                   componentType="text-field"
                   label="Hidden"
                   name="hidden"
-                  validate={
-                    Array [
-                      undefined,
-                    ]
-                  }
                 >
                   <TextField
                     FieldProvider={[Function]}

--- a/packages/react-form-renderer/src/tests/parsers/__snapshots__/default-schema-validator.test.js.snap
+++ b/packages/react-form-renderer/src/tests/parsers/__snapshots__/default-schema-validator.test.js.snap
@@ -76,7 +76,7 @@ exports[`Default schema validator should fail if field validate item is an objec
 "
         Error occured in field definition with name: \\"foo\\".
         Field validator at index: 0 does not have correct \\"type\\" property!
-        Received \\"magic\\", expected one of: [required-validator,min-length-validator,max-length-validator,exact-length-validator,min-items-validator,min-number-value,max-number-value,pattern-validator,url-validator].
+        Received \\"magic\\", expected one of: [].
       "
 `;
 

--- a/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
+++ b/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
@@ -2,6 +2,7 @@ import output from './output';
 import React from 'react';
 import defaultSchemaValidator from '../../parsers/default-schema-validator';
 import componentTypes from '../../components/component-types';
+import { validatorTypes as validatorTypesDefault } from '../..';
 
 describe('Default schema validator', () => {
   let formFieldsMapper;
@@ -317,6 +318,28 @@ describe('Default schema validator', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
+  it('should not fail if field validate item is an object and validator type is custom.', () => {
+    expect(() =>
+      defaultSchemaValidator(
+        {
+          fields: [
+            {
+              component: 'foo',
+              name: 'foo',
+              validate: [
+                {
+                  type: 'magic'
+                }
+              ]
+            }
+          ]
+        },
+        formFieldsMapper,
+        ['magic']
+      )
+    ).not.toThrow();
+  });
+
   it('should fail validation when using wrong data type', () => {
     expect(() =>
       defaultSchemaValidator(
@@ -350,17 +373,21 @@ describe('Default schema validator', () => {
 
   it('should pass validation', () => {
     expect(() =>
-      defaultSchemaValidator(output, {
-        ...formFieldsMapper,
-        'sub-form': () => <div />,
-        'text-field': () => <div />,
-        'textarea-field': () => <div />,
-        checkbox: () => <div />,
-        radio: () => <div />,
-        'select-field': () => <div />,
-        'date-picker': () => <div />,
-        'time-picker': () => <div />
-      })
+      defaultSchemaValidator(
+        output,
+        {
+          ...formFieldsMapper,
+          'sub-form': () => <div />,
+          'text-field': () => <div />,
+          'textarea-field': () => <div />,
+          checkbox: () => <div />,
+          radio: () => <div />,
+          'select-field': () => <div />,
+          'date-picker': () => <div />,
+          'time-picker': () => <div />
+        },
+        Object.values(validatorTypesDefault)
+      )
     ).not.toThrow();
   });
 });

--- a/packages/react-form-renderer/src/tests/validators/validators.test.js
+++ b/packages/react-form-renderer/src/tests/validators/validators.test.js
@@ -7,151 +7,151 @@ import validatorTypes from '../../components/validator-types';
 describe('New validators', () => {
   describe('Required validator', () => {
     it('should pass required validator', () => {
-      expect(validatorMapper(validatorTypes.REQUIRED)()('Foo')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.REQUIRED]()('Foo')).toBeUndefined();
     });
 
     it('should fail required validator', () => {
-      expect(validatorMapper(validatorTypes.REQUIRED)()()).toBe('Required');
+      expect(validatorMapper[validatorTypes.REQUIRED]()()).toBe('Required');
     });
 
     it('should fail required validator if string of white spaces', () => {
-      expect(validatorMapper(validatorTypes.REQUIRED)()('  ')).toBe('Required');
+      expect(validatorMapper[validatorTypes.REQUIRED]()('  ')).toBe('Required');
     });
 
     it('should fail required validator if empty string', () => {
-      expect(validatorMapper(validatorTypes.REQUIRED)()('')).toBe('Required');
+      expect(validatorMapper[validatorTypes.REQUIRED]()('')).toBe('Required');
     });
 
     it('should fail required validator if empty array', () => {
-      expect(validatorMapper(validatorTypes.REQUIRED)()([])).toBe('Required');
+      expect(validatorMapper[validatorTypes.REQUIRED]()([])).toBe('Required');
     });
   });
 
   describe('Length validator', () => {
     it('should pass empty value', () => {
-      expect(validatorMapper(validatorTypes.EXACT_LENGTH)({ threshold: 5 })('')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.EXACT_LENGTH]({ threshold: 5 })('')).toBeUndefined();
     });
 
     it('should pass undefined value', () => {
-      expect(validatorMapper(validatorTypes.EXACT_LENGTH)({ threshold: 5 })(undefined)).toBeUndefined();
+      expect(validatorMapper[validatorTypes.EXACT_LENGTH]({ threshold: 5 })(undefined)).toBeUndefined();
     });
 
     it('should pass exact length of 5 characters validation', () => {
-      expect(validatorMapper(validatorTypes.EXACT_LENGTH)({ threshold: 5 })('12345')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.EXACT_LENGTH]({ threshold: 5 })('12345')).toBeUndefined();
     });
 
     it('should fail exact length of 5 characters validation', () => {
-      expect(validatorMapper(validatorTypes.EXACT_LENGTH)({ threshold: 5 })('1234')).toBe('Should be 5 characters long.');
+      expect(validatorMapper[validatorTypes.EXACT_LENGTH]({ threshold: 5 })('1234')).toBe('Should be 5 characters long.');
     });
 
     it('should fail exact length of 5 characters validation with custom message', () => {
-      expect(validatorMapper(validatorTypes.EXACT_LENGTH)({ threshold: 5, message: 'Not 5 long' })('123456')).toBe('Not 5 long');
+      expect(validatorMapper[validatorTypes.EXACT_LENGTH]({ threshold: 5, message: 'Not 5 long' })('123456')).toBe('Not 5 long');
     });
 
     it('should pass min length of 3 characters validation', () => {
-      expect(validatorMapper(validatorTypes.MIN_LENGTH)({ threshold: 3 })('12345')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MIN_LENGTH]({ threshold: 3 })('12345')).toBeUndefined();
     });
 
     it('should not pass min length of 3 characters validation', () => {
-      expect(validatorMapper(validatorTypes.MIN_LENGTH)({ threshold: 3 })('12')).toBe('Must have at least 3 characters.');
+      expect(validatorMapper[validatorTypes.MIN_LENGTH]({ threshold: 3 })('12')).toBe('Must have at least 3 characters.');
     });
 
     it('should not pass min length of 3 characters validation with custom message', () => {
-      expect(validatorMapper(validatorTypes.MIN_LENGTH)({ threshold: 3, message: 'Too short!' })('12')).toBe('Too short!');
+      expect(validatorMapper[validatorTypes.MIN_LENGTH]({ threshold: 3, message: 'Too short!' })('12')).toBe('Too short!');
     });
 
     it('should pass max length of 3 characters long validation', () => {
-      expect(validatorMapper(validatorTypes.MAX_LENGTH)({ threshold: 3 })('12')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MAX_LENGTH]({ threshold: 3 })('12')).toBeUndefined();
     });
 
     it('should not pass max length of 3 characters validation', () => {
-      expect(validatorMapper(validatorTypes.MAX_LENGTH)({ threshold: 3 })('1234')).toBe('Can have maximum of 3 characters.');
+      expect(validatorMapper[validatorTypes.MAX_LENGTH]({ threshold: 3 })('1234')).toBe('Can have maximum of 3 characters.');
     });
 
     it('should not pass max length of 3 characters validation with custom message', () => {
-      expect(validatorMapper(validatorTypes.MAX_LENGTH)({ threshold: 3, message: 'Too long!' })('1234')).toBe('Too long!');
+      expect(validatorMapper[validatorTypes.MAX_LENGTH]({ threshold: 3, message: 'Too long!' })('1234')).toBe('Too long!');
     });
 
     it('should pass min items of 3 validation', () => {
-      expect(validatorMapper(validatorTypes.MIN_ITEMS_VALIDATOR)({ threshold: 3 })(['1', '2', '3'])).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MIN_ITEMS_VALIDATOR]({ threshold: 3 })(['1', '2', '3'])).toBeUndefined();
     });
 
     it('should pass min items of 3 validation', () => {
-      expect(validatorMapper(validatorTypes.MIN_ITEMS_VALIDATOR)({ threshold: 3, message: 'Too few' })(['1', '2'])).toBe('Too few');
+      expect(validatorMapper[validatorTypes.MIN_ITEMS_VALIDATOR]({ threshold: 3, message: 'Too few' })(['1', '2'])).toBe('Too few');
     });
 
     it('should pass min items of 3 validation with more items', () => {
-      expect(validatorMapper(validatorTypes.MIN_ITEMS_VALIDATOR)({ threshold: 3 })(['1', '2', '3', '4'])).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MIN_ITEMS_VALIDATOR]({ threshold: 3 })(['1', '2', '3', '4'])).toBeUndefined();
     });
   });
 
   describe('pattern validator', () => {
     it('should pass pattern validation with configured regexp pattern', () => {
-      expect(validatorMapper(validatorTypes.PATTERN_VALIDATOR)({ pattern: /^Foo$/ })('Foo')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.PATTERN_VALIDATOR]({ pattern: /^Foo$/ })('Foo')).toBeUndefined();
     });
 
     it('should fail pattern validation and return default message', () => {
-      expect(validatorMapper(validatorTypes.PATTERN_VALIDATOR)({ pattern: /^Foo$/ })('Bar')).toEqual('Value does not match pattern: /^Foo$/.');
+      expect(validatorMapper[validatorTypes.PATTERN_VALIDATOR]({ pattern: /^Foo$/ })('Bar')).toEqual('Value does not match pattern: /^Foo$/.');
     });
 
     it('should fail pattern validation and return custom message', () => {
-      expect(validatorMapper(validatorTypes.PATTERN_VALIDATOR)({ pattern: /^Foo$/, message: 'Custom message' })('Bar')).toEqual('Custom message');
+      expect(validatorMapper[validatorTypes.PATTERN_VALIDATOR]({ pattern: /^Foo$/, message: 'Custom message' })('Bar')).toEqual('Custom message');
     });
 
     it('should pass pattern validation with configured regexp pattern as string', () => {
-      expect(validatorMapper(validatorTypes.PATTERN_VALIDATOR)({ pattern: '^Foo$' })('Foo')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.PATTERN_VALIDATOR]({ pattern: '^Foo$' })('Foo')).toBeUndefined();
     });
 
     it('should pass pattern validation with configured regexp pattern as string and with flags', () => {
-      expect(validatorMapper(validatorTypes.PATTERN_VALIDATOR)({ pattern: '^Foo$', flags: 'i' })('foo')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.PATTERN_VALIDATOR]({ pattern: '^Foo$', flags: 'i' })('foo')).toBeUndefined();
     });
 
     it('should fail pattern validation with configured regexp pattern as string', () => {
-      expect(validatorMapper(validatorTypes.PATTERN_VALIDATOR)({ pattern: '^Foo$' })('Bar')).toBe('Value does not match pattern: ^Foo$.');
+      expect(validatorMapper[validatorTypes.PATTERN_VALIDATOR]({ pattern: '^Foo$' })('Bar')).toBe('Value does not match pattern: ^Foo$.');
     });
   });
 
   describe('min value validator', () => {
     it('should pass the validation', () => {
-      expect(validatorMapper(validatorTypes.MIN_NUMBER_VALUE)({ value: 99 })(123)).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99 })(123)).toBeUndefined();
     });
 
     it('should pass the validation if minimum value', () => {
-      expect(validatorMapper(validatorTypes.MIN_NUMBER_VALUE)({ value: 99 })(99)).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99 })(99)).toBeUndefined();
     });
 
     it('should pass the validation if no input given', () => {
-      expect(validatorMapper(validatorTypes.MIN_NUMBER_VALUE)({ value: 99 })()).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99 })()).toBeUndefined();
     });
 
     it('should not pass the validation (includethreshold is false)', () => {
-      expect(validatorMapper(validatorTypes.MIN_NUMBER_VALUE)({ value: 99, includeThreshold: false })(99)).toEqual('Value must be greater than 99.');
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, includeThreshold: false })(99)).toEqual('Value must be greater than 99.');
     });
 
     it('should not pass the validation and return custom message', () => {
-      expect(validatorMapper(validatorTypes.MIN_NUMBER_VALUE)({ value: 99, message: 'Foo' })(1)).toEqual('Foo');
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, message: 'Foo' })(1)).toEqual('Foo');
     });
   });
 
   describe('max value validator', () => {
     it('should pass the validation', () => {
-      expect(validatorMapper(validatorTypes.MAX_NUMBER_VALUE)({ value: 99 })(1)).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MAX_NUMBER_VALUE]({ value: 99 })(1)).toBeUndefined();
     });
 
     it('should pass the validation if maximum value', () => {
-      expect(validatorMapper(validatorTypes.MAX_NUMBER_VALUE)({ value: 99 })(99)).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MAX_NUMBER_VALUE]({ value: 99 })(99)).toBeUndefined();
     });
 
     it('should pass the validation if no input given', () => {
-      expect(validatorMapper(validatorTypes.MAX_NUMBER_VALUE)({ value: 99 })()).toBeUndefined();
+      expect(validatorMapper[validatorTypes.MAX_NUMBER_VALUE]({ value: 99 })()).toBeUndefined();
     });
 
     it('should not pass the validation (includethreshold is false)', () => {
-      expect(validatorMapper(validatorTypes.MAX_NUMBER_VALUE)({ value: 99, includeThreshold: false })(99)).toEqual('Value must be less than 99');
+      expect(validatorMapper[validatorTypes.MAX_NUMBER_VALUE]({ value: 99, includeThreshold: false })(99)).toEqual('Value must be less than 99');
     });
 
     it('should not pass the validation and return custom validation', () => {
-      expect(validatorMapper(validatorTypes.MAX_NUMBER_VALUE)({ value: 99, message: 'Foo' })(123)).toEqual('Foo');
+      expect(validatorMapper[validatorTypes.MAX_NUMBER_VALUE]({ value: 99, message: 'Foo' })(123)).toEqual('Foo');
     });
   });
 
@@ -310,61 +310,61 @@ describe('New validators', () => {
     });
 
     it('should fail validations and return globally overriden messages', () => {
-      expect(validatorMapper(validatorTypes.REQUIRED)()()).toEqual('Foo required');
-      expect(validatorMapper(validatorTypes.MIN_LENGTH)({ threshold: 5 })('12')).toEqual('Bar');
+      expect(validatorMapper[validatorTypes.REQUIRED]()()).toEqual('Foo required');
+      expect(validatorMapper[validatorTypes.MIN_LENGTH]({ threshold: 5 })('12')).toEqual('Bar');
     });
   });
 
   describe('URL validator', () => {
     const failMessage = 'String is not URL.';
     it('should pass validation without any configuration', () => {
-      expect(validatorMapper(validatorTypes.URL)({})('https://www.google.com/')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({})('http://www.google.com/')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({})('https://www.google.com/')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({})('http://www.google.com/')).toBeUndefined();
     });
 
     it('should fail validation withouth any configuration', () => {
-      expect(validatorMapper(validatorTypes.URL)({})('https://www.')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({})('https://www.')).toBe(failMessage);
     });
 
     it('should return custom message', () => {
       const customMessage = 'customMessage';
 
-      expect(validatorMapper(validatorTypes.URL)({ message: customMessage })('https://www.')).toBe(customMessage);
+      expect(validatorMapper[validatorTypes.URL]({ message: customMessage })('https://www.')).toBe(customMessage);
     });
 
     it('should validate only URL with ftp protocol', () => {
-      expect(validatorMapper(validatorTypes.URL)({ protocol: 'ftp' })('https://www.google.com/')).toBe(failMessage);
-      expect(validatorMapper(validatorTypes.URL)({ protocol: 'ftp' })('ftp://www.google.com/')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocol: 'ftp' })('https://www.google.com/')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({ protocol: 'ftp' })('ftp://www.google.com/')).toBeUndefined();
     });
 
     it('should validate only URL with ftp and shh protocols', () => {
-      expect(validatorMapper(validatorTypes.URL)({ protocols: ['ftp', 'ssh'] })('https://www.google.com/')).toBe(failMessage);
-      expect(validatorMapper(validatorTypes.URL)({ protocols: ['ftp', 'ssh'] })('ftp://www.google.com/')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({ protocols: ['ftp', 'ssh'] })('ssh://www.google.com/')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocols: ['ftp', 'ssh'] })('https://www.google.com/')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({ protocols: ['ftp', 'ssh'] })('ftp://www.google.com/')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocols: ['ftp', 'ssh'] })('ssh://www.google.com/')).toBeUndefined();
     });
 
     it('should validate only IPv4 adress as valid URL', () => {
-      expect(validatorMapper(validatorTypes.URL)({ ipv4: false })('http://123.123.123.222/')).toBe(failMessage);
-      expect(validatorMapper(validatorTypes.URL)({})('http://123.123.123.222')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ ipv4: false })('http://123.123.123.222/')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({})('http://123.123.123.222')).toBeUndefined();
     });
 
     it('should validate only IPv4 adress as valid URL without protocol', () => {
-      expect(validatorMapper(validatorTypes.URL)({ protocolIdentifier: false })('123.123.123.222')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocolIdentifier: false })('123.123.123.222')).toBeUndefined();
     });
 
     it('should validate only as invalid URL without initial //', () => {
-      expect(validatorMapper(validatorTypes.URL)({})('//www.google.com')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({ emptyProtocol: false })('//www.google.com')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({})('//www.google.com')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ emptyProtocol: false })('//www.google.com')).toBe(failMessage);
     });
 
     it('should validate only IPv6 adress as valid URL', () => {
-      expect(validatorMapper(validatorTypes.URL)({ ipv6: false })('http://2001:db8:85a3::8a2e:370:7334:3838/')).toBe(failMessage);
-      expect(validatorMapper(validatorTypes.URL)({})('http://2001:db8:85a3::8a2e:370:7334:3838')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({ protocolIdentifier: false })('2001:db8:85a3::8a2e:370:7334:3838')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({ protocolIdentifier: false })('::1')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({ protocolIdentifier: false })('1::')).toBeUndefined();
-      expect(validatorMapper(validatorTypes.URL)({ protocolIdentifier: false })('1::xxx')).toBe(failMessage);
-      expect(validatorMapper(validatorTypes.URL)({ protocolIdentifier: false, ipv4: false })('192.168.1.1')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({ ipv6: false })('http://2001:db8:85a3::8a2e:370:7334:3838/')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({})('http://2001:db8:85a3::8a2e:370:7334:3838')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocolIdentifier: false })('2001:db8:85a3::8a2e:370:7334:3838')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocolIdentifier: false })('::1')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocolIdentifier: false })('1::')).toBeUndefined();
+      expect(validatorMapper[validatorTypes.URL]({ protocolIdentifier: false })('1::xxx')).toBe(failMessage);
+      expect(validatorMapper[validatorTypes.URL]({ protocolIdentifier: false, ipv4: false })('192.168.1.1')).toBe(failMessage);
     });
   });
 });

--- a/packages/react-form-renderer/src/validators/validator-mapper.js
+++ b/packages/react-form-renderer/src/validators/validator-mapper.js
@@ -3,18 +3,17 @@ import { required, length, pattern, numericality } from './';
 import url from './url-validator';
 import validatorTypes from '../components/validator-types';
 
-export default (validatorType) =>
-  ({
-    [validatorTypes.REQUIRED]: required,
-    [validatorTypes.MIN_LENGTH]: ({ threshold, ...rest }) => length({ minimum: threshold, ...rest }),
-    [validatorTypes.MAX_LENGTH]: ({ threshold, ...rest }) => length({ maximum: threshold, ...rest }),
-    [validatorTypes.EXACT_LENGTH]: ({ threshold, ...rest }) => length({ is: threshold, ...rest }),
-    [validatorTypes.MIN_ITEMS_VALIDATOR]: ({ threshold, ...rest }) =>
-      length({ minimum: threshold, message: `Must have at least ${threshold} items.`, ...rest }),
-    [validatorTypes.PATTERN_VALIDATOR]: pattern,
-    [validatorTypes.MAX_NUMBER_VALUE]: ({ value, includeThreshold = true, ...rest }) =>
-      numericality({ [includeThreshold ? '<=' : '<']: value, ...rest }),
-    [validatorTypes.MIN_NUMBER_VALUE]: ({ value, includeThreshold = true, ...rest }) =>
-      numericality({ [includeThreshold ? '>=' : '>']: value, ...rest }),
-    [validatorTypes.URL]: ({ message, ...options }) => pattern({ pattern: url(options), message: message || 'String is not URL.' })
-  }[validatorType]);
+export default {
+  [validatorTypes.REQUIRED]: required,
+  [validatorTypes.MIN_LENGTH]: ({ threshold, ...rest }) => length({ minimum: threshold, ...rest }),
+  [validatorTypes.MAX_LENGTH]: ({ threshold, ...rest }) => length({ maximum: threshold, ...rest }),
+  [validatorTypes.EXACT_LENGTH]: ({ threshold, ...rest }) => length({ is: threshold, ...rest }),
+  [validatorTypes.MIN_ITEMS_VALIDATOR]: ({ threshold, ...rest }) =>
+    length({ minimum: threshold, message: `Must have at least ${threshold} items.`, ...rest }),
+  [validatorTypes.PATTERN_VALIDATOR]: pattern,
+  [validatorTypes.MAX_NUMBER_VALUE]: ({ value, includeThreshold = true, ...rest }) =>
+    numericality({ [includeThreshold ? '<=' : '<']: value, ...rest }),
+  [validatorTypes.MIN_NUMBER_VALUE]: ({ value, includeThreshold = true, ...rest }) =>
+    numericality({ [includeThreshold ? '>=' : '>']: value, ...rest }),
+  [validatorTypes.URL]: ({ message, ...options }) => pattern({ pattern: url(options), message: message || 'String is not URL.' })
+};


### PR DESCRIPTION
Allows to use a custom validator mapper

```jsx
const customValidatorMapper = {
  custom: () => (value) => value > 6 ? 'Value is bigger than 6' : undefined
}

const schema = {
  fields: [{
   name: 'name',
   component: 'text-field',
   validate: [{type: 'custom'}]
  }]
}

<FormRenderer 
  ...
  schema={schema}
  validatorMapper={customValidatorMapper}
/>
```

- This mapper is merged with the default one (user can rewrite the default ones)
- schemaValidator still controls if the type is in validatorMapper (even the custom ones!)

(and as a bonus, empty validation is no longer passed as a prop!)