### PR TITLE
[V2] feat(renderer): use debug instead of onStateUpdate

### DIFF
--- a/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
@@ -94,8 +94,7 @@ exports[`<Input Addon> should render group button before input addon correctly 1
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -166,157 +165,11 @@ exports[`<Input Addon> should render group button before input addon correctly 1
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 1",
-                            "name": "set1",
-                            "onClick": [Function],
-                          },
-                          Object {
-                            "component": "button",
-                            "label": "Set 2",
-                            "name": "set2",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 1",
-                            "name": "set1",
-                            "onClick": [Function],
-                          },
-                          Object {
-                            "component": "button",
-                            "label": "Set 2",
-                            "name": "set2",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -421,8 +274,7 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -505,169 +357,11 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-group",
-                        "fields": Array [
-                          Object {
-                            "component": "plain-text",
-                            "label": "-",
-                            "name": "name1",
-                            "variant": "span",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 3",
-                            "name": "set3",
-                          },
-                        ],
-                        "name": "i-a-g-3",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-group",
-                        "fields": Array [
-                          Object {
-                            "component": "plain-text",
-                            "label": "-",
-                            "name": "name1",
-                            "variant": "span",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 3",
-                            "name": "set3",
-                          },
-                        ],
-                        "name": "i-a-g-3",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -755,8 +449,7 @@ exports[`<Input Addon> should render single after input addon correctly 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -805,135 +498,11 @@ exports[`<Input Addon> should render single after input addon correctly 1`] = `
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "after": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "plain-text",
-                        "label": "-",
-                        "name": "name1",
-                        "variant": "span",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "after": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "plain-text",
-                        "label": "-",
-                        "name": "name1",
-                        "variant": "span",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -1021,8 +590,7 @@ exports[`<Input Addon> should render single before input addon correctly 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -1071,135 +639,11 @@ exports[`<Input Addon> should render single before input addon correctly 1`] = `
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "plain-text",
-                        "label": "-",
-                        "name": "name1",
-                        "variant": "span",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "plain-text",
-                        "label": "-",
-                        "name": "name1",
-                        "variant": "span",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -1286,8 +730,7 @@ exports[`<Input Addon> should render single button after input addon correctly 1
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -1334,133 +777,11 @@ exports[`<Input Addon> should render single button after input addon correctly 1
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "after": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "button",
-                        "label": "Set 3",
-                        "name": "set3",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "after": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "button",
-                        "label": "Set 3",
-                        "name": "set3",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -1553,8 +874,7 @@ exports[`<Input Addon> should render single button before input addon correctly 
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -1613,145 +933,11 @@ exports[`<Input Addon> should render single button before input addon correctly 
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 2",
-                            "name": "set2",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 2",
-                            "name": "set2",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -1877,8 +1063,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <Component
       formFields={
         Array [
           <SingleField
@@ -2003,211 +1188,11 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "button": [Function],
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "input-addon-button-group": [Function],
-            "input-addon-group": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [Function],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <Component
-        formFields={
-          Array [
-            <SingleField
-              component="text-field"
-              inputAddon={
-                Object {
-                  "after": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-group",
-                        "fields": Array [
-                          Object {
-                            "component": "plain-text",
-                            "label": "-",
-                            "name": "name1",
-                            "variant": "span",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 3",
-                            "name": "set3",
-                          },
-                        ],
-                        "name": "i-a-g-3",
-                      },
-                    ],
-                  },
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 1",
-                            "name": "set1",
-                            "onClick": [Function],
-                          },
-                          Object {
-                            "component": "button",
-                            "label": "Set 2",
-                            "name": "set2",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                    ],
-                  },
-                }
-              }
-              label="Text Box With Input Addon"
-              name="text_box_21"
-              title="Text Box With Input Addon"
-            />,
-          ]
-        }
-        schema={
-          Object {
-            "fields": Array [
-              Object {
-                "component": "text-field",
-                "inputAddon": Object {
-                  "after": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-group",
-                        "fields": Array [
-                          Object {
-                            "component": "plain-text",
-                            "label": "-",
-                            "name": "name1",
-                            "variant": "span",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 3",
-                            "name": "set3",
-                          },
-                        ],
-                        "name": "i-a-g-3",
-                      },
-                    ],
-                  },
-                  "before": Object {
-                    "fields": Array [
-                      Object {
-                        "component": "input-addon-button-group",
-                        "fields": Array [
-                          Object {
-                            "component": "button",
-                            "label": "Set 1",
-                            "name": "set1",
-                            "onClick": [Function],
-                          },
-                          Object {
-                            "component": "button",
-                            "label": "Set 2",
-                            "name": "set2",
-                          },
-                        ],
-                        "name": "i-a-g-2",
-                      },
-                    ],
-                  },
-                },
-                "label": "Text Box With Input Addon",
-                "name": "text_box_21",
-                "title": "Text Box With Input Addon",
-              },
-            ],
-          }
-        }
-      >
-        <div>
-          FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
-        </div>
-      </Component>
-    </FormContent>
+      <div>
+        FormRenderer is missing 'FormTemplate' prop: ({formFields, schema}) =&gt; &lt;FormTemplate {...} /&gt;
+      </div>
+    </Component>
   </ReactFinalForm>
 </FormRenderer>
 `;

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -91,8 +91,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <FormTemplate
       formFields={
         Array [
           <SingleField
@@ -159,80 +158,8 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "dual-list-select": [Function],
-            "field-array": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [MockFunction],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <FormTemplate
+      <PF4FormTemplate
         formFields={
           Array [
             <SingleField
@@ -299,8 +226,15 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
             ],
           }
         }
+        showFormControls={false}
       >
-        <PF4FormTemplate
+        <FormTemplate
+          Button={[Function]}
+          ButtonGroup={[Function]}
+          Description={[Function]}
+          FormWrapper={[Function]}
+          Title={[Function]}
+          disableSubmit={Array []}
           formFields={
             Array [
               <SingleField
@@ -369,126 +303,80 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
           }
           showFormControls={false}
         >
-          <FormTemplate
-            Button={[Function]}
-            ButtonGroup={[Function]}
-            Description={[Function]}
-            FormWrapper={[Function]}
-            Title={[Function]}
-            disableSubmit={Array []}
-            formFields={
-              Array [
-                <SingleField
-                  component="wizard"
-                  fields={
-                    Array [
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "foo-field",
-                          },
-                        ],
-                        "name": "1",
-                        "nextStep": "2",
-                        "title": "foo-step",
-                      },
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "bar-field",
-                          },
-                        ],
-                        "name": "2",
-                        "title": "bar-step",
-                      },
-                    ]
-                  }
-                  name="wizard"
-                />,
-              ]
-            }
-            schema={
-              Object {
-                "fields": Array [
-                  Object {
-                    "component": "wizard",
-                    "fields": Array [
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "foo-field",
-                          },
-                        ],
-                        "name": "1",
-                        "nextStep": "2",
-                        "title": "foo-step",
-                      },
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "bar-field",
-                          },
-                        ],
-                        "name": "2",
-                        "title": "bar-step",
-                      },
-                    ],
-                    "name": "wizard",
-                  },
-                ],
-              }
-            }
-            showFormControls={false}
+          <Form
+            onSubmit={[Function]}
           >
-            <Form
+            <form
+              className="pf-c-form"
+              noValidate={true}
               onSubmit={[Function]}
             >
-              <form
-                className="pf-c-form"
-                noValidate={true}
-                onSubmit={[Function]}
+              <SingleField
+                component="wizard"
+                fields={
+                  Array [
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "foo-field",
+                        },
+                      ],
+                      "name": "1",
+                      "nextStep": "2",
+                      "title": "foo-step",
+                    },
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "bar-field",
+                        },
+                      ],
+                      "name": "2",
+                      "title": "bar-step",
+                    },
+                  ]
+                }
+                key="wizard"
+                name="wizard"
               >
-                <SingleField
-                  component="wizard"
-                  fields={
-                    Array [
-                      Object {
-                        "fields": Array [
+                <FormConditionWrapper>
+                  <FormFieldHideWrapper
+                    hideField={false}
+                  >
+                    <FieldWrapper
+                      component={[Function]}
+                      componentType="wizard"
+                      fields={
+                        Array [
                           Object {
-                            "component": "text-field",
-                            "name": "foo-field",
+                            "fields": Array [
+                              Object {
+                                "component": "text-field",
+                                "name": "foo-field",
+                              },
+                            ],
+                            "name": "1",
+                            "nextStep": "2",
+                            "title": "foo-step",
                           },
-                        ],
-                        "name": "1",
-                        "nextStep": "2",
-                        "title": "foo-step",
-                      },
-                      Object {
-                        "fields": Array [
                           Object {
-                            "component": "text-field",
-                            "name": "bar-field",
+                            "fields": Array [
+                              Object {
+                                "component": "text-field",
+                                "name": "bar-field",
+                              },
+                            ],
+                            "name": "2",
+                            "title": "bar-step",
                           },
-                        ],
-                        "name": "2",
-                        "title": "bar-step",
-                      },
-                    ]
-                  }
-                  key="wizard"
-                  name="wizard"
-                >
-                  <FormConditionWrapper>
-                    <FormFieldHideWrapper
-                      hideField={false}
+                        ]
+                      }
+                      name="wizard"
                     >
-                      <FieldWrapper
-                        component={[Function]}
-                        componentType="wizard"
+                      <WizardFunction
+                        buttonLabels={Object {}}
                         fields={
                           Array [
                             Object {
@@ -515,9 +403,17 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                           ]
                         }
                         name="wizard"
+                        validate={[Function]}
                       >
-                        <WizardFunction
-                          buttonLabels={Object {}}
+                        <Wizard
+                          buttonLabels={
+                            Object {
+                              "back": "Back",
+                              "cancel": "Cancel",
+                              "next": "Next",
+                              "submit": "Submit",
+                            }
+                          }
                           fields={
                             Array [
                               Object {
@@ -546,61 +442,90 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                           name="wizard"
                           validate={[Function]}
                         >
-                          <Wizard
-                            buttonLabels={
-                              Object {
-                                "back": "Back",
-                                "cancel": "Cancel",
-                                "next": "Next",
-                                "submit": "Submit",
-                              }
-                            }
-                            fields={
-                              Array [
-                                Object {
-                                  "fields": Array [
-                                    Object {
-                                      "component": "text-field",
-                                      "name": "foo-field",
-                                    },
-                                  ],
-                                  "name": "1",
-                                  "nextStep": "2",
-                                  "title": "foo-step",
-                                },
-                                Object {
-                                  "fields": Array [
-                                    Object {
-                                      "component": "text-field",
-                                      "name": "bar-field",
-                                    },
-                                  ],
-                                  "name": "2",
-                                  "title": "bar-step",
-                                },
-                              ]
-                            }
-                            name="wizard"
-                            validate={[Function]}
-                          >
-                            <Modal>
+                          <Modal>
+                            <div
+                              className="pf-c-wizard no-shadow   "
+                              onKeyDown={[Function]}
+                              role="dialog"
+                            >
                               <div
-                                className="pf-c-wizard no-shadow   "
-                                onKeyDown={[Function]}
-                                role="dialog"
+                                className="pf-c-wizard__outer-wrap"
                               >
-                                <div
-                                  className="pf-c-wizard__outer-wrap"
-                                >
-                                  <WizardNav>
-                                    <nav
-                                      className="pf-c-wizard__nav"
+                                <WizardNav>
+                                  <nav
+                                    className="pf-c-wizard__nav"
+                                  >
+                                    <ol
+                                      className="pf-c-wizard__nav-list"
                                     >
-                                      <ol
-                                        className="pf-c-wizard__nav-list"
-                                      >
-                                        <FormSpy>
-                                          <WizardNavigation
+                                      <FormSpy>
+                                        <WizardNavigation
+                                          activeStepIndex={0}
+                                          formOptions={
+                                            Object {
+                                              "batch": [Function],
+                                              "blur": [Function],
+                                              "change": [Function],
+                                              "clearOnUnmount": false,
+                                              "clearedValue": undefined,
+                                              "concat": [Function],
+                                              "destroyOnUnregister": false,
+                                              "focus": [Function],
+                                              "getFieldState": [Function],
+                                              "getRegisteredFields": [Function],
+                                              "getState": [Function],
+                                              "handleSubmit": [Function],
+                                              "initialize": [Function],
+                                              "insert": [Function],
+                                              "isValidationPaused": [Function],
+                                              "move": [Function],
+                                              "onCancel": [MockFunction],
+                                              "onReset": undefined,
+                                              "onSubmit": [MockFunction],
+                                              "pauseValidation": [Function],
+                                              "pop": [Function],
+                                              "pristine": true,
+                                              "push": [Function],
+                                              "registerField": [Function],
+                                              "remove": [Function],
+                                              "removeBatch": [Function],
+                                              "renderForm": [Function],
+                                              "reset": [Function],
+                                              "resetFieldState": [Function],
+                                              "resumeValidation": [Function],
+                                              "setConfig": [Function],
+                                              "shift": [Function],
+                                              "submit": [Function],
+                                              "subscribe": [Function],
+                                              "swap": [Function],
+                                              "unshift": [Function],
+                                              "update": [Function],
+                                              "valid": true,
+                                            }
+                                          }
+                                          isDynamic={false}
+                                          jumpToStep={[Function]}
+                                          maxStepIndex={0}
+                                          navSchema={
+                                            Array [
+                                              Object {
+                                                "index": 0,
+                                                "primary": true,
+                                                "substepOf": undefined,
+                                                "title": "foo-step",
+                                              },
+                                              Object {
+                                                "index": 1,
+                                                "primary": true,
+                                                "substepOf": undefined,
+                                                "title": "bar-step",
+                                              },
+                                            ]
+                                          }
+                                          setPrevSteps={[Function]}
+                                          values={Object {}}
+                                        >
+                                          <Component
                                             activeStepIndex={0}
                                             formOptions={
                                               Object {
@@ -644,7 +569,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 "valid": true,
                                               }
                                             }
-                                            isDynamic={false}
                                             jumpToStep={[Function]}
                                             maxStepIndex={0}
                                             navSchema={
@@ -663,122 +587,241 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 },
                                               ]
                                             }
-                                            setPrevSteps={[Function]}
-                                            values={Object {}}
                                           >
-                                            <Component
-                                              activeStepIndex={0}
-                                              formOptions={
-                                                Object {
-                                                  "batch": [Function],
-                                                  "blur": [Function],
-                                                  "change": [Function],
-                                                  "clearOnUnmount": false,
-                                                  "clearedValue": undefined,
-                                                  "concat": [Function],
-                                                  "destroyOnUnregister": false,
-                                                  "focus": [Function],
-                                                  "getFieldState": [Function],
-                                                  "getRegisteredFields": [Function],
-                                                  "getState": [Function],
-                                                  "handleSubmit": [Function],
-                                                  "initialize": [Function],
-                                                  "insert": [Function],
-                                                  "isValidationPaused": [Function],
-                                                  "move": [Function],
-                                                  "onCancel": [MockFunction],
-                                                  "onReset": undefined,
-                                                  "onSubmit": [MockFunction],
-                                                  "pauseValidation": [Function],
-                                                  "pop": [Function],
-                                                  "pristine": true,
-                                                  "push": [Function],
-                                                  "registerField": [Function],
-                                                  "remove": [Function],
-                                                  "removeBatch": [Function],
-                                                  "renderForm": [Function],
-                                                  "reset": [Function],
-                                                  "resetFieldState": [Function],
-                                                  "resumeValidation": [Function],
-                                                  "setConfig": [Function],
-                                                  "shift": [Function],
-                                                  "submit": [Function],
-                                                  "subscribe": [Function],
-                                                  "swap": [Function],
-                                                  "unshift": [Function],
-                                                  "update": [Function],
-                                                  "valid": true,
-                                                }
-                                              }
-                                              jumpToStep={[Function]}
-                                              maxStepIndex={0}
-                                              navSchema={
-                                                Array [
-                                                  Object {
-                                                    "index": 0,
-                                                    "primary": true,
-                                                    "substepOf": undefined,
-                                                    "title": "foo-step",
-                                                  },
-                                                  Object {
-                                                    "index": 1,
-                                                    "primary": true,
-                                                    "substepOf": undefined,
-                                                    "title": "bar-step",
-                                                  },
-                                                ]
-                                              }
+                                            <WizardNavItem
+                                              isCurrent={true}
+                                              isDisabled={false}
+                                              key="foo-step"
+                                              onNavItemClick={[Function]}
+                                              step={0}
+                                              text="foo-step"
                                             >
-                                              <WizardNavItem
-                                                isCurrent={true}
-                                                isDisabled={false}
-                                                key="foo-step"
-                                                onNavItemClick={[Function]}
-                                                step={0}
-                                                text="foo-step"
+                                              <li
+                                                className="pf-c-wizard__nav-item"
                                               >
-                                                <li
-                                                  className="pf-c-wizard__nav-item"
+                                                <a
+                                                  aria-current="page"
+                                                  aria-disabled={false}
+                                                  className="pf-c-wizard__nav-link pf-m-current"
+                                                  onClick={[Function]}
                                                 >
-                                                  <a
-                                                    aria-current="page"
-                                                    aria-disabled={false}
-                                                    className="pf-c-wizard__nav-link pf-m-current"
-                                                    onClick={[Function]}
-                                                  >
-                                                    foo-step
-                                                  </a>
-                                                </li>
-                                              </WizardNavItem>
-                                              <WizardNavItem
-                                                isCurrent={false}
-                                                isDisabled={true}
-                                                key="bar-step"
-                                                onNavItemClick={[Function]}
-                                                step={1}
-                                                text="bar-step"
+                                                  foo-step
+                                                </a>
+                                              </li>
+                                            </WizardNavItem>
+                                            <WizardNavItem
+                                              isCurrent={false}
+                                              isDisabled={true}
+                                              key="bar-step"
+                                              onNavItemClick={[Function]}
+                                              step={1}
+                                              text="bar-step"
+                                            >
+                                              <li
+                                                className="pf-c-wizard__nav-item"
                                               >
-                                                <li
-                                                  className="pf-c-wizard__nav-item"
+                                                <a
+                                                  aria-current={false}
+                                                  aria-disabled={true}
+                                                  className="pf-c-wizard__nav-link pf-m-disabled"
+                                                  onClick={[Function]}
+                                                  tabIndex={-1}
                                                 >
-                                                  <a
-                                                    aria-current={false}
-                                                    aria-disabled={true}
-                                                    className="pf-c-wizard__nav-link pf-m-disabled"
-                                                    onClick={[Function]}
-                                                    tabIndex={-1}
+                                                  bar-step
+                                                </a>
+                                              </li>
+                                            </WizardNavItem>
+                                          </Component>
+                                        </WizardNavigation>
+                                      </FormSpy>
+                                    </ol>
+                                  </nav>
+                                </WizardNav>
+                                <WizardStep
+                                  buttonLabels={
+                                    Object {
+                                      "back": "Back",
+                                      "cancel": "Cancel",
+                                      "next": "Next",
+                                      "submit": "Submit",
+                                    }
+                                  }
+                                  disableBack={true}
+                                  fields={
+                                    Array [
+                                      Object {
+                                        "component": "text-field",
+                                        "name": "foo-field",
+                                      },
+                                    ]
+                                  }
+                                  formOptions={
+                                    Object {
+                                      "batch": [Function],
+                                      "blur": [Function],
+                                      "change": [Function],
+                                      "clearOnUnmount": false,
+                                      "clearedValue": undefined,
+                                      "concat": [Function],
+                                      "destroyOnUnregister": false,
+                                      "focus": [Function],
+                                      "getFieldState": [Function],
+                                      "getRegisteredFields": [Function],
+                                      "getState": [Function],
+                                      "handleSubmit": [Function],
+                                      "initialize": [Function],
+                                      "insert": [Function],
+                                      "isValidationPaused": [Function],
+                                      "move": [Function],
+                                      "onCancel": [MockFunction],
+                                      "onReset": undefined,
+                                      "onSubmit": [MockFunction],
+                                      "pauseValidation": [Function],
+                                      "pop": [Function],
+                                      "pristine": true,
+                                      "push": [Function],
+                                      "registerField": [Function],
+                                      "remove": [Function],
+                                      "removeBatch": [Function],
+                                      "renderForm": [Function],
+                                      "reset": [Function],
+                                      "resetFieldState": [Function],
+                                      "resumeValidation": [Function],
+                                      "setConfig": [Function],
+                                      "shift": [Function],
+                                      "submit": [Function],
+                                      "subscribe": [Function],
+                                      "swap": [Function],
+                                      "unshift": [Function],
+                                      "update": [Function],
+                                      "valid": true,
+                                    }
+                                  }
+                                  handleNext={[Function]}
+                                  handlePrev={[Function]}
+                                  name="1"
+                                  nextStep="2"
+                                  title="foo-step"
+                                >
+                                  <WizardBody
+                                    hasBodyPadding={true}
+                                  >
+                                    <main
+                                      className="pf-c-wizard__main"
+                                    >
+                                      <div
+                                        className="pf-c-wizard__main-body"
+                                      >
+                                        <div
+                                          className="pf-c-form"
+                                        >
+                                          <SingleField
+                                            component="text-field"
+                                            key="foo-field"
+                                            name="foo-field"
+                                          >
+                                            <FormConditionWrapper>
+                                              <FormFieldHideWrapper
+                                                hideField={false}
+                                              >
+                                                <FieldWrapper
+                                                  component={[Function]}
+                                                  componentType="text-field"
+                                                  name="foo-field"
+                                                >
+                                                  <TextField
+                                                    name="foo-field"
+                                                    validate={[Function]}
                                                   >
-                                                    bar-step
-                                                  </a>
-                                                </li>
-                                              </WizardNavItem>
-                                            </Component>
-                                          </WizardNavigation>
-                                        </FormSpy>
-                                      </ol>
-                                    </nav>
-                                  </WizardNav>
-                                  <WizardStep
+                                                    <FormGroup
+                                                      id="foo-field"
+                                                      isRequired={false}
+                                                      meta={
+                                                        Object {
+                                                          "active": false,
+                                                          "data": Object {},
+                                                          "dirty": false,
+                                                          "dirtySinceLastSubmit": false,
+                                                          "error": undefined,
+                                                          "initial": undefined,
+                                                          "invalid": false,
+                                                          "length": undefined,
+                                                          "modified": false,
+                                                          "pristine": true,
+                                                          "submitError": undefined,
+                                                          "submitFailed": false,
+                                                          "submitSucceeded": false,
+                                                          "submitting": false,
+                                                          "touched": false,
+                                                          "valid": true,
+                                                          "validating": false,
+                                                          "visited": false,
+                                                        }
+                                                      }
+                                                    >
+                                                      <FormGroup
+                                                        fieldId="foo-field"
+                                                        isRequired={false}
+                                                        isValid={true}
+                                                      >
+                                                        <div
+                                                          className="pf-c-form__group"
+                                                        >
+                                                          <ForwardRef
+                                                            id="foo-field"
+                                                            name="foo-field"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            onFocus={[Function]}
+                                                            value=""
+                                                          >
+                                                            <TextInputBase
+                                                              aria-label={null}
+                                                              className=""
+                                                              id="foo-field"
+                                                              innerRef={null}
+                                                              isDisabled={false}
+                                                              isReadOnly={false}
+                                                              isRequired={false}
+                                                              isValid={true}
+                                                              name="foo-field"
+                                                              onBlur={[Function]}
+                                                              onChange={[Function]}
+                                                              onFocus={[Function]}
+                                                              type="text"
+                                                              validated="default"
+                                                              value=""
+                                                            >
+                                                              <input
+                                                                aria-invalid={false}
+                                                                aria-label={null}
+                                                                className="pf-c-form-control"
+                                                                disabled={false}
+                                                                id="foo-field"
+                                                                name="foo-field"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                onFocus={[Function]}
+                                                                readOnly={false}
+                                                                required={false}
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </TextInputBase>
+                                                          </ForwardRef>
+                                                        </div>
+                                                      </FormGroup>
+                                                    </FormGroup>
+                                                  </TextField>
+                                                </FieldWrapper>
+                                              </FormFieldHideWrapper>
+                                            </FormConditionWrapper>
+                                          </SingleField>
+                                        </div>
+                                      </div>
+                                    </main>
+                                  </WizardBody>
+                                  <WizardStepButtons
                                     buttonLabels={
                                       Object {
                                         "back": "Back",
@@ -788,14 +831,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                       }
                                     }
                                     disableBack={true}
-                                    fields={
-                                      Array [
-                                        Object {
-                                          "component": "text-field",
-                                          "name": "foo-field",
-                                        },
-                                      ]
-                                    }
                                     formOptions={
                                       Object {
                                         "batch": [Function],
@@ -842,187 +877,53 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                     handlePrev={[Function]}
                                     name="1"
                                     nextStep="2"
-                                    title="foo-step"
                                   >
-                                    <WizardBody
-                                      hasBodyPadding={true}
+                                    <footer
+                                      className="pf-c-wizard__footer "
                                     >
-                                      <main
-                                        className="pf-c-wizard__main"
+                                      <NextButton
+                                        batch={[Function]}
+                                        blur={[Function]}
+                                        change={[Function]}
+                                        clearOnUnmount={false}
+                                        concat={[Function]}
+                                        destroyOnUnregister={false}
+                                        focus={[Function]}
+                                        getFieldState={[Function]}
+                                        getRegisteredFields={[Function]}
+                                        getState={[Function]}
+                                        handleNext={[Function]}
+                                        handleSubmit={[Function]}
+                                        initialize={[Function]}
+                                        insert={[Function]}
+                                        isValidationPaused={[Function]}
+                                        move={[Function]}
+                                        nextLabel="Next"
+                                        nextStep="2"
+                                        onCancel={[MockFunction]}
+                                        onSubmit={[MockFunction]}
+                                        pauseValidation={[Function]}
+                                        pop={[Function]}
+                                        pristine={true}
+                                        push={[Function]}
+                                        registerField={[Function]}
+                                        remove={[Function]}
+                                        removeBatch={[Function]}
+                                        renderForm={[Function]}
+                                        reset={[Function]}
+                                        resetFieldState={[Function]}
+                                        resumeValidation={[Function]}
+                                        setConfig={[Function]}
+                                        shift={[Function]}
+                                        submit={[Function]}
+                                        submitLabel="Submit"
+                                        subscribe={[Function]}
+                                        swap={[Function]}
+                                        unshift={[Function]}
+                                        update={[Function]}
+                                        valid={true}
                                       >
-                                        <div
-                                          className="pf-c-wizard__main-body"
-                                        >
-                                          <div
-                                            className="pf-c-form"
-                                          >
-                                            <SingleField
-                                              component="text-field"
-                                              key="foo-field"
-                                              name="foo-field"
-                                            >
-                                              <FormConditionWrapper>
-                                                <FormFieldHideWrapper
-                                                  hideField={false}
-                                                >
-                                                  <FieldWrapper
-                                                    component={[Function]}
-                                                    componentType="text-field"
-                                                    name="foo-field"
-                                                  >
-                                                    <TextField
-                                                      name="foo-field"
-                                                      validate={[Function]}
-                                                    >
-                                                      <FormGroup
-                                                        id="foo-field"
-                                                        isRequired={false}
-                                                        meta={
-                                                          Object {
-                                                            "active": false,
-                                                            "data": Object {},
-                                                            "dirty": false,
-                                                            "dirtySinceLastSubmit": false,
-                                                            "error": undefined,
-                                                            "initial": undefined,
-                                                            "invalid": false,
-                                                            "length": undefined,
-                                                            "modified": false,
-                                                            "pristine": true,
-                                                            "submitError": undefined,
-                                                            "submitFailed": false,
-                                                            "submitSucceeded": false,
-                                                            "submitting": false,
-                                                            "touched": false,
-                                                            "valid": true,
-                                                            "validating": false,
-                                                            "visited": false,
-                                                          }
-                                                        }
-                                                      >
-                                                        <FormGroup
-                                                          fieldId="foo-field"
-                                                          isRequired={false}
-                                                          isValid={true}
-                                                        >
-                                                          <div
-                                                            className="pf-c-form__group"
-                                                          >
-                                                            <ForwardRef
-                                                              id="foo-field"
-                                                              name="foo-field"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              onFocus={[Function]}
-                                                              value=""
-                                                            >
-                                                              <TextInputBase
-                                                                aria-label={null}
-                                                                className=""
-                                                                id="foo-field"
-                                                                innerRef={null}
-                                                                isDisabled={false}
-                                                                isReadOnly={false}
-                                                                isRequired={false}
-                                                                isValid={true}
-                                                                name="foo-field"
-                                                                onBlur={[Function]}
-                                                                onChange={[Function]}
-                                                                onFocus={[Function]}
-                                                                type="text"
-                                                                validated="default"
-                                                                value=""
-                                                              >
-                                                                <input
-                                                                  aria-invalid={false}
-                                                                  aria-label={null}
-                                                                  className="pf-c-form-control"
-                                                                  disabled={false}
-                                                                  id="foo-field"
-                                                                  name="foo-field"
-                                                                  onBlur={[Function]}
-                                                                  onChange={[Function]}
-                                                                  onFocus={[Function]}
-                                                                  readOnly={false}
-                                                                  required={false}
-                                                                  type="text"
-                                                                  value=""
-                                                                />
-                                                              </TextInputBase>
-                                                            </ForwardRef>
-                                                          </div>
-                                                        </FormGroup>
-                                                      </FormGroup>
-                                                    </TextField>
-                                                  </FieldWrapper>
-                                                </FormFieldHideWrapper>
-                                              </FormConditionWrapper>
-                                            </SingleField>
-                                          </div>
-                                        </div>
-                                      </main>
-                                    </WizardBody>
-                                    <WizardStepButtons
-                                      buttonLabels={
-                                        Object {
-                                          "back": "Back",
-                                          "cancel": "Cancel",
-                                          "next": "Next",
-                                          "submit": "Submit",
-                                        }
-                                      }
-                                      disableBack={true}
-                                      formOptions={
-                                        Object {
-                                          "batch": [Function],
-                                          "blur": [Function],
-                                          "change": [Function],
-                                          "clearOnUnmount": false,
-                                          "clearedValue": undefined,
-                                          "concat": [Function],
-                                          "destroyOnUnregister": false,
-                                          "focus": [Function],
-                                          "getFieldState": [Function],
-                                          "getRegisteredFields": [Function],
-                                          "getState": [Function],
-                                          "handleSubmit": [Function],
-                                          "initialize": [Function],
-                                          "insert": [Function],
-                                          "isValidationPaused": [Function],
-                                          "move": [Function],
-                                          "onCancel": [MockFunction],
-                                          "onReset": undefined,
-                                          "onSubmit": [MockFunction],
-                                          "pauseValidation": [Function],
-                                          "pop": [Function],
-                                          "pristine": true,
-                                          "push": [Function],
-                                          "registerField": [Function],
-                                          "remove": [Function],
-                                          "removeBatch": [Function],
-                                          "renderForm": [Function],
-                                          "reset": [Function],
-                                          "resetFieldState": [Function],
-                                          "resumeValidation": [Function],
-                                          "setConfig": [Function],
-                                          "shift": [Function],
-                                          "submit": [Function],
-                                          "subscribe": [Function],
-                                          "swap": [Function],
-                                          "unshift": [Function],
-                                          "update": [Function],
-                                          "valid": true,
-                                        }
-                                      }
-                                      handleNext={[Function]}
-                                      handlePrev={[Function]}
-                                      name="1"
-                                      nextStep="2"
-                                    >
-                                      <footer
-                                        className="pf-c-wizard__footer "
-                                      >
-                                        <NextButton
+                                        <SimpleNext
                                           batch={[Function]}
                                           blur={[Function]}
                                           change={[Function]}
@@ -1034,7 +935,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                           getRegisteredFields={[Function]}
                                           getState={[Function]}
                                           handleNext={[Function]}
-                                          handleSubmit={[Function]}
                                           initialize={[Function]}
                                           insert={[Function]}
                                           isValidationPaused={[Function]}
@@ -1057,205 +957,163 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                           setConfig={[Function]}
                                           shift={[Function]}
                                           submit={[Function]}
-                                          submitLabel="Submit"
                                           subscribe={[Function]}
                                           swap={[Function]}
                                           unshift={[Function]}
                                           update={[Function]}
                                           valid={true}
                                         >
-                                          <SimpleNext
-                                            batch={[Function]}
-                                            blur={[Function]}
-                                            change={[Function]}
-                                            clearOnUnmount={false}
-                                            concat={[Function]}
-                                            destroyOnUnregister={false}
-                                            focus={[Function]}
-                                            getFieldState={[Function]}
-                                            getRegisteredFields={[Function]}
-                                            getState={[Function]}
-                                            handleNext={[Function]}
-                                            initialize={[Function]}
-                                            insert={[Function]}
-                                            isValidationPaused={[Function]}
-                                            move={[Function]}
-                                            nextLabel="Next"
-                                            nextStep="2"
-                                            onCancel={[MockFunction]}
-                                            onSubmit={[MockFunction]}
-                                            pauseValidation={[Function]}
-                                            pop={[Function]}
-                                            pristine={true}
-                                            push={[Function]}
-                                            registerField={[Function]}
-                                            remove={[Function]}
-                                            removeBatch={[Function]}
-                                            renderForm={[Function]}
-                                            reset={[Function]}
-                                            resetFieldState={[Function]}
-                                            resumeValidation={[Function]}
-                                            setConfig={[Function]}
-                                            shift={[Function]}
-                                            submit={[Function]}
-                                            subscribe={[Function]}
-                                            swap={[Function]}
-                                            unshift={[Function]}
-                                            update={[Function]}
-                                            valid={true}
+                                          <Component
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                            variant="primary"
                                           >
-                                            <Component
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              type="button"
-                                              variant="primary"
+                                            <ComponentWithOuia
+                                              component={[Function]}
+                                              componentProps={
+                                                Object {
+                                                  "children": "Next",
+                                                  "isDisabled": false,
+                                                  "onClick": [Function],
+                                                  "type": "button",
+                                                  "variant": "primary",
+                                                }
+                                              }
+                                              consumerContext={null}
                                             >
-                                              <ComponentWithOuia
-                                                component={[Function]}
-                                                componentProps={
+                                              <Button
+                                                isDisabled={false}
+                                                onClick={[Function]}
+                                                ouiaContext={
                                                   Object {
-                                                    "children": "Next",
-                                                    "isDisabled": false,
-                                                    "onClick": [Function],
-                                                    "type": "button",
-                                                    "variant": "primary",
+                                                    "isOuia": false,
+                                                    "ouiaId": null,
                                                   }
                                                 }
-                                                consumerContext={null}
+                                                type="button"
+                                                variant="primary"
                                               >
-                                                <Button
-                                                  isDisabled={false}
+                                                <button
+                                                  aria-disabled={null}
+                                                  aria-label={null}
+                                                  className="pf-c-button pf-m-primary"
+                                                  disabled={false}
                                                   onClick={[Function]}
-                                                  ouiaContext={
-                                                    Object {
-                                                      "isOuia": false,
-                                                      "ouiaId": null,
-                                                    }
-                                                  }
+                                                  tabIndex={null}
                                                   type="button"
-                                                  variant="primary"
                                                 >
-                                                  <button
-                                                    aria-disabled={null}
-                                                    aria-label={null}
-                                                    className="pf-c-button pf-m-primary"
-                                                    disabled={false}
-                                                    onClick={[Function]}
-                                                    tabIndex={null}
-                                                    type="button"
-                                                  >
-                                                    Next
-                                                  </button>
-                                                </Button>
-                                              </ComponentWithOuia>
-                                            </Component>
-                                          </SimpleNext>
-                                        </NextButton>
-                                        <Component
-                                          isDisabled={true}
-                                          onClick={[Function]}
-                                          type="button"
-                                          variant="secondary"
+                                                  Next
+                                                </button>
+                                              </Button>
+                                            </ComponentWithOuia>
+                                          </Component>
+                                        </SimpleNext>
+                                      </NextButton>
+                                      <Component
+                                        isDisabled={true}
+                                        onClick={[Function]}
+                                        type="button"
+                                        variant="secondary"
+                                      >
+                                        <ComponentWithOuia
+                                          component={[Function]}
+                                          componentProps={
+                                            Object {
+                                              "children": "Back",
+                                              "isDisabled": true,
+                                              "onClick": [Function],
+                                              "type": "button",
+                                              "variant": "secondary",
+                                            }
+                                          }
+                                          consumerContext={null}
                                         >
-                                          <ComponentWithOuia
-                                            component={[Function]}
-                                            componentProps={
+                                          <Button
+                                            isDisabled={true}
+                                            onClick={[Function]}
+                                            ouiaContext={
                                               Object {
-                                                "children": "Back",
-                                                "isDisabled": true,
-                                                "onClick": [Function],
-                                                "type": "button",
-                                                "variant": "secondary",
+                                                "isOuia": false,
+                                                "ouiaId": null,
                                               }
                                             }
-                                            consumerContext={null}
+                                            type="button"
+                                            variant="secondary"
                                           >
-                                            <Button
-                                              isDisabled={true}
+                                            <button
+                                              aria-disabled={null}
+                                              aria-label={null}
+                                              className="pf-c-button pf-m-secondary"
+                                              disabled={true}
                                               onClick={[Function]}
-                                              ouiaContext={
-                                                Object {
-                                                  "isOuia": false,
-                                                  "ouiaId": null,
-                                                }
-                                              }
+                                              tabIndex={null}
                                               type="button"
-                                              variant="secondary"
                                             >
-                                              <button
-                                                aria-disabled={null}
-                                                aria-label={null}
-                                                className="pf-c-button pf-m-secondary"
-                                                disabled={true}
-                                                onClick={[Function]}
-                                                tabIndex={null}
-                                                type="button"
-                                              >
-                                                Back
-                                              </button>
-                                            </Button>
-                                          </ComponentWithOuia>
-                                        </Component>
-                                        <Component
-                                          onClick={[Function]}
-                                          type="button"
-                                          variant="link"
+                                              Back
+                                            </button>
+                                          </Button>
+                                        </ComponentWithOuia>
+                                      </Component>
+                                      <Component
+                                        onClick={[Function]}
+                                        type="button"
+                                        variant="link"
+                                      >
+                                        <ComponentWithOuia
+                                          component={[Function]}
+                                          componentProps={
+                                            Object {
+                                              "children": "Cancel",
+                                              "onClick": [Function],
+                                              "type": "button",
+                                              "variant": "link",
+                                            }
+                                          }
+                                          consumerContext={null}
                                         >
-                                          <ComponentWithOuia
-                                            component={[Function]}
-                                            componentProps={
+                                          <Button
+                                            onClick={[Function]}
+                                            ouiaContext={
                                               Object {
-                                                "children": "Cancel",
-                                                "onClick": [Function],
-                                                "type": "button",
-                                                "variant": "link",
+                                                "isOuia": false,
+                                                "ouiaId": null,
                                               }
                                             }
-                                            consumerContext={null}
+                                            type="button"
+                                            variant="link"
                                           >
-                                            <Button
+                                            <button
+                                              aria-disabled={null}
+                                              aria-label={null}
+                                              className="pf-c-button pf-m-link"
+                                              disabled={false}
                                               onClick={[Function]}
-                                              ouiaContext={
-                                                Object {
-                                                  "isOuia": false,
-                                                  "ouiaId": null,
-                                                }
-                                              }
+                                              tabIndex={null}
                                               type="button"
-                                              variant="link"
                                             >
-                                              <button
-                                                aria-disabled={null}
-                                                aria-label={null}
-                                                className="pf-c-button pf-m-link"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                tabIndex={null}
-                                                type="button"
-                                              >
-                                                Cancel
-                                              </button>
-                                            </Button>
-                                          </ComponentWithOuia>
-                                        </Component>
-                                      </footer>
-                                    </WizardStepButtons>
-                                  </WizardStep>
-                                </div>
+                                              Cancel
+                                            </button>
+                                          </Button>
+                                        </ComponentWithOuia>
+                                      </Component>
+                                    </footer>
+                                  </WizardStepButtons>
+                                </WizardStep>
                               </div>
-                            </Modal>
-                          </Wizard>
-                        </WizardFunction>
-                      </FieldWrapper>
-                    </FormFieldHideWrapper>
-                  </FormConditionWrapper>
-                </SingleField>
-              </form>
-            </Form>
-          </FormTemplate>
-        </PF4FormTemplate>
-      </FormTemplate>
-    </FormContent>
+                            </div>
+                          </Modal>
+                        </Wizard>
+                      </WizardFunction>
+                    </FieldWrapper>
+                  </FormFieldHideWrapper>
+                </FormConditionWrapper>
+              </SingleField>
+            </form>
+          </Form>
+        </FormTemplate>
+      </PF4FormTemplate>
+    </FormTemplate>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -1354,8 +1212,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <FormTemplate
       formFields={
         Array [
           <SingleField
@@ -1424,80 +1281,8 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
           ],
         }
       }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "dual-list-select": [Function],
-            "field-array": [Function],
-            "plain-text": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "switch": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-            "wizard": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": [MockFunction],
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
-        }
-      }
     >
-      <FormTemplate
+      <PF4FormTemplate
         formFields={
           Array [
             <SingleField
@@ -1566,8 +1351,15 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
             ],
           }
         }
+        showFormControls={false}
       >
-        <PF4FormTemplate
+        <FormTemplate
+          Button={[Function]}
+          ButtonGroup={[Function]}
+          Description={[Function]}
+          FormWrapper={[Function]}
+          Title={[Function]}
+          disableSubmit={Array []}
           formFields={
             Array [
               <SingleField
@@ -1638,129 +1430,82 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
           }
           showFormControls={false}
         >
-          <FormTemplate
-            Button={[Function]}
-            ButtonGroup={[Function]}
-            Description={[Function]}
-            FormWrapper={[Function]}
-            Title={[Function]}
-            disableSubmit={Array []}
-            formFields={
-              Array [
-                <SingleField
-                  component="wizard"
-                  fields={
-                    Array [
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "foo-field",
-                          },
-                        ],
-                        "name": "1",
-                        "nextStep": "2",
-                        "title": "foo-step",
-                      },
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "bar-field",
-                          },
-                        ],
-                        "name": "2",
-                        "title": "bar-step",
-                      },
-                    ]
-                  }
-                  inModal={true}
-                  name="wizard"
-                />,
-              ]
-            }
-            schema={
-              Object {
-                "fields": Array [
-                  Object {
-                    "component": "wizard",
-                    "fields": Array [
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "foo-field",
-                          },
-                        ],
-                        "name": "1",
-                        "nextStep": "2",
-                        "title": "foo-step",
-                      },
-                      Object {
-                        "fields": Array [
-                          Object {
-                            "component": "text-field",
-                            "name": "bar-field",
-                          },
-                        ],
-                        "name": "2",
-                        "title": "bar-step",
-                      },
-                    ],
-                    "inModal": true,
-                    "name": "wizard",
-                  },
-                ],
-              }
-            }
-            showFormControls={false}
+          <Form
+            onSubmit={[Function]}
           >
-            <Form
+            <form
+              className="pf-c-form"
+              noValidate={true}
               onSubmit={[Function]}
             >
-              <form
-                className="pf-c-form"
-                noValidate={true}
-                onSubmit={[Function]}
+              <SingleField
+                component="wizard"
+                fields={
+                  Array [
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "foo-field",
+                        },
+                      ],
+                      "name": "1",
+                      "nextStep": "2",
+                      "title": "foo-step",
+                    },
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "text-field",
+                          "name": "bar-field",
+                        },
+                      ],
+                      "name": "2",
+                      "title": "bar-step",
+                    },
+                  ]
+                }
+                inModal={true}
+                key="wizard"
+                name="wizard"
               >
-                <SingleField
-                  component="wizard"
-                  fields={
-                    Array [
-                      Object {
-                        "fields": Array [
+                <FormConditionWrapper>
+                  <FormFieldHideWrapper
+                    hideField={false}
+                  >
+                    <FieldWrapper
+                      component={[Function]}
+                      componentType="wizard"
+                      fields={
+                        Array [
                           Object {
-                            "component": "text-field",
-                            "name": "foo-field",
+                            "fields": Array [
+                              Object {
+                                "component": "text-field",
+                                "name": "foo-field",
+                              },
+                            ],
+                            "name": "1",
+                            "nextStep": "2",
+                            "title": "foo-step",
                           },
-                        ],
-                        "name": "1",
-                        "nextStep": "2",
-                        "title": "foo-step",
-                      },
-                      Object {
-                        "fields": Array [
                           Object {
-                            "component": "text-field",
-                            "name": "bar-field",
+                            "fields": Array [
+                              Object {
+                                "component": "text-field",
+                                "name": "bar-field",
+                              },
+                            ],
+                            "name": "2",
+                            "title": "bar-step",
                           },
-                        ],
-                        "name": "2",
-                        "title": "bar-step",
-                      },
-                    ]
-                  }
-                  inModal={true}
-                  key="wizard"
-                  name="wizard"
-                >
-                  <FormConditionWrapper>
-                    <FormFieldHideWrapper
-                      hideField={false}
+                        ]
+                      }
+                      inModal={true}
+                      name="wizard"
                     >
-                      <FieldWrapper
-                        component={[Function]}
-                        componentType="wizard"
+                      <WizardFunction
+                        buttonLabels={Object {}}
                         fields={
                           Array [
                             Object {
@@ -1788,9 +1533,17 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                         }
                         inModal={true}
                         name="wizard"
+                        validate={[Function]}
                       >
-                        <WizardFunction
-                          buttonLabels={Object {}}
+                        <Wizard
+                          buttonLabels={
+                            Object {
+                              "back": "Back",
+                              "cancel": "Cancel",
+                              "next": "Next",
+                              "submit": "Submit",
+                            }
+                          }
                           fields={
                             Array [
                               Object {
@@ -1820,46 +1573,112 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                           name="wizard"
                           validate={[Function]}
                         >
-                          <Wizard
-                            buttonLabels={
-                              Object {
-                                "back": "Back",
-                                "cancel": "Cancel",
-                                "next": "Next",
-                                "submit": "Submit",
-                              }
-                            }
-                            fields={
-                              Array [
-                                Object {
-                                  "fields": Array [
-                                    Object {
-                                      "component": "text-field",
-                                      "name": "foo-field",
-                                    },
-                                  ],
-                                  "name": "1",
-                                  "nextStep": "2",
-                                  "title": "foo-step",
-                                },
-                                Object {
-                                  "fields": Array [
-                                    Object {
-                                      "component": "text-field",
-                                      "name": "bar-field",
-                                    },
-                                  ],
-                                  "name": "2",
-                                  "title": "bar-step",
-                                },
-                              ]
+                          <Modal
+                            container={
+                              <div>
+                                <div
+                                  class="pf-c-backdrop"
+                                >
+                                  <div
+                                    class="pf-l-bullseye"
+                                  >
+                                    <div
+                                      aria-modal="true"
+                                      class="pf-c-wizard    "
+                                      role="dialog"
+                                    >
+                                      <div
+                                        class="pf-c-wizard__outer-wrap"
+                                      >
+                                        <nav
+                                          class="pf-c-wizard__nav"
+                                        >
+                                          <ol
+                                            class="pf-c-wizard__nav-list"
+                                          >
+                                            <li
+                                              class="pf-c-wizard__nav-item"
+                                            >
+                                              <a
+                                                aria-current="page"
+                                                aria-disabled="false"
+                                                class="pf-c-wizard__nav-link pf-m-current"
+                                              >
+                                                foo-step
+                                              </a>
+                                            </li>
+                                            <li
+                                              class="pf-c-wizard__nav-item"
+                                            >
+                                              <a
+                                                aria-current="false"
+                                                aria-disabled="true"
+                                                class="pf-c-wizard__nav-link pf-m-disabled"
+                                                tabindex="-1"
+                                              >
+                                                bar-step
+                                              </a>
+                                            </li>
+                                          </ol>
+                                        </nav>
+                                        <main
+                                          class="pf-c-wizard__main"
+                                        >
+                                          <div
+                                            class="pf-c-wizard__main-body"
+                                          >
+                                            <div
+                                              class="pf-c-form"
+                                            >
+                                              <div
+                                                class="pf-c-form__group"
+                                              >
+                                                <input
+                                                  aria-invalid="false"
+                                                  class="pf-c-form-control"
+                                                  id="foo-field"
+                                                  name="foo-field"
+                                                  type="text"
+                                                  value=""
+                                                />
+                                                
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </main>
+                                        <footer
+                                          class="pf-c-wizard__footer "
+                                        >
+                                          <button
+                                            class="pf-c-button pf-m-primary"
+                                            type="button"
+                                          >
+                                            Next
+                                          </button>
+                                          <button
+                                            class="pf-c-button pf-m-secondary"
+                                            disabled=""
+                                            type="button"
+                                          >
+                                            Back
+                                          </button>
+                                          <button
+                                            class="pf-c-button pf-m-link"
+                                            type="button"
+                                          >
+                                            Cancel
+                                          </button>
+                                        </footer>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
                             }
                             inModal={true}
-                            name="wizard"
-                            validate={[Function]}
                           >
-                            <Modal
-                              container={
+                            <Portal
+                              containerInfo={
                                 <div>
                                   <div
                                     class="pf-c-backdrop"
@@ -1960,137 +1779,99 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                   </div>
                                 </div>
                               }
-                              inModal={true}
                             >
-                              <Portal
-                                containerInfo={
-                                  <div>
+                              <Backdrop>
+                                <div
+                                  className="pf-c-backdrop"
+                                >
+                                  <Bullseye>
                                     <div
-                                      class="pf-c-backdrop"
+                                      className="pf-l-bullseye"
                                     >
                                       <div
-                                        class="pf-l-bullseye"
+                                        aria-modal="true"
+                                        className="pf-c-wizard    "
+                                        onKeyDown={[Function]}
+                                        role="dialog"
                                       >
                                         <div
-                                          aria-modal="true"
-                                          class="pf-c-wizard    "
-                                          role="dialog"
+                                          className="pf-c-wizard__outer-wrap"
                                         >
-                                          <div
-                                            class="pf-c-wizard__outer-wrap"
-                                          >
+                                          <WizardNav>
                                             <nav
-                                              class="pf-c-wizard__nav"
+                                              className="pf-c-wizard__nav"
                                             >
                                               <ol
-                                                class="pf-c-wizard__nav-list"
+                                                className="pf-c-wizard__nav-list"
                                               >
-                                                <li
-                                                  class="pf-c-wizard__nav-item"
-                                                >
-                                                  <a
-                                                    aria-current="page"
-                                                    aria-disabled="false"
-                                                    class="pf-c-wizard__nav-link pf-m-current"
+                                                <FormSpy>
+                                                  <WizardNavigation
+                                                    activeStepIndex={0}
+                                                    formOptions={
+                                                      Object {
+                                                        "batch": [Function],
+                                                        "blur": [Function],
+                                                        "change": [Function],
+                                                        "clearOnUnmount": false,
+                                                        "clearedValue": undefined,
+                                                        "concat": [Function],
+                                                        "destroyOnUnregister": false,
+                                                        "focus": [Function],
+                                                        "getFieldState": [Function],
+                                                        "getRegisteredFields": [Function],
+                                                        "getState": [Function],
+                                                        "handleSubmit": [Function],
+                                                        "initialize": [Function],
+                                                        "insert": [Function],
+                                                        "isValidationPaused": [Function],
+                                                        "move": [Function],
+                                                        "onCancel": [MockFunction],
+                                                        "onReset": undefined,
+                                                        "onSubmit": [MockFunction],
+                                                        "pauseValidation": [Function],
+                                                        "pop": [Function],
+                                                        "pristine": true,
+                                                        "push": [Function],
+                                                        "registerField": [Function],
+                                                        "remove": [Function],
+                                                        "removeBatch": [Function],
+                                                        "renderForm": [Function],
+                                                        "reset": [Function],
+                                                        "resetFieldState": [Function],
+                                                        "resumeValidation": [Function],
+                                                        "setConfig": [Function],
+                                                        "shift": [Function],
+                                                        "submit": [Function],
+                                                        "subscribe": [Function],
+                                                        "swap": [Function],
+                                                        "unshift": [Function],
+                                                        "update": [Function],
+                                                        "valid": true,
+                                                      }
+                                                    }
+                                                    isDynamic={false}
+                                                    jumpToStep={[Function]}
+                                                    maxStepIndex={0}
+                                                    navSchema={
+                                                      Array [
+                                                        Object {
+                                                          "index": 0,
+                                                          "primary": true,
+                                                          "substepOf": undefined,
+                                                          "title": "foo-step",
+                                                        },
+                                                        Object {
+                                                          "index": 1,
+                                                          "primary": true,
+                                                          "substepOf": undefined,
+                                                          "title": "bar-step",
+                                                        },
+                                                      ]
+                                                    }
+                                                    setPrevSteps={[Function]}
+                                                    values={Object {}}
                                                   >
-                                                    foo-step
-                                                  </a>
-                                                </li>
-                                                <li
-                                                  class="pf-c-wizard__nav-item"
-                                                >
-                                                  <a
-                                                    aria-current="false"
-                                                    aria-disabled="true"
-                                                    class="pf-c-wizard__nav-link pf-m-disabled"
-                                                    tabindex="-1"
-                                                  >
-                                                    bar-step
-                                                  </a>
-                                                </li>
-                                              </ol>
-                                            </nav>
-                                            <main
-                                              class="pf-c-wizard__main"
-                                            >
-                                              <div
-                                                class="pf-c-wizard__main-body"
-                                              >
-                                                <div
-                                                  class="pf-c-form"
-                                                >
-                                                  <div
-                                                    class="pf-c-form__group"
-                                                  >
-                                                    <input
-                                                      aria-invalid="false"
-                                                      class="pf-c-form-control"
-                                                      id="foo-field"
-                                                      name="foo-field"
-                                                      type="text"
-                                                      value=""
-                                                    />
-                                                    
-                                                  </div>
-                                                </div>
-                                              </div>
-                                            </main>
-                                            <footer
-                                              class="pf-c-wizard__footer "
-                                            >
-                                              <button
-                                                class="pf-c-button pf-m-primary"
-                                                type="button"
-                                              >
-                                                Next
-                                              </button>
-                                              <button
-                                                class="pf-c-button pf-m-secondary"
-                                                disabled=""
-                                                type="button"
-                                              >
-                                                Back
-                                              </button>
-                                              <button
-                                                class="pf-c-button pf-m-link"
-                                                type="button"
-                                              >
-                                                Cancel
-                                              </button>
-                                            </footer>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                }
-                              >
-                                <Backdrop>
-                                  <div
-                                    className="pf-c-backdrop"
-                                  >
-                                    <Bullseye>
-                                      <div
-                                        className="pf-l-bullseye"
-                                      >
-                                        <div
-                                          aria-modal="true"
-                                          className="pf-c-wizard    "
-                                          onKeyDown={[Function]}
-                                          role="dialog"
-                                        >
-                                          <div
-                                            className="pf-c-wizard__outer-wrap"
-                                          >
-                                            <WizardNav>
-                                              <nav
-                                                className="pf-c-wizard__nav"
-                                              >
-                                                <ol
-                                                  className="pf-c-wizard__nav-list"
-                                                >
-                                                  <FormSpy>
-                                                    <WizardNavigation
+                                                    <Component
                                                       activeStepIndex={0}
                                                       formOptions={
                                                         Object {
@@ -2134,7 +1915,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                           "valid": true,
                                                         }
                                                       }
-                                                      isDynamic={false}
                                                       jumpToStep={[Function]}
                                                       maxStepIndex={0}
                                                       navSchema={
@@ -2153,122 +1933,241 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                           },
                                                         ]
                                                       }
-                                                      setPrevSteps={[Function]}
-                                                      values={Object {}}
                                                     >
-                                                      <Component
-                                                        activeStepIndex={0}
-                                                        formOptions={
-                                                          Object {
-                                                            "batch": [Function],
-                                                            "blur": [Function],
-                                                            "change": [Function],
-                                                            "clearOnUnmount": false,
-                                                            "clearedValue": undefined,
-                                                            "concat": [Function],
-                                                            "destroyOnUnregister": false,
-                                                            "focus": [Function],
-                                                            "getFieldState": [Function],
-                                                            "getRegisteredFields": [Function],
-                                                            "getState": [Function],
-                                                            "handleSubmit": [Function],
-                                                            "initialize": [Function],
-                                                            "insert": [Function],
-                                                            "isValidationPaused": [Function],
-                                                            "move": [Function],
-                                                            "onCancel": [MockFunction],
-                                                            "onReset": undefined,
-                                                            "onSubmit": [MockFunction],
-                                                            "pauseValidation": [Function],
-                                                            "pop": [Function],
-                                                            "pristine": true,
-                                                            "push": [Function],
-                                                            "registerField": [Function],
-                                                            "remove": [Function],
-                                                            "removeBatch": [Function],
-                                                            "renderForm": [Function],
-                                                            "reset": [Function],
-                                                            "resetFieldState": [Function],
-                                                            "resumeValidation": [Function],
-                                                            "setConfig": [Function],
-                                                            "shift": [Function],
-                                                            "submit": [Function],
-                                                            "subscribe": [Function],
-                                                            "swap": [Function],
-                                                            "unshift": [Function],
-                                                            "update": [Function],
-                                                            "valid": true,
-                                                          }
-                                                        }
-                                                        jumpToStep={[Function]}
-                                                        maxStepIndex={0}
-                                                        navSchema={
-                                                          Array [
-                                                            Object {
-                                                              "index": 0,
-                                                              "primary": true,
-                                                              "substepOf": undefined,
-                                                              "title": "foo-step",
-                                                            },
-                                                            Object {
-                                                              "index": 1,
-                                                              "primary": true,
-                                                              "substepOf": undefined,
-                                                              "title": "bar-step",
-                                                            },
-                                                          ]
-                                                        }
+                                                      <WizardNavItem
+                                                        isCurrent={true}
+                                                        isDisabled={false}
+                                                        key="foo-step"
+                                                        onNavItemClick={[Function]}
+                                                        step={0}
+                                                        text="foo-step"
                                                       >
-                                                        <WizardNavItem
-                                                          isCurrent={true}
-                                                          isDisabled={false}
-                                                          key="foo-step"
-                                                          onNavItemClick={[Function]}
-                                                          step={0}
-                                                          text="foo-step"
+                                                        <li
+                                                          className="pf-c-wizard__nav-item"
                                                         >
-                                                          <li
-                                                            className="pf-c-wizard__nav-item"
+                                                          <a
+                                                            aria-current="page"
+                                                            aria-disabled={false}
+                                                            className="pf-c-wizard__nav-link pf-m-current"
+                                                            onClick={[Function]}
                                                           >
-                                                            <a
-                                                              aria-current="page"
-                                                              aria-disabled={false}
-                                                              className="pf-c-wizard__nav-link pf-m-current"
-                                                              onClick={[Function]}
-                                                            >
-                                                              foo-step
-                                                            </a>
-                                                          </li>
-                                                        </WizardNavItem>
-                                                        <WizardNavItem
-                                                          isCurrent={false}
-                                                          isDisabled={true}
-                                                          key="bar-step"
-                                                          onNavItemClick={[Function]}
-                                                          step={1}
-                                                          text="bar-step"
+                                                            foo-step
+                                                          </a>
+                                                        </li>
+                                                      </WizardNavItem>
+                                                      <WizardNavItem
+                                                        isCurrent={false}
+                                                        isDisabled={true}
+                                                        key="bar-step"
+                                                        onNavItemClick={[Function]}
+                                                        step={1}
+                                                        text="bar-step"
+                                                      >
+                                                        <li
+                                                          className="pf-c-wizard__nav-item"
                                                         >
-                                                          <li
-                                                            className="pf-c-wizard__nav-item"
+                                                          <a
+                                                            aria-current={false}
+                                                            aria-disabled={true}
+                                                            className="pf-c-wizard__nav-link pf-m-disabled"
+                                                            onClick={[Function]}
+                                                            tabIndex={-1}
                                                           >
-                                                            <a
-                                                              aria-current={false}
-                                                              aria-disabled={true}
-                                                              className="pf-c-wizard__nav-link pf-m-disabled"
-                                                              onClick={[Function]}
-                                                              tabIndex={-1}
+                                                            bar-step
+                                                          </a>
+                                                        </li>
+                                                      </WizardNavItem>
+                                                    </Component>
+                                                  </WizardNavigation>
+                                                </FormSpy>
+                                              </ol>
+                                            </nav>
+                                          </WizardNav>
+                                          <WizardStep
+                                            buttonLabels={
+                                              Object {
+                                                "back": "Back",
+                                                "cancel": "Cancel",
+                                                "next": "Next",
+                                                "submit": "Submit",
+                                              }
+                                            }
+                                            disableBack={true}
+                                            fields={
+                                              Array [
+                                                Object {
+                                                  "component": "text-field",
+                                                  "name": "foo-field",
+                                                },
+                                              ]
+                                            }
+                                            formOptions={
+                                              Object {
+                                                "batch": [Function],
+                                                "blur": [Function],
+                                                "change": [Function],
+                                                "clearOnUnmount": false,
+                                                "clearedValue": undefined,
+                                                "concat": [Function],
+                                                "destroyOnUnregister": false,
+                                                "focus": [Function],
+                                                "getFieldState": [Function],
+                                                "getRegisteredFields": [Function],
+                                                "getState": [Function],
+                                                "handleSubmit": [Function],
+                                                "initialize": [Function],
+                                                "insert": [Function],
+                                                "isValidationPaused": [Function],
+                                                "move": [Function],
+                                                "onCancel": [MockFunction],
+                                                "onReset": undefined,
+                                                "onSubmit": [MockFunction],
+                                                "pauseValidation": [Function],
+                                                "pop": [Function],
+                                                "pristine": true,
+                                                "push": [Function],
+                                                "registerField": [Function],
+                                                "remove": [Function],
+                                                "removeBatch": [Function],
+                                                "renderForm": [Function],
+                                                "reset": [Function],
+                                                "resetFieldState": [Function],
+                                                "resumeValidation": [Function],
+                                                "setConfig": [Function],
+                                                "shift": [Function],
+                                                "submit": [Function],
+                                                "subscribe": [Function],
+                                                "swap": [Function],
+                                                "unshift": [Function],
+                                                "update": [Function],
+                                                "valid": true,
+                                              }
+                                            }
+                                            handleNext={[Function]}
+                                            handlePrev={[Function]}
+                                            name="1"
+                                            nextStep="2"
+                                            title="foo-step"
+                                          >
+                                            <WizardBody
+                                              hasBodyPadding={true}
+                                            >
+                                              <main
+                                                className="pf-c-wizard__main"
+                                              >
+                                                <div
+                                                  className="pf-c-wizard__main-body"
+                                                >
+                                                  <div
+                                                    className="pf-c-form"
+                                                  >
+                                                    <SingleField
+                                                      component="text-field"
+                                                      key="foo-field"
+                                                      name="foo-field"
+                                                    >
+                                                      <FormConditionWrapper>
+                                                        <FormFieldHideWrapper
+                                                          hideField={false}
+                                                        >
+                                                          <FieldWrapper
+                                                            component={[Function]}
+                                                            componentType="text-field"
+                                                            name="foo-field"
+                                                          >
+                                                            <TextField
+                                                              name="foo-field"
+                                                              validate={[Function]}
                                                             >
-                                                              bar-step
-                                                            </a>
-                                                          </li>
-                                                        </WizardNavItem>
-                                                      </Component>
-                                                    </WizardNavigation>
-                                                  </FormSpy>
-                                                </ol>
-                                              </nav>
-                                            </WizardNav>
-                                            <WizardStep
+                                                              <FormGroup
+                                                                id="foo-field"
+                                                                isRequired={false}
+                                                                meta={
+                                                                  Object {
+                                                                    "active": false,
+                                                                    "data": Object {},
+                                                                    "dirty": false,
+                                                                    "dirtySinceLastSubmit": false,
+                                                                    "error": undefined,
+                                                                    "initial": undefined,
+                                                                    "invalid": false,
+                                                                    "length": undefined,
+                                                                    "modified": false,
+                                                                    "pristine": true,
+                                                                    "submitError": undefined,
+                                                                    "submitFailed": false,
+                                                                    "submitSucceeded": false,
+                                                                    "submitting": false,
+                                                                    "touched": false,
+                                                                    "valid": true,
+                                                                    "validating": false,
+                                                                    "visited": false,
+                                                                  }
+                                                                }
+                                                              >
+                                                                <FormGroup
+                                                                  fieldId="foo-field"
+                                                                  isRequired={false}
+                                                                  isValid={true}
+                                                                >
+                                                                  <div
+                                                                    className="pf-c-form__group"
+                                                                  >
+                                                                    <ForwardRef
+                                                                      id="foo-field"
+                                                                      name="foo-field"
+                                                                      onBlur={[Function]}
+                                                                      onChange={[Function]}
+                                                                      onFocus={[Function]}
+                                                                      value=""
+                                                                    >
+                                                                      <TextInputBase
+                                                                        aria-label={null}
+                                                                        className=""
+                                                                        id="foo-field"
+                                                                        innerRef={null}
+                                                                        isDisabled={false}
+                                                                        isReadOnly={false}
+                                                                        isRequired={false}
+                                                                        isValid={true}
+                                                                        name="foo-field"
+                                                                        onBlur={[Function]}
+                                                                        onChange={[Function]}
+                                                                        onFocus={[Function]}
+                                                                        type="text"
+                                                                        validated="default"
+                                                                        value=""
+                                                                      >
+                                                                        <input
+                                                                          aria-invalid={false}
+                                                                          aria-label={null}
+                                                                          className="pf-c-form-control"
+                                                                          disabled={false}
+                                                                          id="foo-field"
+                                                                          name="foo-field"
+                                                                          onBlur={[Function]}
+                                                                          onChange={[Function]}
+                                                                          onFocus={[Function]}
+                                                                          readOnly={false}
+                                                                          required={false}
+                                                                          type="text"
+                                                                          value=""
+                                                                        />
+                                                                      </TextInputBase>
+                                                                    </ForwardRef>
+                                                                  </div>
+                                                                </FormGroup>
+                                                              </FormGroup>
+                                                            </TextField>
+                                                          </FieldWrapper>
+                                                        </FormFieldHideWrapper>
+                                                      </FormConditionWrapper>
+                                                    </SingleField>
+                                                  </div>
+                                                </div>
+                                              </main>
+                                            </WizardBody>
+                                            <WizardStepButtons
                                               buttonLabels={
                                                 Object {
                                                   "back": "Back",
@@ -2278,14 +2177,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                 }
                                               }
                                               disableBack={true}
-                                              fields={
-                                                Array [
-                                                  Object {
-                                                    "component": "text-field",
-                                                    "name": "foo-field",
-                                                  },
-                                                ]
-                                              }
                                               formOptions={
                                                 Object {
                                                   "batch": [Function],
@@ -2332,187 +2223,53 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                               handlePrev={[Function]}
                                               name="1"
                                               nextStep="2"
-                                              title="foo-step"
                                             >
-                                              <WizardBody
-                                                hasBodyPadding={true}
+                                              <footer
+                                                className="pf-c-wizard__footer "
                                               >
-                                                <main
-                                                  className="pf-c-wizard__main"
+                                                <NextButton
+                                                  batch={[Function]}
+                                                  blur={[Function]}
+                                                  change={[Function]}
+                                                  clearOnUnmount={false}
+                                                  concat={[Function]}
+                                                  destroyOnUnregister={false}
+                                                  focus={[Function]}
+                                                  getFieldState={[Function]}
+                                                  getRegisteredFields={[Function]}
+                                                  getState={[Function]}
+                                                  handleNext={[Function]}
+                                                  handleSubmit={[Function]}
+                                                  initialize={[Function]}
+                                                  insert={[Function]}
+                                                  isValidationPaused={[Function]}
+                                                  move={[Function]}
+                                                  nextLabel="Next"
+                                                  nextStep="2"
+                                                  onCancel={[MockFunction]}
+                                                  onSubmit={[MockFunction]}
+                                                  pauseValidation={[Function]}
+                                                  pop={[Function]}
+                                                  pristine={true}
+                                                  push={[Function]}
+                                                  registerField={[Function]}
+                                                  remove={[Function]}
+                                                  removeBatch={[Function]}
+                                                  renderForm={[Function]}
+                                                  reset={[Function]}
+                                                  resetFieldState={[Function]}
+                                                  resumeValidation={[Function]}
+                                                  setConfig={[Function]}
+                                                  shift={[Function]}
+                                                  submit={[Function]}
+                                                  submitLabel="Submit"
+                                                  subscribe={[Function]}
+                                                  swap={[Function]}
+                                                  unshift={[Function]}
+                                                  update={[Function]}
+                                                  valid={true}
                                                 >
-                                                  <div
-                                                    className="pf-c-wizard__main-body"
-                                                  >
-                                                    <div
-                                                      className="pf-c-form"
-                                                    >
-                                                      <SingleField
-                                                        component="text-field"
-                                                        key="foo-field"
-                                                        name="foo-field"
-                                                      >
-                                                        <FormConditionWrapper>
-                                                          <FormFieldHideWrapper
-                                                            hideField={false}
-                                                          >
-                                                            <FieldWrapper
-                                                              component={[Function]}
-                                                              componentType="text-field"
-                                                              name="foo-field"
-                                                            >
-                                                              <TextField
-                                                                name="foo-field"
-                                                                validate={[Function]}
-                                                              >
-                                                                <FormGroup
-                                                                  id="foo-field"
-                                                                  isRequired={false}
-                                                                  meta={
-                                                                    Object {
-                                                                      "active": false,
-                                                                      "data": Object {},
-                                                                      "dirty": false,
-                                                                      "dirtySinceLastSubmit": false,
-                                                                      "error": undefined,
-                                                                      "initial": undefined,
-                                                                      "invalid": false,
-                                                                      "length": undefined,
-                                                                      "modified": false,
-                                                                      "pristine": true,
-                                                                      "submitError": undefined,
-                                                                      "submitFailed": false,
-                                                                      "submitSucceeded": false,
-                                                                      "submitting": false,
-                                                                      "touched": false,
-                                                                      "valid": true,
-                                                                      "validating": false,
-                                                                      "visited": false,
-                                                                    }
-                                                                  }
-                                                                >
-                                                                  <FormGroup
-                                                                    fieldId="foo-field"
-                                                                    isRequired={false}
-                                                                    isValid={true}
-                                                                  >
-                                                                    <div
-                                                                      className="pf-c-form__group"
-                                                                    >
-                                                                      <ForwardRef
-                                                                        id="foo-field"
-                                                                        name="foo-field"
-                                                                        onBlur={[Function]}
-                                                                        onChange={[Function]}
-                                                                        onFocus={[Function]}
-                                                                        value=""
-                                                                      >
-                                                                        <TextInputBase
-                                                                          aria-label={null}
-                                                                          className=""
-                                                                          id="foo-field"
-                                                                          innerRef={null}
-                                                                          isDisabled={false}
-                                                                          isReadOnly={false}
-                                                                          isRequired={false}
-                                                                          isValid={true}
-                                                                          name="foo-field"
-                                                                          onBlur={[Function]}
-                                                                          onChange={[Function]}
-                                                                          onFocus={[Function]}
-                                                                          type="text"
-                                                                          validated="default"
-                                                                          value=""
-                                                                        >
-                                                                          <input
-                                                                            aria-invalid={false}
-                                                                            aria-label={null}
-                                                                            className="pf-c-form-control"
-                                                                            disabled={false}
-                                                                            id="foo-field"
-                                                                            name="foo-field"
-                                                                            onBlur={[Function]}
-                                                                            onChange={[Function]}
-                                                                            onFocus={[Function]}
-                                                                            readOnly={false}
-                                                                            required={false}
-                                                                            type="text"
-                                                                            value=""
-                                                                          />
-                                                                        </TextInputBase>
-                                                                      </ForwardRef>
-                                                                    </div>
-                                                                  </FormGroup>
-                                                                </FormGroup>
-                                                              </TextField>
-                                                            </FieldWrapper>
-                                                          </FormFieldHideWrapper>
-                                                        </FormConditionWrapper>
-                                                      </SingleField>
-                                                    </div>
-                                                  </div>
-                                                </main>
-                                              </WizardBody>
-                                              <WizardStepButtons
-                                                buttonLabels={
-                                                  Object {
-                                                    "back": "Back",
-                                                    "cancel": "Cancel",
-                                                    "next": "Next",
-                                                    "submit": "Submit",
-                                                  }
-                                                }
-                                                disableBack={true}
-                                                formOptions={
-                                                  Object {
-                                                    "batch": [Function],
-                                                    "blur": [Function],
-                                                    "change": [Function],
-                                                    "clearOnUnmount": false,
-                                                    "clearedValue": undefined,
-                                                    "concat": [Function],
-                                                    "destroyOnUnregister": false,
-                                                    "focus": [Function],
-                                                    "getFieldState": [Function],
-                                                    "getRegisteredFields": [Function],
-                                                    "getState": [Function],
-                                                    "handleSubmit": [Function],
-                                                    "initialize": [Function],
-                                                    "insert": [Function],
-                                                    "isValidationPaused": [Function],
-                                                    "move": [Function],
-                                                    "onCancel": [MockFunction],
-                                                    "onReset": undefined,
-                                                    "onSubmit": [MockFunction],
-                                                    "pauseValidation": [Function],
-                                                    "pop": [Function],
-                                                    "pristine": true,
-                                                    "push": [Function],
-                                                    "registerField": [Function],
-                                                    "remove": [Function],
-                                                    "removeBatch": [Function],
-                                                    "renderForm": [Function],
-                                                    "reset": [Function],
-                                                    "resetFieldState": [Function],
-                                                    "resumeValidation": [Function],
-                                                    "setConfig": [Function],
-                                                    "shift": [Function],
-                                                    "submit": [Function],
-                                                    "subscribe": [Function],
-                                                    "swap": [Function],
-                                                    "unshift": [Function],
-                                                    "update": [Function],
-                                                    "valid": true,
-                                                  }
-                                                }
-                                                handleNext={[Function]}
-                                                handlePrev={[Function]}
-                                                name="1"
-                                                nextStep="2"
-                                              >
-                                                <footer
-                                                  className="pf-c-wizard__footer "
-                                                >
-                                                  <NextButton
+                                                  <SimpleNext
                                                     batch={[Function]}
                                                     blur={[Function]}
                                                     change={[Function]}
@@ -2524,7 +2281,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                     getRegisteredFields={[Function]}
                                                     getState={[Function]}
                                                     handleNext={[Function]}
-                                                    handleSubmit={[Function]}
                                                     initialize={[Function]}
                                                     insert={[Function]}
                                                     isValidationPaused={[Function]}
@@ -2547,210 +2303,168 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                     setConfig={[Function]}
                                                     shift={[Function]}
                                                     submit={[Function]}
-                                                    submitLabel="Submit"
                                                     subscribe={[Function]}
                                                     swap={[Function]}
                                                     unshift={[Function]}
                                                     update={[Function]}
                                                     valid={true}
                                                   >
-                                                    <SimpleNext
-                                                      batch={[Function]}
-                                                      blur={[Function]}
-                                                      change={[Function]}
-                                                      clearOnUnmount={false}
-                                                      concat={[Function]}
-                                                      destroyOnUnregister={false}
-                                                      focus={[Function]}
-                                                      getFieldState={[Function]}
-                                                      getRegisteredFields={[Function]}
-                                                      getState={[Function]}
-                                                      handleNext={[Function]}
-                                                      initialize={[Function]}
-                                                      insert={[Function]}
-                                                      isValidationPaused={[Function]}
-                                                      move={[Function]}
-                                                      nextLabel="Next"
-                                                      nextStep="2"
-                                                      onCancel={[MockFunction]}
-                                                      onSubmit={[MockFunction]}
-                                                      pauseValidation={[Function]}
-                                                      pop={[Function]}
-                                                      pristine={true}
-                                                      push={[Function]}
-                                                      registerField={[Function]}
-                                                      remove={[Function]}
-                                                      removeBatch={[Function]}
-                                                      renderForm={[Function]}
-                                                      reset={[Function]}
-                                                      resetFieldState={[Function]}
-                                                      resumeValidation={[Function]}
-                                                      setConfig={[Function]}
-                                                      shift={[Function]}
-                                                      submit={[Function]}
-                                                      subscribe={[Function]}
-                                                      swap={[Function]}
-                                                      unshift={[Function]}
-                                                      update={[Function]}
-                                                      valid={true}
+                                                    <Component
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      type="button"
+                                                      variant="primary"
                                                     >
-                                                      <Component
-                                                        isDisabled={false}
-                                                        onClick={[Function]}
-                                                        type="button"
-                                                        variant="primary"
+                                                      <ComponentWithOuia
+                                                        component={[Function]}
+                                                        componentProps={
+                                                          Object {
+                                                            "children": "Next",
+                                                            "isDisabled": false,
+                                                            "onClick": [Function],
+                                                            "type": "button",
+                                                            "variant": "primary",
+                                                          }
+                                                        }
+                                                        consumerContext={null}
                                                       >
-                                                        <ComponentWithOuia
-                                                          component={[Function]}
-                                                          componentProps={
+                                                        <Button
+                                                          isDisabled={false}
+                                                          onClick={[Function]}
+                                                          ouiaContext={
                                                             Object {
-                                                              "children": "Next",
-                                                              "isDisabled": false,
-                                                              "onClick": [Function],
-                                                              "type": "button",
-                                                              "variant": "primary",
+                                                              "isOuia": false,
+                                                              "ouiaId": null,
                                                             }
                                                           }
-                                                          consumerContext={null}
+                                                          type="button"
+                                                          variant="primary"
                                                         >
-                                                          <Button
-                                                            isDisabled={false}
+                                                          <button
+                                                            aria-disabled={null}
+                                                            aria-label={null}
+                                                            className="pf-c-button pf-m-primary"
+                                                            disabled={false}
                                                             onClick={[Function]}
-                                                            ouiaContext={
-                                                              Object {
-                                                                "isOuia": false,
-                                                                "ouiaId": null,
-                                                              }
-                                                            }
+                                                            tabIndex={null}
                                                             type="button"
-                                                            variant="primary"
                                                           >
-                                                            <button
-                                                              aria-disabled={null}
-                                                              aria-label={null}
-                                                              className="pf-c-button pf-m-primary"
-                                                              disabled={false}
-                                                              onClick={[Function]}
-                                                              tabIndex={null}
-                                                              type="button"
-                                                            >
-                                                              Next
-                                                            </button>
-                                                          </Button>
-                                                        </ComponentWithOuia>
-                                                      </Component>
-                                                    </SimpleNext>
-                                                  </NextButton>
-                                                  <Component
-                                                    isDisabled={true}
-                                                    onClick={[Function]}
-                                                    type="button"
-                                                    variant="secondary"
+                                                            Next
+                                                          </button>
+                                                        </Button>
+                                                      </ComponentWithOuia>
+                                                    </Component>
+                                                  </SimpleNext>
+                                                </NextButton>
+                                                <Component
+                                                  isDisabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
+                                                  variant="secondary"
+                                                >
+                                                  <ComponentWithOuia
+                                                    component={[Function]}
+                                                    componentProps={
+                                                      Object {
+                                                        "children": "Back",
+                                                        "isDisabled": true,
+                                                        "onClick": [Function],
+                                                        "type": "button",
+                                                        "variant": "secondary",
+                                                      }
+                                                    }
+                                                    consumerContext={null}
                                                   >
-                                                    <ComponentWithOuia
-                                                      component={[Function]}
-                                                      componentProps={
+                                                    <Button
+                                                      isDisabled={true}
+                                                      onClick={[Function]}
+                                                      ouiaContext={
                                                         Object {
-                                                          "children": "Back",
-                                                          "isDisabled": true,
-                                                          "onClick": [Function],
-                                                          "type": "button",
-                                                          "variant": "secondary",
+                                                          "isOuia": false,
+                                                          "ouiaId": null,
                                                         }
                                                       }
-                                                      consumerContext={null}
+                                                      type="button"
+                                                      variant="secondary"
                                                     >
-                                                      <Button
-                                                        isDisabled={true}
+                                                      <button
+                                                        aria-disabled={null}
+                                                        aria-label={null}
+                                                        className="pf-c-button pf-m-secondary"
+                                                        disabled={true}
                                                         onClick={[Function]}
-                                                        ouiaContext={
-                                                          Object {
-                                                            "isOuia": false,
-                                                            "ouiaId": null,
-                                                          }
-                                                        }
+                                                        tabIndex={null}
                                                         type="button"
-                                                        variant="secondary"
                                                       >
-                                                        <button
-                                                          aria-disabled={null}
-                                                          aria-label={null}
-                                                          className="pf-c-button pf-m-secondary"
-                                                          disabled={true}
-                                                          onClick={[Function]}
-                                                          tabIndex={null}
-                                                          type="button"
-                                                        >
-                                                          Back
-                                                        </button>
-                                                      </Button>
-                                                    </ComponentWithOuia>
-                                                  </Component>
-                                                  <Component
-                                                    onClick={[Function]}
-                                                    type="button"
-                                                    variant="link"
+                                                        Back
+                                                      </button>
+                                                    </Button>
+                                                  </ComponentWithOuia>
+                                                </Component>
+                                                <Component
+                                                  onClick={[Function]}
+                                                  type="button"
+                                                  variant="link"
+                                                >
+                                                  <ComponentWithOuia
+                                                    component={[Function]}
+                                                    componentProps={
+                                                      Object {
+                                                        "children": "Cancel",
+                                                        "onClick": [Function],
+                                                        "type": "button",
+                                                        "variant": "link",
+                                                      }
+                                                    }
+                                                    consumerContext={null}
                                                   >
-                                                    <ComponentWithOuia
-                                                      component={[Function]}
-                                                      componentProps={
+                                                    <Button
+                                                      onClick={[Function]}
+                                                      ouiaContext={
                                                         Object {
-                                                          "children": "Cancel",
-                                                          "onClick": [Function],
-                                                          "type": "button",
-                                                          "variant": "link",
+                                                          "isOuia": false,
+                                                          "ouiaId": null,
                                                         }
                                                       }
-                                                      consumerContext={null}
+                                                      type="button"
+                                                      variant="link"
                                                     >
-                                                      <Button
+                                                      <button
+                                                        aria-disabled={null}
+                                                        aria-label={null}
+                                                        className="pf-c-button pf-m-link"
+                                                        disabled={false}
                                                         onClick={[Function]}
-                                                        ouiaContext={
-                                                          Object {
-                                                            "isOuia": false,
-                                                            "ouiaId": null,
-                                                          }
-                                                        }
+                                                        tabIndex={null}
                                                         type="button"
-                                                        variant="link"
                                                       >
-                                                        <button
-                                                          aria-disabled={null}
-                                                          aria-label={null}
-                                                          className="pf-c-button pf-m-link"
-                                                          disabled={false}
-                                                          onClick={[Function]}
-                                                          tabIndex={null}
-                                                          type="button"
-                                                        >
-                                                          Cancel
-                                                        </button>
-                                                      </Button>
-                                                    </ComponentWithOuia>
-                                                  </Component>
-                                                </footer>
-                                              </WizardStepButtons>
-                                            </WizardStep>
-                                          </div>
+                                                        Cancel
+                                                      </button>
+                                                    </Button>
+                                                  </ComponentWithOuia>
+                                                </Component>
+                                              </footer>
+                                            </WizardStepButtons>
+                                          </WizardStep>
                                         </div>
                                       </div>
-                                    </Bullseye>
-                                  </div>
-                                </Backdrop>
-                              </Portal>
-                            </Modal>
-                          </Wizard>
-                        </WizardFunction>
-                      </FieldWrapper>
-                    </FormFieldHideWrapper>
-                  </FormConditionWrapper>
-                </SingleField>
-              </form>
-            </Form>
-          </FormTemplate>
-        </PF4FormTemplate>
-      </FormTemplate>
-    </FormContent>
+                                    </div>
+                                  </Bullseye>
+                                </div>
+                              </Backdrop>
+                            </Portal>
+                          </Modal>
+                        </Wizard>
+                      </WizardFunction>
+                    </FieldWrapper>
+                  </FormFieldHideWrapper>
+                </FormConditionWrapper>
+              </SingleField>
+            </form>
+          </Form>
+        </FormTemplate>
+      </PF4FormTemplate>
+    </FormTemplate>
   </ReactFinalForm>
 </FormRenderer>
 `;

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -1,25 +1,26 @@
-/* eslint-disable */
-import React, { useState, memo } from "react";
-import ReactDOM from "react-dom";
+/* eslint-disable camelcase */
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
 import FormRenderer from '../src';
 import componentMapper from './form-fields-mapper';
 import FormTemplate from './form-template';
-import sandboxSchema from './sandbox'
+import sandboxSchema from './sandbox';
 
-const intl = (name) => `translated ${name}`
+const intl = (name) => `translated ${name}`;
 
 const actionMapper = {
-    loadData: (data) => () => new Promise((resolve) => setTimeout(() => resolve({ custom: 'ererewr', ...data }), 1700)),
-    loadLabel: intl
-}
+  loadData: (data) => () => new Promise((resolve) => setTimeout(() => resolve({ custom: 'ererewr', ...data }), 1700)),
+  loadLabel: intl
+};
 
-
-const ChildForm = memo(({setValues}) => (
-    <FormRenderer
-        key="HELP"
+const App = () => {
+  const [values, setValues] = useState({});
+  return (
+    <div style={{ padding: 20 }}>
+      <FormRenderer
         initialValues={{
-            text_box_1: 'hue',
-            text_box_3: 'initial'
+          text_box_1: 'hue',
+          text_box_3: 'initial'
         }}
         clearedValue={'bla'}
         componentMapper={componentMapper}
@@ -28,21 +29,13 @@ const ChildForm = memo(({setValues}) => (
         canReset
         onReset={() => console.log('i am resseting')}
         schema={sandboxSchema}
-        onStateUpdate={state => setValues(state.values)}
+        debug={(state) => setValues(state.values)}
         FormTemplate={FormTemplate}
         actionMapper={actionMapper}
-    />
-))
-
-const App = () => {
-    const [values, setValues] = useState({})
-    return (
-    <div style={{ padding: 20 }}>
-        <ChildForm setValues={setValues} />
-        <div>
-            {JSON.stringify(values, null, 2)}
-        </div>
+      />
+      <div>{JSON.stringify(values, null, 2)}</div>
     </div>
-)}
+  );
+};
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/react-form-renderer/src/components/form-renderer.js
+++ b/packages/react-form-renderer/src/components/form-renderer.js
@@ -9,24 +9,6 @@ import renderForm from '../form-renderer/render-form';
 import defaultSchemaValidator from '../parsers/default-schema-validator';
 import SchemaErrorComponent from '../form-renderer/schema-error-component';
 import defaultValidatorMapper from '../validators/validator-mapper';
-import useComponentSpy from '../hooks/use-component-spy';
-
-const FormContent = ({ value, formFields, schema, onStateUpdate, Template }) => {
-  useComponentSpy(onStateUpdate);
-  return (
-    <RendererContext.Provider value={value}>
-      <Template formFields={formFields} schema={schema} />
-    </RendererContext.Provider>
-  );
-};
-
-FormContent.propTypes = {
-  value: PropTypes.object.isRequired,
-  formFields: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
-  schema: PropTypes.object.isRequired,
-  onStateUpdate: PropTypes.func,
-  Template: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func]).isRequired
-};
 
 const FormRenderer = ({
   componentMapper,
@@ -42,7 +24,7 @@ const FormRenderer = ({
   schema,
   validatorMapper,
   actionMapper,
-  onStateUpdate
+  debug
 }) => {
   let schemaError;
 
@@ -74,12 +56,9 @@ const FormRenderer = ({
       initialValues={initialValues}
       validate={validate}
       subscription={{ pristine: true, submitting: true, valid: true, ...subscription }}
+      debug={debug}
       render={({ handleSubmit, pristine, valid, form: { reset, mutators, getState, submit, ...form }, ...state }) => (
-        <FormContent
-          formFields={renderForm(schema.fields)}
-          schema={schema}
-          onStateUpdate={onStateUpdate}
-          Template={Template}
+        <RendererContext.Provider
           value={{
             componentMapper,
             validatorMapper: validatorMapperMerged,
@@ -101,14 +80,15 @@ const FormRenderer = ({
               ...form
             }
           }}
-        />
+        >
+          <Template formFields={renderForm(schema.fields)} schema={schema} />
+        </RendererContext.Provider>
       )}
     />
   );
 };
 
 FormRenderer.propTypes = {
-  onStateUpdate: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
   onReset: PropTypes.func,
@@ -127,7 +107,8 @@ FormRenderer.propTypes = {
   }),
   actionMapper: PropTypes.shape({
     [PropTypes.string]: PropTypes.func
-  })
+  }),
+  debug: PropTypes.func
 };
 
 FormRenderer.defaultProps = {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -66,8 +66,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <FormTemplate
       formFields={
         Array [
           <SingleField
@@ -92,73 +91,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               "name": "secret",
             },
           ],
-        }
-      }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": undefined,
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
         }
       }
     >
@@ -190,126 +122,97 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
           }
         }
       >
-        <FormTemplate
-          formFields={
-            Array [
-              <SingleField
-                component="text-field"
-                name="component1"
-              />,
-              <SingleField
-                component="select"
-                name="secret"
-              />,
-            ]
-          }
-          schema={
-            Object {
-              "fields": Array [
-                Object {
-                  "component": "text-field",
-                  "name": "component1",
-                },
-                Object {
-                  "component": "select",
-                  "name": "secret",
-                },
-              ],
-            }
-          }
+        <form
+          onSubmit={[Function]}
         >
-          <form
-            onSubmit={[Function]}
+          <SingleField
+            component="text-field"
+            key="component1"
+            name="component1"
           >
-            <SingleField
-              component="text-field"
-              key="component1"
-              name="component1"
-            >
-              <FormConditionWrapper>
-                <FormFieldHideWrapper
-                  hideField={false}
+            <FormConditionWrapper>
+              <FormFieldHideWrapper
+                hideField={false}
+              >
+                <FieldWrapper
+                  component={[Function]}
+                  componentType="text-field"
+                  name="component1"
                 >
-                  <FieldWrapper
-                    component={[Function]}
-                    componentType="text-field"
+                  <TextField
                     name="component1"
+                    validate={[Function]}
                   >
-                    <TextField
-                      name="component1"
-                      validate={[Function]}
+                    <div
+                      className="nested-item"
                     >
-                      <div
-                        className="nested-item"
-                      >
-                        <input
-                          id="component1"
-                          name="component1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          value=""
-                        />
-                      </div>
-                    </TextField>
-                  </FieldWrapper>
-                </FormFieldHideWrapper>
-              </FormConditionWrapper>
-            </SingleField>
-            <SingleField
-              component="select"
-              key="secret"
-              name="secret"
-            >
-              <FormConditionWrapper>
-                <FormFieldHideWrapper
-                  hideField={false}
+                      <input
+                        id="component1"
+                        name="component1"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value=""
+                      />
+                    </div>
+                  </TextField>
+                </FieldWrapper>
+              </FormFieldHideWrapper>
+            </FormConditionWrapper>
+          </SingleField>
+          <SingleField
+            component="select"
+            key="secret"
+            name="secret"
+          >
+            <FormConditionWrapper>
+              <FormFieldHideWrapper
+                hideField={false}
+              >
+                <FieldWrapper
+                  component={[Function]}
+                  componentType="select"
+                  name="secret"
                 >
-                  <FieldWrapper
-                    component={[Function]}
-                    componentType="select"
+                  <Component
                     name="secret"
+                    validate={[Function]}
                   >
-                    <Component
-                      name="secret"
-                      validate={[Function]}
+                    <div
+                      className="nested-item"
                     >
-                      <div
-                        className="nested-item"
-                      >
-                        Select field
-                      </div>
-                    </Component>
-                  </FieldWrapper>
-                </FormFieldHideWrapper>
-              </FormConditionWrapper>
-            </SingleField>
-            <FormSpy>
-              <button
-                disabled={false}
-                type="submit"
-              >
-                Submit
-              </button>
-              <button
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-              >
-                Reset
-              </button>
-              <button
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-              >
-                Cancel
-              </button>
-            </FormSpy>
-          </form>
-        </FormTemplate>
+                      Select field
+                    </div>
+                  </Component>
+                </FieldWrapper>
+              </FormFieldHideWrapper>
+            </FormConditionWrapper>
+          </SingleField>
+          <FormSpy>
+            <button
+              disabled={false}
+              type="submit"
+            >
+              Submit
+            </button>
+            <button
+              disabled={true}
+              onClick={[Function]}
+              type="button"
+            >
+              Reset
+            </button>
+            <button
+              disabled={true}
+              onClick={[Function]}
+              type="button"
+            >
+              Cancel
+            </button>
+          </FormSpy>
+        </form>
       </FormTemplate>
-    </FormContent>
+    </FormTemplate>
   </ReactFinalForm>
 </FormRenderer>
 `;
@@ -383,8 +286,7 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
       }
     }
   >
-    <FormContent
-      Template={[Function]}
+    <FormTemplate
       formFields={
         Array [
           <SingleField
@@ -415,73 +317,6 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
               "name": "hidden",
             },
           ],
-        }
-      }
-      value={
-        Object {
-          "actionMapper": undefined,
-          "componentMapper": Object {
-            "checkbox": [Function],
-            "date-picker": [Function],
-            "radio": [Function],
-            "select": [Function],
-            "sub-form": [Function],
-            "tabs": [Function],
-            "text-field": [Function],
-            "textarea": [Function],
-            "time-picker": [Function],
-          },
-          "formOptions": Object {
-            "batch": [Function],
-            "blur": [Function],
-            "change": [Function],
-            "clearOnUnmount": false,
-            "clearedValue": undefined,
-            "concat": [Function],
-            "destroyOnUnregister": false,
-            "focus": [Function],
-            "getFieldState": [Function],
-            "getRegisteredFields": [Function],
-            "getState": [Function],
-            "handleSubmit": [Function],
-            "initialize": [Function],
-            "insert": [Function],
-            "isValidationPaused": [Function],
-            "move": [Function],
-            "onCancel": undefined,
-            "onReset": undefined,
-            "onSubmit": [MockFunction],
-            "pauseValidation": [Function],
-            "pop": [Function],
-            "pristine": true,
-            "push": [Function],
-            "registerField": [Function],
-            "remove": [Function],
-            "removeBatch": [Function],
-            "renderForm": [Function],
-            "reset": [Function],
-            "resetFieldState": [Function],
-            "resumeValidation": [Function],
-            "setConfig": [Function],
-            "shift": [Function],
-            "submit": [Function],
-            "subscribe": [Function],
-            "swap": [Function],
-            "unshift": [Function],
-            "update": [Function],
-            "valid": true,
-          },
-          "validatorMapper": Object {
-            "exact-length-validator": [Function],
-            "max-length-validator": [Function],
-            "max-number-value": [Function],
-            "min-items-validator": [Function],
-            "min-length-validator": [Function],
-            "min-number-value": [Function],
-            "pattern-validator": [Function],
-            "required-validator": [Function],
-            "url-validator": [Function],
-          },
         }
       }
     >
@@ -519,70 +354,78 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
           }
         }
       >
-        <FormTemplate
-          formFields={
-            Array [
-              <SingleField
-                component="text-field"
-                label="Visible"
-                name="visible"
-              />,
-              <SingleField
-                component="text-field"
-                hideField={true}
-                label="Hidden"
-                name="hidden"
-              />,
-            ]
-          }
-          schema={
-            Object {
-              "fields": Array [
-                Object {
-                  "component": "text-field",
-                  "label": "Visible",
-                  "name": "visible",
-                },
-                Object {
-                  "component": "text-field",
-                  "hideField": true,
-                  "label": "Hidden",
-                  "name": "hidden",
-                },
-              ],
-            }
-          }
+        <form
+          onSubmit={[Function]}
         >
-          <form
-            onSubmit={[Function]}
+          <SingleField
+            component="text-field"
+            key="visible"
+            label="Visible"
+            name="visible"
           >
-            <SingleField
-              component="text-field"
-              key="visible"
-              label="Visible"
-              name="visible"
-            >
-              <FormConditionWrapper>
-                <FormFieldHideWrapper
-                  hideField={false}
+            <FormConditionWrapper>
+              <FormFieldHideWrapper
+                hideField={false}
+              >
+                <FieldWrapper
+                  component={[Function]}
+                  componentType="text-field"
+                  label="Visible"
+                  name="visible"
+                >
+                  <TextField
+                    label="Visible"
+                    name="visible"
+                    validate={[Function]}
+                  >
+                    <div
+                      className="nested-item"
+                    >
+                      <input
+                        id="visible"
+                        name="visible"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value=""
+                      />
+                    </div>
+                  </TextField>
+                </FieldWrapper>
+              </FormFieldHideWrapper>
+            </FormConditionWrapper>
+          </SingleField>
+          <SingleField
+            component="text-field"
+            hideField={true}
+            key="hidden"
+            label="Hidden"
+            name="hidden"
+          >
+            <FormConditionWrapper>
+              <FormFieldHideWrapper
+                hideField={true}
+              >
+                <div
+                  hidden={true}
                 >
                   <FieldWrapper
                     component={[Function]}
                     componentType="text-field"
-                    label="Visible"
-                    name="visible"
+                    label="Hidden"
+                    name="hidden"
                   >
                     <TextField
-                      label="Visible"
-                      name="visible"
+                      label="Hidden"
+                      name="hidden"
                       validate={[Function]}
                     >
                       <div
                         className="nested-item"
                       >
                         <input
-                          id="visible"
-                          name="visible"
+                          id="hidden"
+                          name="hidden"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -591,78 +434,35 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                       </div>
                     </TextField>
                   </FieldWrapper>
-                </FormFieldHideWrapper>
-              </FormConditionWrapper>
-            </SingleField>
-            <SingleField
-              component="text-field"
-              hideField={true}
-              key="hidden"
-              label="Hidden"
-              name="hidden"
+                </div>
+              </FormFieldHideWrapper>
+            </FormConditionWrapper>
+          </SingleField>
+          <FormSpy>
+            <button
+              disabled={false}
+              type="submit"
             >
-              <FormConditionWrapper>
-                <FormFieldHideWrapper
-                  hideField={true}
-                >
-                  <div
-                    hidden={true}
-                  >
-                    <FieldWrapper
-                      component={[Function]}
-                      componentType="text-field"
-                      label="Hidden"
-                      name="hidden"
-                    >
-                      <TextField
-                        label="Hidden"
-                        name="hidden"
-                        validate={[Function]}
-                      >
-                        <div
-                          className="nested-item"
-                        >
-                          <input
-                            id="hidden"
-                            name="hidden"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            value=""
-                          />
-                        </div>
-                      </TextField>
-                    </FieldWrapper>
-                  </div>
-                </FormFieldHideWrapper>
-              </FormConditionWrapper>
-            </SingleField>
-            <FormSpy>
-              <button
-                disabled={false}
-                type="submit"
-              >
-                Submit
-              </button>
-              <button
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-              >
-                Reset
-              </button>
-              <button
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-              >
-                Cancel
-              </button>
-            </FormSpy>
-          </form>
-        </FormTemplate>
+              Submit
+            </button>
+            <button
+              disabled={true}
+              onClick={[Function]}
+              type="button"
+            >
+              Reset
+            </button>
+            <button
+              disabled={true}
+              onClick={[Function]}
+              type="button"
+            >
+              Cancel
+            </button>
+          </FormSpy>
+        </form>
       </FormTemplate>
-    </FormContent>
+    </FormTemplate>
   </ReactFinalForm>
 </FormRenderer>
 `;


### PR DESCRIPTION
onStateUpdate prop is removed from the renderer, instead of it use debug (please see [Final Form Documentation)](https://final-form.org/docs/react-final-form/types/FormProps#debug)

```jsx
<FormRenderer {...} debug={console.log} />
```