### PR TITLE
Update CodeEditor options for md codes snippets

### DIFF
--- a/packages/react-renderer-demo/src/app/src/components/mdx/mdx-components.js
+++ b/packages/react-renderer-demo/src/app/src/components/mdx/mdx-components.js
@@ -72,18 +72,20 @@ const MdxComponents = {
         theme="tomorrow_night"
         name="UNIQUE_ID_OF_DIV"
         editorProps={{ $blockScrolling: true }}
-        value={children}
+        value={children.replace(/\n+$/, '')}
         fontSize={14}
         maxLines={Infinity}
         showPrintMargin={false}
-        showGutter={true}
+        showGutter={false}
         highlightActiveLine={false}
         style={{ width: '80%', margin: 10 }}
         setOptions={{
-          showLineNumbers: true
+          showLineNumbers: false,
+          readOnly: true
         }}
         onLoad={(editor) => {
           editor.getSession().setUseWorker(false);
+          editor.renderer.$cursorLayer.element.style.display = 'none';
         }}
       />
     </div>


### PR DESCRIPTION
- removes the additional last line
- hides cursor
- hides lineNumbers (I don't think it's useful and it also makes the code examples harder to read)

Before

![image](https://user-images.githubusercontent.com/32869456/76960276-66ec0a00-691b-11ea-8dd5-339a0e7fae17.png)

After

![image](https://user-images.githubusercontent.com/32869456/76960257-5e93cf00-691b-11ea-85be-a09a563a45eb.png)
