### PR TITLE
fix(renderer): boolean is never empty

### DIFF
--- a/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
+++ b/packages/react-form-renderer/src/form-renderer/enhanced-on-change.js
@@ -51,6 +51,10 @@ const checkEmpty = value => {
     return false;
   }
 
+  if (typeof value === 'boolean') {
+    return false;
+  }
+
   if (typeof value === 'string' && value.length > 0) {
     return false;
   }

--- a/packages/react-form-renderer/src/tests/form-renderer/enhanced-on-change.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/enhanced-on-change.test.js
@@ -29,6 +29,25 @@ describe('#enhancedOnChange', () => {
     expect(enhancedOnChange({ onChange: value => value, clearedValue }, value)).toEqual('Me');
   });
 
+  it('should return booelan values correctly with initialValue set', () => {
+    const initial = false;
+    const valueFalse = {
+      target: {
+        checked: false,
+        type: 'checkbox',
+      },
+    };
+    expect(enhancedOnChange({ onChange: value => value, clearedValue, initial }, valueFalse)).toEqual(false);
+
+    const valueTrue = {
+      target: {
+        checked: true,
+        type: 'checkbox',
+      },
+    };
+    expect(enhancedOnChange({ onChange: value => value, clearedValue, initial }, valueTrue)).toEqual(true);
+  });
+
   it('should correctly convert array datatype from strings to integers', () => {
     const value = [ '1', '2', 3 ];
     expect(enhancedOnChange({ dataType: 'integer', onChange: value => value, clearedValue }, value)).toEqual([ 1, 2, 3 ]);


### PR DESCRIPTION
When setting initialValue on `checkbox` type fields, the `checkEmpty` method always returns `true`, so the value is set to `clearedValue` (which is `undefined`)

Fixed by setting that a `boolean` value is never empty.