### PR TITLE
fix(radios): allow to use key in radios

### DIFF
--- a/packages/mui-component-mapper/src/form-fields/radio.js
+++ b/packages/mui-component-mapper/src/form-fields/radio.js
@@ -23,7 +23,7 @@ const RadioGroup = ({
       <FormLabel component="legend">{ label }</FormLabel>
       { options.map(option => (
         <FieldProvider
-          key={ `${input.name}-${option.value}` }
+          key={ `${input.name}-${option.key || option.value}` }
           name={ input.name }
           value={ option.value }
           type="radio"

--- a/packages/pf3-component-mapper/src/form-fields/radio.js
+++ b/packages/pf3-component-mapper/src/form-fields/radio.js
@@ -4,7 +4,7 @@ import { Radio } from 'patternfly-react';
 
 const RadioGroup = ({ FieldProvider, options, isDisabled, isReadOnly, input }) => options.map(option => (
   <FieldProvider
-    key={ `${input.name}-${option.value}` }
+    key={ `${input.name}-${option.key || option.value}` }
     name={ input.name }
     value={ option.value }
     type="radio"

--- a/packages/pf4-component-mapper/src/form-fields/radio.js
+++ b/packages/pf4-component-mapper/src/form-fields/radio.js
@@ -6,7 +6,7 @@ import { Radio } from '@patternfly/react-core/dist/js/components/Radio/Radio';
 const RadioGroup = ({ FieldProvider, options, isDisabled, isReadOnly, input, ...props }) => options.map(option => (
   <FieldProvider
     { ...props }
-    key={ `${input.name}-${option.value}` }
+    key={ `${input.name}-${option.key || option.value}` }
     name={ input.name }
     value={ option.value }
     type="radio"
@@ -15,7 +15,7 @@ const RadioGroup = ({ FieldProvider, options, isDisabled, isReadOnly, input, ...
         { ...input }
         isChecked={ input.checked }
         label={ option.label }
-        id={ `${input.name}-${option.value}` }
+        id={ `${input.name}-${option.key || option.value}` }
         aria-label={ option.label }
         isDisabled={ isDisabled || isReadOnly }
         onChange={ () => input.onChange(option.value) } />) }


### PR DESCRIPTION
In Sources UI I am using radios to set object as values.

So it does `key='radio-[object Object]'` errors.