### PR TITLE
[V2] feat(renderer): add schemaValidatorMapper

### DIFF
--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -5,6 +5,7 @@ import FormRenderer, { validatorTypes } from '../src';
 import componentMapper from './form-fields-mapper';
 import FormTemplate from './form-template';
 // import sandboxSchema from './sandbox';
+import DefaultSchemaError from '../src/parsers/schema-errors';
 
 const intl = (name) => `translated ${name}`;
 
@@ -59,6 +60,17 @@ const App = () => {
         schema={asyncValidatorSchema}
         FormTemplate={FormTemplate}
         actionMapper={actionMapper}
+        schemaValidatorMapper={{
+          actions: {
+            loadLabel: (action, fieldName) => {
+              if (typeof action[1] !== 'string') {
+                throw new DefaultSchemaError(
+                  `Second argument of loadLabel action has to be a string: ID of the text from the translated database. Error found in ${fieldName}`
+                );
+              }
+            }
+          }
+        }}
       />
     </div>
   );

--- a/packages/react-form-renderer/src/components/form-renderer.js
+++ b/packages/react-form-renderer/src/components/form-renderer.js
@@ -24,6 +24,7 @@ const FormRenderer = ({
   schema,
   validatorMapper,
   actionMapper,
+  schemaValidatorMapper,
   debug,
   ...props
 }) => {
@@ -34,7 +35,7 @@ const FormRenderer = ({
   try {
     const validatorTypes = Object.keys(validatorMapperMerged);
     const actionTypes = actionMapper ? Object.keys(actionMapper) : [];
-    defaultSchemaValidator(schema, componentMapper, validatorTypes, actionTypes);
+    defaultSchemaValidator(schema, componentMapper, validatorTypes, actionTypes, schemaValidatorMapper);
   } catch (error) {
     schemaError = error;
     console.error(error);
@@ -113,7 +114,18 @@ FormRenderer.propTypes = {
   actionMapper: PropTypes.shape({
     [PropTypes.string]: PropTypes.func
   }),
-  debug: PropTypes.func
+  debug: PropTypes.func,
+  schemaValidatorMapper: PropTypes.shape({
+    components: PropTypes.shape({
+      [PropTypes.string]: PropTypes.func
+    }),
+    validators: PropTypes.shape({
+      [PropTypes.string]: PropTypes.func
+    }),
+    actions: PropTypes.shape({
+      [PropTypes.string]: PropTypes.func
+    })
+  })
 };
 
 FormRenderer.defaultProps = {

--- a/packages/react-form-renderer/src/index.js
+++ b/packages/react-form-renderer/src/index.js
@@ -12,3 +12,4 @@ export { default as Form } from './components/form';
 export { default as FieldArray } from './components/field-array';
 export { default as FieldProvider } from './components/field-provider';
 export { default as useFieldApi } from './hooks/use-field-api';
+export { default as DefaultSchemaError } from './parsers/schema-errors';

--- a/packages/react-form-renderer/src/tests/form-renderer/schema-validator-mapper.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/schema-validator-mapper.test.js
@@ -1,0 +1,170 @@
+/* eslint-disable no-console */
+import React from 'react';
+import { mount } from 'enzyme';
+import FormRenderer from '../../components/form-renderer';
+import componentTypes from '../../components/component-types';
+import DefaultSchemaError from '../../parsers/schema-errors';
+import SchemaErrorComponent from '../../form-renderer/schema-error-component';
+
+describe('schemaValidatorMapper', () => {
+  let initialProps;
+  let schemaValidatorMapper;
+  let _console;
+
+  beforeEach(() => {
+    initialProps = {
+      componentMapper: {
+        [componentTypes.TEXT_FIELD]: () => <div>heeeellooo</div>,
+        [componentTypes.SUB_FORM]: () => <div>heeeellooo</div>
+      },
+      validatorMapper: {
+        custom: () => () => undefined
+      },
+      actionMapper: {
+        translateString: () => 'string'
+      },
+      FormTemplate: () => <div>heeeellooo</div>,
+      onSubmit: jest.fn(),
+      schema: {
+        fields: [
+          {
+            component: componentTypes.TEXT_FIELD,
+            name: 'field-input',
+            validate: [{ type: 'custom' }],
+            actions: {
+              label: ['translateString']
+            }
+          }
+        ]
+      }
+    };
+    schemaValidatorMapper = {};
+    _console = console.error;
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = _console;
+  });
+
+  it('component schema error', () => {
+    schemaValidatorMapper = {
+      components: {
+        [componentTypes.TEXT_FIELD]: (field) => {
+          if (!field.customProp) {
+            throw new DefaultSchemaError(`Please include "customProp" in ${field.name}`);
+          }
+        }
+      }
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} schemaValidatorMapper={schemaValidatorMapper} />);
+
+    expect(wrapper.find(SchemaErrorComponent).text()).toEqual(expect.stringContaining('Please include "customProp" in field-input'));
+  });
+
+  it('validator schema error', () => {
+    schemaValidatorMapper = {
+      validators: {
+        custom: (validator, fieldName) => {
+          if (!validator.customProp) {
+            throw new DefaultSchemaError(`Please include "customProp" in custom validator in ${fieldName}`);
+          }
+        }
+      }
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} schemaValidatorMapper={schemaValidatorMapper} />);
+
+    expect(wrapper.find(SchemaErrorComponent).text()).toEqual(
+      expect.stringContaining('Please include "customProp" in custom validator in field-input')
+    );
+  });
+
+  it('action schema error', () => {
+    schemaValidatorMapper = {
+      actions: {
+        translateString: (action, fieldName) => {
+          if (!action.length < 2) {
+            throw new DefaultSchemaError(`TranslateString actions has to have two arguments in: ${fieldName}`);
+          }
+        }
+      }
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} schemaValidatorMapper={schemaValidatorMapper} />);
+
+    expect(wrapper.find(SchemaErrorComponent).text()).toEqual(
+      expect.stringContaining('TranslateString actions has to have two arguments in: field-input')
+    );
+  });
+
+  describe('nested components', () => {
+    beforeEach(() => {
+      initialProps = {
+        ...initialProps,
+        schema: {
+          fields: [
+            {
+              component: componentTypes.SUB_FORM,
+              name: 'subform',
+              ...initialProps.schema
+            }
+          ]
+        }
+      };
+    });
+
+    it('component schema error', () => {
+      schemaValidatorMapper = {
+        components: {
+          [componentTypes.TEXT_FIELD]: (field) => {
+            if (!field.customProp) {
+              throw new DefaultSchemaError(`Please include "customProp" in ${field.name}`);
+            }
+          }
+        }
+      };
+
+      const wrapper = mount(<FormRenderer {...initialProps} schemaValidatorMapper={schemaValidatorMapper} />);
+
+      expect(wrapper.find(SchemaErrorComponent).text()).toEqual(expect.stringContaining('Please include "customProp" in field-input'));
+    });
+
+    it('validator schema error', () => {
+      schemaValidatorMapper = {
+        validators: {
+          custom: (validator, fieldName) => {
+            if (!validator.customProp) {
+              throw new DefaultSchemaError(`Please include "customProp" in custom validator in ${fieldName}`);
+            }
+          }
+        }
+      };
+
+      const wrapper = mount(<FormRenderer {...initialProps} schemaValidatorMapper={schemaValidatorMapper} />);
+
+      expect(wrapper.find(SchemaErrorComponent).text()).toEqual(
+        expect.stringContaining('Please include "customProp" in custom validator in field-input')
+      );
+    });
+
+    it('action schema error', () => {
+      schemaValidatorMapper = {
+        actions: {
+          translateString: (action, fieldName) => {
+            if (!action.length < 2) {
+              throw new DefaultSchemaError(`TranslateString actions has to have two arguments in: ${fieldName}`);
+            }
+          }
+        }
+      };
+
+      const wrapper = mount(<FormRenderer {...initialProps} schemaValidatorMapper={schemaValidatorMapper} />);
+
+      expect(wrapper.find(SchemaErrorComponent).text()).toEqual(
+        expect.stringContaining('TranslateString actions has to have two arguments in: field-input')
+      );
+    });
+  });
+});

--- a/packages/react-renderer-demo/src/app/pages/renderer/renderer-api.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/renderer-api.md
@@ -30,6 +30,7 @@ Form Renderer provides a lot of customization via props.
 |onCancel|func|A cancel callback, which receives `values` as the first argument.||
 |debug|func|A function which will be called with every form update, i.e. `({ values }) => setValues(values)`, please take a look [here](https://final-form.org/docs/react-final-form/types/FormProps#debug)||
 |initialValues|object|An object of fields names as keys and values as their values.||
+|[schemaValidatorMapper](/renderer/schema-validator)|object|Schema validators mapper. You can control schemas of your components, validators and actions.||
 |subscription|object|You can pass your own [subscription](https://final-form.org/docs/react-final-form/types/FormProps#subscription), which will be added to default settings.|`{ pristine: true, submitting: true, valid: true }`|
 |[validate](/renderer/validators)|func|A function which receives all form values and returns an object with errors.||
 |[validatorMapper](/renderer/validators#validatormapper)|object|A mapper containing custom validators, it's automatically merged with the default one.||

--- a/packages/react-renderer-demo/src/app/pages/renderer/schema-validator.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/schema-validator.md
@@ -1,5 +1,5 @@
 import Grid from '@material-ui/core/Grid'
-
+import RawComponent from '@docs/raw-component';
 import ListOfContents from '../../src/helpers/list-of-contents';
 
 <Grid container item>
@@ -13,7 +13,7 @@ It's a simple object containing three keys: `components`, `actions`, `validators
 
 For returning an error please use `DefaultSchemaError` imported from the renderer's package. If the schema is correct, do nothing.
 
-## Example
+## Schema
 
 ```jsx
 import FormRenderer, { DefaultSchemaError } from '@data-driven-forms/react-form-renderer';
@@ -52,6 +52,10 @@ const schemaValidatorMapper = {
     schemaValidatorMapper={schemaValidatorMapper}
 />
 ```
+
+## Example
+
+<RawComponent source="schema-validator" />
 
 </Grid>
 <Grid item xs={false} md={2}>

--- a/packages/react-renderer-demo/src/app/pages/renderer/schema-validator.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/schema-validator.md
@@ -1,0 +1,60 @@
+import Grid from '@material-ui/core/Grid'
+
+import ListOfContents from '../../src/helpers/list-of-contents';
+
+<Grid container item>
+<Grid item xs={12} md={10}>
+
+# Schema validation
+
+Data Driven Forms contains default schema validator, that controls basic schema attributes: `name`, `component`, conditions, validators, etc. If you want to control your own validators, components or actions, use [schemaValidatorMapper](/renderer/renderer-api#optionalprops) prop.
+
+It's a simple object containing three keys: `components`, `actions`, `validators`. Each of these is an another object with names as keys and functions as returns. Components' validators receive the whole field object, actions'/validators' validators receive two arguments: action/validator as the first one and the name of the field as the second one.
+
+For returning an error please use `DefaultSchemaError` imported from the renderer's package. If the schema is correct, do nothing.
+
+## Example
+
+```jsx
+import FormRenderer, { DefaultSchemaError } from '@data-driven-forms/react-form-renderer';
+
+const schemaValidatorMapper = {
+    components: {
+        // schema validators for components
+        [component]: (field) => {
+            if(someError(field)) {
+                throw new DefaultSchemaError(`Error message in field ${field.name}`);
+            }
+        }
+    },
+    actions: {
+        // schema validators for actions
+        [actionName]: (action, fieldName) => {
+            if(someError(action)) {
+                throw new DefaultSchemaError(`Error message in field ${fieldName}`);
+            }
+        }
+    },
+    validators: {
+        // schema validators for validators
+        [validatorType]: (validator, fieldName) => {
+            if(someError(validator)) {
+                throw new DefaultSchemaError(`Error message in field ${fieldName}`);
+            }
+        }
+    }
+}
+
+...
+
+<FormRenderer
+    {...props}
+    schemaValidatorMapper={schemaValidatorMapper}
+/>
+```
+
+</Grid>
+<Grid item xs={false} md={2}>
+  <ListOfContents file="renderer/schema-validator" />
+</Grid>
+</Grid>

--- a/packages/react-renderer-demo/src/app/src/components/navigation/documentation-pages.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/documentation-pages.js
@@ -64,6 +64,10 @@ export const docs = [
     linkText: 'FieldArray Provider'
   },
   {
+    component: 'schema-validator',
+    linkText: 'Schema validation'
+  },
+  {
     component: 'migration-guide',
     linkText: 'Migration guide 1.x to 2.x'
   }

--- a/packages/react-renderer-demo/src/app/src/doc-components/schema-validator.js
+++ b/packages/react-renderer-demo/src/app/src/doc-components/schema-validator.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import FormRenderer, { componentTypes, DefaultSchemaError } from '@data-driven-forms/react-form-renderer';
+import { FormTemplate, componentMapper } from '@data-driven-forms/pf4-component-mapper';
+
+const schema = {
+  fields: [
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'i-am-okey',
+      label: 'I am label'
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'need-label'
+    }
+  ]
+};
+
+const schemaValidatorMapper = {
+  components: {
+    [componentTypes.TEXT_FIELD]: (field) => {
+      if (!field.label) {
+        throw new DefaultSchemaError(`Missing label prop in "${field.name}" component`);
+      }
+    }
+  }
+};
+
+const SchemaValidationExample = () => (
+  <div className="pf4">
+    <FormRenderer
+      FormTemplate={FormTemplate}
+      componentMapper={componentMapper}
+      schema={schema}
+      onSubmit={console.log}
+      schemaValidatorMapper={schemaValidatorMapper}
+    />
+  </div>
+);
+
+export default SchemaValidationExample;


### PR DESCRIPTION
todo:

- [x] Docs

```jsx
import FormRenderer, { DefaultSchemaError } from '@data-driven-forms/react-form-renderer';

const schemaValidatorMapper = {
    components: {
        // schema validators for components
        [component]: (field) => {
            if(someError(field)) {
                throw new DefaultSchemaError(`Error message in field ${field.name}`);
            }
        }
    },
    actions: {
        // schema validators for actions
        [actionName]: (action, fieldName) => {
            if(someError(action)) {
                throw new DefaultSchemaError(`Error message in field ${fieldName}`);
            }
        }
    },
    validators: {
        // schema validators for validators
        [validatorType]: (validator, fieldName) => {
            if(someError(validator)) {
                throw new DefaultSchemaError(`Error message in field ${fieldName}`);
            }
        }
    }
}

...

<FormRenderer
    {...props}
    schemaValidatorMapper={schemaValidatorMapper}
/>
```