### PR TITLE
feat(renderer): add proper not, and, or conditions

### DIFF
--- a/packages/react-form-renderer/src/form-renderer/condition.js
+++ b/packages/react-form-renderer/src/form-renderer/condition.js
@@ -6,52 +6,59 @@ import get from 'lodash/get';
 
 const isEmptyValue = (value) => typeof value === 'number' || value === true ? false : lodashIsEmpty(value);
 
-const Condition = ({ condition, children }) => {
-  const fieldCondition = (value, { is, isNotEmpty, isEmpty, pattern, notMatch, flags }) => {
-    if (isNotEmpty){
-      return !isEmptyValue(value);
-    }
+const fieldCondition = (value, { is, isNotEmpty, isEmpty, pattern, notMatch, flags }) => {
+  if (isNotEmpty){
+    return !isEmptyValue(value);
+  }
 
-    if (isEmpty){
-      return isEmptyValue(value);
-    }
+  if (isEmpty){
+    return isEmptyValue(value);
+  }
 
-    if (pattern) {
-      const regExpPattern = RegExp(pattern, flags);
+  if (pattern) {
+    const regExpPattern = RegExp(pattern, flags);
 
-      return notMatch ? !regExpPattern.test(value) : regExpPattern.test(value);
-    }
+    return notMatch ? !regExpPattern.test(value) : regExpPattern.test(value);
+  }
 
-    const isMatched = Array.isArray(is) ? !!is.includes(value) : value === is;
+  const isMatched = Array.isArray(is) ? !!is.includes(value) : value === is;
 
-    return notMatch ? !isMatched : isMatched;
-  };
-
-  const shouldRender = (values, conditionItem) => {
-    if (typeof conditionItem.when === 'string') {
-      return fieldCondition(get(values, conditionItem.when), conditionItem);
-    }
-
-    if (Array.isArray(conditionItem.when)) {
-      return conditionItem.when.map(fieldName => fieldCondition(get(values, fieldName), conditionItem)).find(condition => !!condition);
-    }
-
-    return false;
-  };
-
-  return (
-    <FormSpy>
-      { ({ values }) => {
-        const visible = Array.isArray(condition)
-          ? !condition.map(conditionItem => !!shouldRender(values, conditionItem)).some(result => result === false)
-          : shouldRender(values, condition);
-
-        return visible ? children : null;
-      } }
-    </FormSpy>
-  );
-
+  return notMatch ? !isMatched : isMatched;
 };
+
+export const parseCondition = (condition, values) => {
+  if (Array.isArray(condition)) {
+    return !condition.map((condition) => parseCondition(condition, values)).some(result => result === false);
+  }
+
+  if (condition.and) {
+    return condition.and.map((condition) => parseCondition(condition, values)).every(result => result === true);
+  }
+
+  if (condition.or) {
+    return condition.or.map((condition) => parseCondition(condition, values)).some(result => result === true);
+  }
+
+  if (condition.not) {
+    return !parseCondition(condition.not, values);
+  }
+
+  if (typeof condition.when === 'string') {
+    return fieldCondition(get(values, condition.when), condition);
+  }
+
+  if (Array.isArray(condition.when)) {
+    return !!condition.when.map(fieldName => fieldCondition(get(values, fieldName), condition)).find(condition => !!condition);
+  }
+
+  return false;
+};
+
+const Condition = ({ condition, children }) => (
+  <FormSpy>
+    { ({ values }) => parseCondition(condition, values) ? children : null }
+  </FormSpy>
+);
 
 const conditionProps = {
   when: PropTypes.string.isRequired,

--- a/packages/react-form-renderer/src/parsers/default-schema-validator.js
+++ b/packages/react-form-renderer/src/parsers/default-schema-validator.js
@@ -22,6 +22,20 @@ const checkCondition = (condition, fieldName) => {
     return condition.forEach(item => checkCondition(item, fieldName));
   }
 
+  if (condition.hasOwnProperty('and') && !Array.isArray(condition.and)) {
+    throw new DefaultSchemaError(`
+      Error occured in field definition with "name" property: "${fieldName}".
+      'and' property in a field condition must be an array! Received: ${typeof condition.and}.
+    `);
+  }
+
+  if (condition.hasOwnProperty('or') && !Array.isArray(condition.and)) {
+    throw new DefaultSchemaError(`
+      Error occured in field definition with "name" property: "${fieldName}".
+      'or' propery in a field condition must be an array! Received: ${typeof condition.and}.
+    `);
+  }
+
   if (typeof condition !== 'object') {
     throw new DefaultSchemaError(`
       Error occured in field definition with name: "${fieldName}".
@@ -29,40 +43,42 @@ const checkCondition = (condition, fieldName) => {
     `);
   }
 
-  if (!condition.hasOwnProperty('when')) {
-    throw new DefaultSchemaError(`
+  if (!condition.hasOwnProperty('and') && !condition.hasOwnProperty('or') && !condition.hasOwnProperty('not')) {
+    if (!condition.hasOwnProperty('when')) {
+      throw new DefaultSchemaError(`
       Error occured in field definition with "name" property: "${fieldName}".
       Field condition must have "when" property! Properties received: [${Object.keys(condition)}].
     `);
-  }
+    }
 
-  if (!(typeof condition.when === 'string' || Array.isArray(condition.when))) {
-    throw new DefaultSchemaError(`
+    if (!(typeof condition.when === 'string' || Array.isArray(condition.when))) {
+      throw new DefaultSchemaError(`
       Error occured in field definition with name: "${fieldName}".
       Field condition property "when" must be oof type "string", ${typeof condition.when} received!].
     `);
-  }
+    }
 
-  if (!condition.hasOwnProperty('is') && !condition.hasOwnProperty('isEmpty')
+    if (!condition.hasOwnProperty('is') && !condition.hasOwnProperty('isEmpty')
   && !condition.hasOwnProperty('isNotEmpty') && !condition.hasOwnProperty('pattern')) {
-    throw new DefaultSchemaError(`
+      throw new DefaultSchemaError(`
       Error occured in field definition with name: "${fieldName}".
       Field condition must have one of "is", "isEmpty", "isNotEmpty", "pattern" property! Properties received: [${Object.keys(condition)}].
     `);
-  }
+    }
 
-  if (condition.hasOwnProperty('notMatch') && !condition.hasOwnProperty('pattern') && !condition.hasOwnProperty('is')) {
-    throw new DefaultSchemaError(`
+    if (condition.hasOwnProperty('notMatch') && !condition.hasOwnProperty('pattern') && !condition.hasOwnProperty('is')) {
+      throw new DefaultSchemaError(`
       Error occured in field definition with name: "${fieldName}".
       Field condition must have "pattern" or "is" property when "notMatch" is set! Properties received: [${Object.keys(condition)}].
     `);
-  }
+    }
 
-  if (condition.hasOwnProperty('pattern') && (!(condition.pattern instanceof RegExp) && typeof condition.pattern !== 'string')) {
-    throw new DefaultSchemaError(`
+    if (condition.hasOwnProperty('pattern') && (!(condition.pattern instanceof RegExp) && typeof condition.pattern !== 'string')) {
+      throw new DefaultSchemaError(`
       Error occured in field definition with name: "${fieldName}".
       Field condition must have "pattern" of instance "RegExp" or "string"! Instance received: [${condition.pattern.constructor.name}].
     `);
+    }
   }
 };
 

--- a/packages/react-form-renderer/src/tests/form-renderer/parse-condition.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/parse-condition.test.js
@@ -1,0 +1,311 @@
+import { parseCondition } from '../../form-renderer/condition';
+
+describe('parseCondition', () => {
+  let condition;
+  let values;
+
+  beforeEach(() => {
+    condition = undefined;
+    values = {};
+  });
+
+  it('simple condition - true', () => {
+    condition = {
+      when: 'x',
+      is: 'yes',
+    };
+
+    values = {
+      x: 'yes',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('simple condition - false', () => {
+    condition = {
+      when: 'x',
+      is: 'yes',
+    };
+
+    values = {
+      x: 'no',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  it('and condition - true', () => {
+    condition = {
+      and: [
+        { when: 'x', is: 'true' },
+        { when: 'y', is: 'true' },
+      ],
+    };
+
+    values = {
+      x: 'true',
+      y: 'true',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('and condition - false', () => {
+    condition = {
+      and: [
+        { when: 'x', is: 'true' },
+        { when: 'y', is: 'true' },
+      ],
+    };
+
+    values = {
+      x: 'true',
+      y: 'false',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  it('or condition - true', () => {
+    condition = {
+      or: [
+        { when: 'x', is: 'true' },
+        { when: 'y', is: 'true' },
+      ],
+    };
+
+    values = {
+      x: 'false',
+      y: 'true',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('or condition - false', () => {
+    condition = {
+      or: [
+        { when: 'x', is: 'true' },
+        { when: 'y', is: 'true' },
+      ],
+    };
+
+    values = {
+      x: 'false',
+      y: 'false',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  it('not condition - "true"', () => {
+    condition = {
+      not: { when: 'x', is: 'true' },
+    };
+
+    values = {
+      x: 'true',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  it('not condition - "false"', () => {
+    condition = {
+      not: { when: 'x', is: 'true' },
+    };
+
+    values = {
+      x: 'false',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('not condition with array - "false"', () => {
+    condition = {
+      not: [{ when: 'x', is: 'true' }, { when: 'y', is: 'true' }],
+    };
+
+    values = {
+      x: 'false',
+      y: 'false',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('not condition with array - "true"', () => {
+    condition = {
+      not: [{ when: 'x', is: 'true' }, { when: 'y', is: 'true' }],
+    };
+
+    values = {
+      x: 'true',
+      y: 'true',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  it('backwards compatibility - and condition - true', () => {
+    condition = [
+      { when: 'x', is: 'true' },
+      { when: 'y', is: 'true' },
+    ];
+
+    values = {
+      x: 'true',
+      y: 'true',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('backwards compatibility - and condition - false', () => {
+    condition = [
+      { when: 'x', is: 'true' },
+      { when: 'y', is: 'true' },
+    ];
+
+    values = {
+      x: 'true',
+      y: 'false',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  it('backwards compatibility - or condition - true', () => {
+    condition = { when: [ 'x', 'y' ], is: 'true' };
+
+    values = {
+      x: 'false',
+      y: 'true',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(true);
+  });
+
+  it('backwards compatibility - or condition - false', () => {
+    condition = { when: [ 'x', 'y' ], is: 'true' };
+
+    values = {
+      x: 'false',
+      y: 'false',
+    };
+
+    expect(parseCondition(condition, values)).toEqual(false);
+  });
+
+  describe('nested conditions', () => {
+    it('nested test 1 - true', () => {
+      condition = {
+        or: [
+          { not: { when: 'x', pattern: /true/ }},
+          { not: { when: 'y', pattern: /true/ }},
+          { not: { when: 'z', pattern: /true/ }},
+        ],
+      };
+
+      values = {
+        x: 'false',
+        y: 'false',
+        z: 'false',
+      };
+
+      expect(parseCondition(condition, values)).toEqual(true);
+    });
+
+    it('nested test 1 - true', () => {
+      condition = {
+        or: [
+          { not: { when: 'x', pattern: /true/ }},
+          { not: { when: 'y', pattern: /true/ }},
+          { not: { when: 'z', pattern: /true/ }},
+        ],
+      };
+
+      values = {
+        x: 'true',
+        y: 'false',
+        z: 'false',
+      };
+
+      expect(parseCondition(condition, values)).toEqual(true);
+    });
+
+    it('nested test 1 - false', () => {
+      condition = {
+        or: [
+          { not: { when: 'x', pattern: /true/ }},
+          { not: { when: 'y', pattern: /true/ }},
+          { not: { when: 'z', pattern: /true/ }},
+        ],
+      };
+
+      values = {
+        x: 'true',
+        y: 'true',
+        z: 'true',
+      };
+
+      expect(parseCondition(condition, values)).toEqual(false);
+    });
+
+    it('nested test 2 - true', () => {
+      condition = {
+        and: [
+          { and: [{ when: 'x', pattern: /true/ }, { when: 'z', is: 'true' }]},
+          { or: [{ when: 'y', pattern: /true/ }, { when: 'a', is: 'true' }]},
+        ],
+      };
+
+      values = {
+        x: 'true',
+        z: 'true',
+        y: 'true',
+        a: 'false',
+      };
+
+      expect(parseCondition(condition, values)).toEqual(true);
+    });
+
+    it('nested test 2 - true', () => {
+      condition = {
+        and: [
+          { and: [{ when: 'x', pattern: /true/ }, { when: 'z', is: 'true' }]},
+          { or: [{ when: 'y', pattern: /true/ }, { when: 'a', is: 'true' }]},
+        ],
+      };
+
+      values = {
+        x: 'true',
+        z: 'true',
+        y: 'false',
+        a: 'true',
+      };
+
+      expect(parseCondition(condition, values)).toEqual(true);
+    });
+
+    it('nested test 2 - false', () => {
+      condition = {
+        and: [
+          { and: [{ when: 'x', pattern: /true/ }, { when: 'z', is: 'true' }]},
+          { or: [{ when: 'y', pattern: /true/ }, { when: 'a', is: 'true' }]},
+        ],
+      };
+
+      values = {
+        x: 'false',
+        z: 'true',
+        y: 'false',
+        a: 'true',
+      };
+
+      expect(parseCondition(condition, values)).toEqual(false);
+    });
+  });
+});

--- a/packages/react-form-renderer/src/tests/parsers/__snapshots__/default-schema-validator.test.js.snap
+++ b/packages/react-form-renderer/src/tests/parsers/__snapshots__/default-schema-validator.test.js.snap
@@ -93,6 +93,27 @@ exports[`Default schema validator should fail if input object does fields names 
 
 exports[`Default schema validator should fail if input object does not have fields names 1`] = `"Component of type schema must contain \\"fields\\" property of type array, received undefined!"`;
 
+exports[`Default schema validator should fail validation when using "and" and "or" conditions 1`] = `
+"
+      Error occured in field definition with \\"name\\" property: \\"foo\\".
+      'and' property in a field condition must be an array! Received: object.
+    "
+`;
+
+exports[`Default schema validator should fail validation when using "and" and "or" conditions 2`] = `
+"
+      Error occured in field definition with \\"name\\" property: \\"foo\\".
+      'or' propery in a field condition must be an array! Received: undefined.
+    "
+`;
+
+exports[`Default schema validator should fail validation when using "and" and "or" conditions 3`] = `
+"
+      Error occured in field definition with \\"name\\" property: \\"foo\\".
+      'and' property in a field condition must be an array! Received: object.
+    "
+`;
+
 exports[`Default schema validator should fail validation when using wrong data type 1`] = `
 "
     Error occured in field definition with name: \\"foo\\".

--- a/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
+++ b/packages/react-form-renderer/src/tests/parsers/default-schema-validator.test.js
@@ -188,4 +188,30 @@ describe('Default schema validator', () => {
       'time-picker': () => <div />,
     })).not.toThrow();
   });
+
+  it('should fail validation when using "and" and "or" conditions', () => {
+    expect(() => defaultSchemaValidator({ fields: [{
+      component: 'foo',
+      name: 'foo',
+      condition: {
+        and: { when: 'x', is: 'y' },
+      },
+    }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
+
+    expect(() => defaultSchemaValidator({ fields: [{
+      component: 'foo',
+      name: 'foo',
+      condition: {
+        or: { when: 'x', is: 'y' },
+      },
+    }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
+
+    expect(() => defaultSchemaValidator({ fields: [{
+      component: 'foo',
+      name: 'foo',
+      condition: [{
+        and: { when: 'x', is: 'y' },
+      }, { when: 'foo', is: 'bar' }],
+    }]}, formFieldsMapper)).toThrowErrorMatchingSnapshot();
+  });
 });

--- a/packages/react-renderer-demo/src/app/pages/renderer/condition.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/condition.md
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import Grid from '@material-ui/core/Grid'
 
 import ListOfContents from '../../src/helpers/list-of-contents';
+import RawComponent from '@docs/raw-component';
+
 
 <Grid container item>
 <Grid item xs={12} md={10}>
@@ -36,7 +38,37 @@ You can show a field only if it meets a condition:
 
 ### OR condition. At least one condition must be met
 
-If either of of fields with name `a` and `b` will have value `x` condition is met.
+You can use `or` object to connect two conditions. If either of of fields with name `a` and `b` will have value `x` condition is met.
+
+```jsx
+{
+  or: [condition1, condition2, ...] // (condition1 OR condition2 OR ...)
+}
+```
+
+```jsx
+{
+  fields: [{
+    name: 'Or condition',
+    component: 'text-field',
+    condition: {
+      or: [
+        {
+          when: ['a'],
+          is: 'x'
+        }, {
+          when: ['b'],
+          is: 'x'
+        }
+      ]
+    }
+  }]
+}
+```
+
+As the value you have to use an array of conditions.
+
+Also, you can use a shorthand:
 
 ```jsx
 {
@@ -57,6 +89,12 @@ Field `controlled-field-1` must have value `Bar` and field `controlled-field-2` 
 
 ```jsx
 {
+  and: [condition1, condition2, ...] // (condition1 AND condition2 AND ...)
+}
+```
+
+```jsx
+{
   fields: [
     {
       name: 'controlled-field-1',
@@ -65,7 +103,44 @@ Field `controlled-field-1` must have value `Bar` and field `controlled-field-2` 
     {
       name: 'controlled-field-2',
       component: 'text-field',
-    } {
+    },
+    {
+      name: 'BarFoo',
+      label: 'Foo is Bar!',
+      component: 'text-field',
+      condition: {
+        and: [
+          {
+            when: 'controlled-field-1',
+            is: 'Bar',
+          },
+          {
+            when: 'controlled-field-2',
+            pattern: /FooBar/
+          }
+        ]
+      },
+    },
+  ]
+}
+```
+
+As the value you have to use an array of conditions.
+
+Or you can use a shorthand:
+
+```jsx
+{
+  fields: [
+    {
+      name: 'controlled-field-1',
+      component: 'text-field',
+    },
+    {
+      name: 'controlled-field-2',
+      component: 'text-field',
+    },
+    {
       name: 'BarFoo',
       label: 'Foo is Bar!',
       component: 'text-field',
@@ -79,6 +154,54 @@ Field `controlled-field-1` must have value `Bar` and field `controlled-field-2` 
     },
   ]
 }
+```
+
+### Not
+
+You can simple negate a condition by using a `not`. Following condition is a true, when both of values are not a `x`.
+
+```jsx
+{
+  not: [condition1, condition2, ...] // negate(condition1 AND condition2 AND ...)
+}
+{
+  not: condition1 // negate(condition1)
+}
+```
+
+```jsx
+{
+  fields: [{
+    name: 'Or condition',
+    component: 'text-field',
+    condition: {
+      not: [
+        {
+          when: ['a'],
+          is: 'x'
+        }, {
+          when: ['b'],
+          is: 'x'
+        }
+      ]
+    }
+  }]
+}
+```
+
+As the value you can use an array (AND) or another condition.
+
+### Nesting
+
+Of course it is possible to neste conditions:
+
+```jsx
+condition = {
+  and: [
+    { and: [{ when: 'x', pattern: /true/ }, { when: 'z', is: 'true' }]},
+    { or: [{ when: 'y', pattern: /true/ }, { when: 'a', is: 'true' }]},
+  ],
+};
 ```
 
 ## Conditions
@@ -187,6 +310,10 @@ condition: {
 
 // Foo = 'bar' => false
 ```
+
+## Example
+
+<RawComponent source="condition" />
 
 ## Clearing values
 

--- a/packages/react-renderer-demo/src/app/src/doc-components/condition.js
+++ b/packages/react-renderer-demo/src/app/src/doc-components/condition.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import FormRenderer, { componentTypes } from '@data-driven-forms/react-form-renderer';
+import { layoutMapper, formFieldsMapper } from '@data-driven-forms/pf4-component-mapper';
+
+const schema = {
+  title: 'Example of conditions',
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    name: 'field-1',
+    label: 'Field 1',
+    helperText: 'To show field 2 type a cat',
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    name: 'field-2',
+    label: 'Field 2',
+    helperText: 'To show field 3 type a cat as the second word',
+    condition: {
+      when: 'field-1',
+      is: 'cat',
+    },
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    name: 'field-3',
+    label: 'Field 3',
+    condition: {
+      when: 'field-2',
+      pattern: /^\w+ cat/,
+    },
+    initialValue: 'We all love cats!',
+  }, {
+    component: componentTypes.CHECKBOX,
+    name: 'check-1',
+    label: 'I want to be a true',
+    condition: { when: 'field-3', isNotEmpty: true },
+  }, {
+    component: componentTypes.CHECKBOX,
+    name: 'check-2',
+    label: 'I also want to be true',
+    condition: { when: 'field-3', isNotEmpty: true },
+  }, {
+    component: componentTypes.CHECKBOX,
+    name: 'check-3',
+    label: 'Hmmm, please, uncheck me.',
+    condition: {
+      and: [
+        { when: 'check-1', is: true },
+        { when: 'check-2', is: true },
+      ],
+    },
+    initialValue: true,
+  }, {
+    component: componentTypes.PLAIN_TEXT,
+    name: 'congrats!',
+    label: 'You made it!',
+    condition: {
+      and: [
+        { and: [
+          { when: 'check-1', is: true },
+          { when: 'check-2', is: true },
+        ]},
+        { not: { when: 'check-3', isNotEmpty: true }},
+      ],
+    },
+  }],
+};
+
+const Condition = () => (
+  <div className="pf4">
+    <FormRenderer
+      layoutMapper={ layoutMapper }
+      formFieldsMapper={ formFieldsMapper }
+      schema={ schema }
+      onSubmit={ console.log }
+      showFormControls={ false }
+    />
+  </div>
+);
+
+export default Condition;


### PR DESCRIPTION
Closes #390 

TODO: 
- [x] docs
- [x] schema validator update

Is it alright @Hyperkid123 @skateman ? If so, I will finish it after the next meeting

Adds
- or
- and
- not
- can be nested

(All old conditions still work!)

Examples (look on the tests)

```js
      condition = {
        and: [
          { and: [{ when: 'x', pattern: /true/ }, { when: 'z', is: 'true' }]},
          { or: [{ when: 'y', pattern: /true/ }, { when: 'a', is: 'true' }]},
        ],
      };

      condition = {
        or: [
          { not: { when: 'x', pattern: /true/ }},
          { not: { when: 'y', pattern: /true/ }},
          { not: { when: 'z', pattern: /true/ }},
        ],
      };
```
