### PR TITLE
fix(pf4): wizard predicts steps by default

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/wizard-schema.js
@@ -49,7 +49,6 @@ export const wizardSchema = {
       component: componentTypes.WIZARD,
       name: 'wizzard',
       crossroads: ['source.source-type'],
-      predictSteps: true,
       //inModal: true,
       title: 'Title',
       showTitles: true,
@@ -158,7 +157,6 @@ export const wizardSchemaWithFunction = {
     {
       component: componentTypes.WIZARD,
       name: 'wizzard',
-      predictSteps: true,
       //inModal: true,
       title: 'Title',
       showTitles: true,
@@ -372,7 +370,6 @@ export const wizardSchemaMoreSubsteps = {
       title: 'Dynamic with steps predicting',
       description: 'Description',
       buttonsPosition: 'left',
-      predictSteps: true,
       fields: [
         {
           title: 'Get started with adding source',

--- a/packages/pf4-component-mapper/src/components/wizard.js
+++ b/packages/pf4-component-mapper/src/components/wizard.js
@@ -32,7 +32,6 @@ const Wizard = ({
   isDynamic,
   inModal,
   crossroads,
-  predictSteps,
   title,
   description,
   buttonLabels,
@@ -57,14 +56,14 @@ const Wizard = ({
     if (inModal) {
       dispatch({ type: 'setContainer' });
     } else {
-      dispatch({ type: 'finishLoading', payload: { formOptions, fields, predictSteps } });
+      dispatch({ type: 'finishLoading', payload: { formOptions, fields } });
     }
-  }, [inModal, formOptions, fields, predictSteps]);
+  }, [inModal, formOptions, fields]);
 
   useEffect(() => {
     if (state.container) {
       document.body.appendChild(state.container);
-      dispatch({ type: 'finishLoading', payload: { formOptions, fields, predictSteps } });
+      dispatch({ type: 'finishLoading', payload: { formOptions, fields } });
     }
 
     return () => {
@@ -72,7 +71,7 @@ const Wizard = ({
         document.body.removeChild(state.container);
       }
     };
-  }, [state.container, formOptions, fields, predictSteps, inModal]);
+  }, [state.container, formOptions, fields, inModal]);
 
   if (state.loading) {
     return null;
@@ -114,13 +113,13 @@ const Wizard = ({
     />
   );
 
-  const jumpToStep = (index, valid) => dispatch({ type: 'jumpToStep', payload: { index, valid, fields, predictSteps, crossroads, formOptions } });
+  const jumpToStep = (index, valid) => dispatch({ type: 'jumpToStep', payload: { index, valid, fields, crossroads, formOptions } });
 
   const handlePrev = () => jumpToStep(state.activeStepIndex - 1);
 
-  const handleNext = (nextStep) => dispatch({ type: 'handleNext', payload: { nextStep, formOptions, fields, predictSteps } });
+  const handleNext = (nextStep) => dispatch({ type: 'handleNext', payload: { nextStep, formOptions, fields } });
 
-  const setPrevSteps = () => dispatch({ type: 'setPrevSteps', payload: { formOptions, fields, predictSteps } });
+  const setPrevSteps = () => dispatch({ type: 'setPrevSteps', payload: { formOptions, fields } });
 
   const findCurrentStepWrapped = (step) => findCurrentStep(step, fields);
 
@@ -185,7 +184,6 @@ Wizard.propTypes = {
   setFullHeight: PropTypes.bool,
   isDynamic: PropTypes.bool,
   showTitles: PropTypes.bool,
-  predictSteps: PropTypes.bool,
   crossroads: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -380,63 +380,6 @@ describe('<Wizard />', () => {
     ).toEqual('bar-step');
   });
 
-  it('should build progressive navigation', () => {
-    schema = {
-      fields: [
-        {
-          name: 'wizard',
-          component: 'wizard',
-          isDynamic: true,
-          fields: [
-            {
-              title: 'foo-step',
-              name: '1',
-              fields: [
-                {
-                  name: 'foo-field',
-                  component: 'text-field'
-                }
-              ],
-              nextStep: '2'
-            },
-            {
-              name: '2',
-              title: 'bar-step',
-              fields: [
-                {
-                  name: 'bar-field',
-                  component: 'text-field'
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    };
-
-    const wrapper = mount(<FormRenderer {...initialProps} schema={schema} />);
-
-    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
-    expect(
-      wrapper
-        .find('.pf-c-wizard__nav-item')
-        .first()
-        .childAt(0)
-        .text()
-    ).toEqual('foo-step');
-
-    nextButtonClick(wrapper);
-
-    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(2);
-    expect(
-      wrapper
-        .find('.pf-c-wizard__nav-item')
-        .last()
-        .childAt(0)
-        .text()
-    ).toEqual('bar-step');
-  });
-
   it('should jump when click simple navigation', () => {
     const wrapper = mount(<FormRenderer {...initialProps} />);
 
@@ -637,12 +580,13 @@ describe('<Wizard />', () => {
     const wrapper = mount(<FormRenderer {...initialProps} schema={schema} />);
 
     expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
-    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
+    expect(wrapper.find('.pf-c-wizard__nav-link.pf-m-disabled')).toHaveLength(2); // steps + substep
 
     nextButtonClick(wrapper);
 
     expect(wrapper.find(TextInput).props().name).toEqual('bar-field');
-    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
+    expect(wrapper.find('.pf-c-wizard__nav-link.pf-m-disabled')).toHaveLength(0);
 
     // click on first nav link
     wrapper
@@ -653,8 +597,7 @@ describe('<Wizard />', () => {
     wrapper.update();
 
     expect(wrapper.find(TextInput).props().name).toEqual('foo-field');
-    // visited step perished from navigation
-    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(1);
+    expect(wrapper.find('.pf-c-wizard__nav-item')).toHaveLength(3);
 
     nextButtonClick(wrapper);
 
@@ -862,7 +805,6 @@ describe('<Wizard />', () => {
         {
           component: componentTypes.WIZARD,
           name: 'wizard',
-          predictSteps: true,
           fields: [
             {
               title: FIRST_TITLE,
@@ -1041,7 +983,6 @@ describe('<Wizard />', () => {
           {
             component: componentTypes.WIZARD,
             name: 'wizard',
-            predictSteps: true,
             fields: [
               {
                 title: FIRST_TITLE,
@@ -1129,7 +1070,6 @@ describe('<Wizard />', () => {
           {
             component: componentTypes.WIZARD,
             name: 'wizard',
-            predictSteps: true,
             fields: [
               {
                 title: FIRST_TITLE,
@@ -1206,7 +1146,6 @@ describe('<Wizard />', () => {
           {
             component: componentTypes.WIZARD,
             name: 'wizard',
-            predictSteps: true,
             fields: [
               {
                 title: FIRST_TITLE,
@@ -1288,7 +1227,6 @@ describe('<Wizard />', () => {
           {
             component: componentTypes.WIZARD,
             name: 'wizard',
-            predictSteps: true,
             crossroads: ['source.source-type'],
             fields: [
               {
@@ -1453,7 +1391,6 @@ describe('<Wizard />', () => {
           {
             component: componentTypes.WIZARD,
             name: 'wizard',
-            predictSteps: true,
             crossroads: ['source.source-type'],
             fields: [
               {

--- a/packages/react-renderer-demo/src/app/pages/renderer/migration-guide.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/migration-guide.md
@@ -149,6 +149,10 @@ import { componentMapper } from '@data-driven-forms/pf4-component-mapper'
 
 -   stepKey prop is replaced by name
 
+### PF4 Wizard predictSteps removed
+
+-   predictSteps prop is now removed, wizard always predicts steps
+
 </Grid>
 <Grid item xs={false} md={2}>
   <ListOfContents file="renderer/migration-guide" />

--- a/packages/react-renderer-demo/src/app/src/doc-components/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/pf4-wizard.md
@@ -15,7 +15,6 @@ Don't forget hide form controls by setting \`showFormControls\` to \`false\` as 
 | setFullHeight  | bool  | undefined  | see Patternfly  |
 | isDynamic  | bool  | undefined  | will dynamically generate steps navigation (=progressive wizard), please use if you use any condition fields which changes any field in other steps (wizards with conditional steps are dynamic by default) |
 |showTitles|bool|undefined|If true, step titles will be shown in the wizard body|
-|predictSteps|bool|undefined|If true, dynamic wizard will predict steps in the navigation.|
 |crossroads|array|undefined|Array of field names, which change next steps|
 
 **Default buttonLabels**
@@ -40,7 +39,7 @@ You can rewrite only selection of them, e.g.
 
 **Crossroads**
 
-With the help of `crossroads` you can manually defined which fields change next steps and together with `predictSteps`, it will cause that the wizard navigation is always refreshed, when one of the crossroads name is changed.
+With the help of `crossroads` you can manually defined which fields change next steps, it will cause that the wizard navigation is always refreshed, when one of the crossroads name is changed.
 
 Ex.: `crossroads: ['name', 'nested.password']`
 
@@ -179,9 +178,8 @@ Progressive wizard
 - steps are visible as user visits them
 - user can jump only back
 - use `isDynamic` prop to enforce it
-- use `predictSteps` to allow navigation to show future steps
-    - if you have any conditional fields in the step, you should use `disableForwardJumping` in the step definition, to disable jumping forward in the navigation, otherwise user could miss the changed fields in next steps.
-- you can use `crossroads` to define, which fields the wizzard will listen to and change the navigation according to changes of the defined values 
+- if you have any conditional fields in the step, you should use `disableForwardJumping` in the step definition, to disable jumping forward in the navigation, otherwise user could miss the changed fields in next steps.
+- you can use `crossroads` to define, which fields the wizzard will listen to and change the navigation according to changes of the defined values
 
 ![progressivewizard](https://user-images.githubusercontent.com/32869456/58427241-5b370a80-809f-11e9-8e79-a4a829b8d181.gif)
 


### PR DESCRIPTION
Removes predictSteps from PF4 wizard. It's always true. (There is no reason to not show all steps in the navigation, when it's possible.)