### PR TITLE
Add notification panel to demo

### DIFF
--- a/packages/react-renderer-demo/src/app/pages/_document.js
+++ b/packages/react-renderer-demo/src/app/pages/_document.js
@@ -25,6 +25,7 @@ class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          <script async defer src="https://buttons.github.io/buttons.js"></script>
         </body>
       </html>
     );

--- a/packages/react-renderer-demo/src/app/pages/index.js
+++ b/packages/react-renderer-demo/src/app/pages/index.js
@@ -25,6 +25,11 @@ const useStyles = makeStyles((theme) => ({
     textAlign: 'center',
     marginTop: 48
   },
+  npmLink: {
+    display: 'block',
+    textAlign: 'center',
+    marginTop: 24
+  },
   getStartedAnchor: {
     textDecoration: 'none'
   },
@@ -55,6 +60,20 @@ const LandingPage = () => {
               </Button>
             </a>
           </Link>
+        </div>
+        <div className={classes.npmLink}>
+          <a
+            className="github-button"
+            href="https://github.com/data-driven-forms/react-forms"
+            data-show-count="true"
+            aria-label="Star data-driven-forms/react-forms on GitHub"
+          >
+            Star
+          </a>
+          &nbsp;
+          <a href="https://badge.fury.io/js/%40data-driven-forms%2Freact-form-renderer" rel="noopener noreferrer" target="_blank">
+            <img src="https://badge.fury.io/js/%40data-driven-forms%2Freact-form-renderer.svg" alt="current version" />
+          </a>
         </div>
       </div>
       <LandingPageCards />

--- a/packages/react-renderer-demo/src/app/src/components/notification-panel.js
+++ b/packages/react-renderer-demo/src/app/src/components/notification-panel.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Popper from '@material-ui/core/Popper';
+import Grow from '@material-ui/core/Grow';
+import Paper from '@material-ui/core/Paper';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Divider from '@material-ui/core/Divider';
+import Markdown from 'markdown-to-jsx';
+import { makeStyles } from '@material-ui/core/styles';
+
+import MdxComponents from './mdx/mdx-components';
+
+const options = {
+  overrides: {
+    a: {
+      component: MdxComponents.a
+    }
+  }
+};
+
+const messageList = [
+  {
+    id: '1',
+    date: 'April 8 2020',
+    title: 'Version 2 released',
+    text: `Version 2 of Data Driven Forms has been released.<br /><br />
+    Check what is new in [migration guide](/migration-guide)!<br /><br />
+    If you need documenation for version 1, please use v1 [branch on GitHub](https://github.com/data-driven-forms/react-forms/tree/v1/packages/react-renderer-demo/src/app/pages)
+    or visit our [backup link](https://pokus-next.firebaseapp.com/)!
+    `
+  }
+];
+
+export const lastMessageId = messageList[0].id;
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    transformOrigin: 'top right'
+  },
+  list: {
+    maxWidth: theme.spacing(40),
+    maxHeight: theme.spacing(40),
+    overflow: 'auto'
+  },
+  listItem: {
+    display: 'flex',
+    flexDirection: 'column'
+  }
+}));
+
+const NotificationPanel = ({ isOpen, onClose, anchorRef }) => {
+  const classes = useStyles();
+
+  return (
+    <Popper id="notifications-popup" open={isOpen} anchorEl={anchorRef.current} placement="bottom-end" transition disablePortal role={undefined}>
+      {({ TransitionProps }) => (
+        <ClickAwayListener onClickAway={onClose}>
+          <Grow in={isOpen} {...TransitionProps}>
+            <Paper className={classes.paper}>
+              <List className={classes.list}>
+                {messageList.map((message, index) => (
+                  <React.Fragment key={message.id}>
+                    <ListItem alignItems="flex-start" className={classes.listItem}>
+                      {message.date && <ListItemText secondary={message.date} />}
+                      <ListItemText
+                        primary={message.title}
+                        secondary={<Markdown options={options}>{message.text}</Markdown>}
+                        secondaryTypographyProps={{ color: 'textPrimary', component: 'div' }}
+                      />
+                    </ListItem>
+                    {index < messageList.length - 1 ? <Divider variant="middle" /> : null}
+                  </React.Fragment>
+                ))}
+              </List>
+            </Paper>
+          </Grow>
+        </ClickAwayListener>
+      )}
+    </Popper>
+  );
+};
+
+NotificationPanel.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  anchorRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]).isRequired
+};
+
+export default NotificationPanel;


### PR DESCRIPTION
This PR adds a notification panel to demo
- last checked is stored in localStorage
- using MDX to format messages (can use links, etc.)
- messages are hard coded in the code

![demonotifications](https://user-images.githubusercontent.com/32869456/78779771-cc249f80-799d-11ea-98a9-1d7542e2e172.gif)
