### PR TITLE
Fixes falsy values for initialValue + initiliazeOnMount

### DIFF
--- a/packages/react-form-renderer/src/form-renderer/field-provider.js
+++ b/packages/react-form-renderer/src/form-renderer/field-provider.js
@@ -8,7 +8,9 @@ import { dataTypes } from '../constants';
 class FieldProvider extends Component{
   componentDidMount() {
     if (this.props.initializeOnMount) {
-      const initialValue = this.props.initialValue || this.props.formOptions.getFieldState(this.props.name).initial;
+      const initialValue = this.props.hasOwnProperty('initialValue') ?
+        this.props.initialValue :
+        this.props.formOptions.getFieldState(this.props.name).initial;
       this.props.formOptions.change(this.props.name, initialValue);
     }
   }

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -884,5 +884,69 @@ describe('renderForm function', () => {
       mountInitializedField(wrapper);
       expectSchemaInitialValue(wrapper);
     });
+
+    it('should set false value in initializeOnMount', () => {
+      layoutMapper = {
+        [layoutComponents.FORM_WRAPPER]: ({ children, ...props }) => <form { ...props }>{ children }</form>,
+        [layoutComponents.BUTTON]: ({ label, ...rest }) =>  <button { ...rest }>{ label }</button>,
+        [layoutComponents.BUTTON_GROUP]: ({ children }) => <div>{ children }</div>,
+        [layoutComponents.TITLE]: ({ children }) => <div>{ children }</div>,
+        [layoutComponents.DESCRIPTION]: ({ children }) => <div>{ children }</div>,
+      };
+
+      const schema = {
+        fields: [{
+          component: components.TEXT_FIELD,
+          name: 'input',
+        }, {
+          component: components.TEXT_FIELD,
+          name: 'unmounted',
+          initialValue: false,
+          initializeOnMount: true,
+          condition: {
+            when: 'input',
+            is: 'show_false',
+          },
+        }, {
+          component: components.TEXT_FIELD,
+          name: 'unmounted',
+          initialValue: true,
+          initializeOnMount: true,
+          condition: {
+            when: 'input',
+            is: 'show_true',
+          },
+        }],
+      };
+
+      const onSubmit = jest.fn();
+
+      const wrapper = mount(
+        <FormRenderer
+          layoutMapper={ layoutMapper }
+          formFieldsMapper={{
+            [components.TEXT_FIELD]: TextField,
+          }}
+          schema={ schema }
+          onSubmit={ onSubmit }
+        />
+      );
+
+      wrapper.find('input').first().simulate('change', { target: { value: 'show_true' }});
+      wrapper.update();
+
+      wrapper.find('form').simulate('submit');
+
+      expect(onSubmit).toHaveBeenCalledWith({ input: 'show_true', unmounted: true }, expect.any(Object), expect.any(Function));
+      onSubmit.mockClear();
+
+      wrapper.find('input').first().simulate('change', { target: { value: 'show_false' }});
+      wrapper.update();
+
+      wrapper.find('form').simulate('submit');
+      wrapper.update();
+
+      expect(onSubmit).toHaveBeenCalledWith({ input: 'show_false', unmounted: false }, expect.any(Object), expect.any(Function));
+    });
   });
 });

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -739,7 +739,7 @@ describe('renderForm function', () => {
         component: componentTypes.TEXT_FIELD,
         name: INITIALIZED_FIELD,
         initializeOnMount,
-        initialValue,
+        ...(initialValue ? { initialValue } : {}),
         condition: {
           when: SHOWER_FIELD,
           is: SHOW_VALUE,
@@ -947,6 +947,70 @@ describe('renderForm function', () => {
       wrapper.update();
 
       expect(onSubmit).toHaveBeenCalledWith({ input: 'show_false', unmounted: false }, expect.any(Object), expect.any(Function));
+    });
+
+    it('should set unefined value in initializeOnMount', () => {
+      layoutMapper = {
+        [layoutComponents.FORM_WRAPPER]: ({ children, ...props }) => <form { ...props }>{ children }</form>,
+        [layoutComponents.BUTTON]: ({ label, ...rest }) =>  <button { ...rest }>{ label }</button>,
+        [layoutComponents.BUTTON_GROUP]: ({ children }) => <div>{ children }</div>,
+        [layoutComponents.TITLE]: ({ children }) => <div>{ children }</div>,
+        [layoutComponents.DESCRIPTION]: ({ children }) => <div>{ children }</div>,
+      };
+
+      const schema = {
+        fields: [{
+          component: components.TEXT_FIELD,
+          name: 'input',
+        }, {
+          component: components.TEXT_FIELD,
+          name: 'unmounted',
+          initialValue: undefined,
+          initializeOnMount: true,
+          condition: {
+            when: 'input',
+            is: 'show_undef',
+          },
+        }, {
+          component: components.TEXT_FIELD,
+          name: 'unmounted',
+          initialValue: true,
+          initializeOnMount: true,
+          condition: {
+            when: 'input',
+            is: 'show_true',
+          },
+        }],
+      };
+
+      const onSubmit = jest.fn();
+
+      const wrapper = mount(
+        <FormRenderer
+          layoutMapper={ layoutMapper }
+          formFieldsMapper={{
+            [components.TEXT_FIELD]: TextField,
+          }}
+          schema={ schema }
+          onSubmit={ onSubmit }
+        />
+      );
+
+      wrapper.find('input').first().simulate('change', { target: { value: 'show_true' }});
+      wrapper.update();
+
+      wrapper.find('form').simulate('submit');
+
+      expect(onSubmit).toHaveBeenCalledWith({ input: 'show_true', unmounted: true }, expect.any(Object), expect.any(Function));
+      onSubmit.mockClear();
+
+      wrapper.find('input').first().simulate('change', { target: { value: 'show_undef' }});
+      wrapper.update();
+
+      wrapper.find('form').simulate('submit');
+      wrapper.update();
+
+      expect(onSubmit).toHaveBeenCalledWith({ input: 'show_undef', unmounted: undefined }, expect.any(Object), expect.any(Function));
     });
   });
 });


### PR DESCRIPTION
- Fixes falsy values set in initialValue + initializeOnMount

When a field is mounted first time, initialValue is registered into the form state. So, falsy values work well. However, if truly value is registered first, falsy value is not able to override it as the condition in  fieldProvider thinks that the initialValue is not set at all.

```jsx
      const schema = {
        fields: [{
          component: components.TEXT_FIELD,
          name: 'input',
        }, {
          component: components.TEXT_FIELD,
          name: 'unmounted',
          initialValue: false,
          initializeOnMount: true,
          condition: {
            when: 'input',
            is: 'show_false',
          },
        }, {
          component: components.TEXT_FIELD,
          name: 'unmounted',
          initialValue: true,
          initializeOnMount: true,
          condition: {
            when: 'input',
            is: 'show_true',
          },
        }],
      };
```

1. user sets 'show_false'
-> formState's initialValue is set to false
-> value is set to `false`
2. user sets 'show_true'
-> value is set to `true`
3. user sets 'show_false'
-> formState's initialValue is taken
-> value is set to `false` (however, it there will be for example `0`, `''` or `null`, it will be still set to `false`
---
1. user sets 'show_true'
-> formState's initialValue is set to true
-> value is set to `true`
2. user sets 'show_false'
-> initialValue is "false" so the value is set to formState's initialValue `true`
...