### PR TITLE
Fix notificiation counter on first render

### DIFF
--- a/packages/react-renderer-demo/src/app/src/components/layout.js
+++ b/packages/react-renderer-demo/src/app/src/components/layout.js
@@ -21,7 +21,7 @@ import ConnectedLinks from './common/connected-links';
 import Footer from './footer';
 
 import dynamic from 'next/dynamic';
-import NotificationPanel, { lastMessageId } from './notification-panel';
+import NotificationPanel, { lastMessageId, oldestMessageId } from './notification-panel';
 const DocSearch = dynamic(import('./docsearch'), {
   ssr: false
 });
@@ -126,7 +126,7 @@ const Layout = ({ children }) => {
   const searchRef = useRef(null);
   const anchorRef = useRef(null);
   const [openNotification, setOpenNotifiation] = useState(false);
-  const [lastCheck, setLastCheck] = useState('');
+  const [lastCheck, setLastCheck] = useState(lastMessageId);
 
   useEffect(() => {
     setLinks(findConnectedLinks(router.asPath, flatSchema) || {});
@@ -189,7 +189,7 @@ const Layout = ({ children }) => {
         >
           <DocSearch />
           <IconButton aria-label="show new notifications" onClick={handleToggle} color="inherit" ref={anchorRef} className={clsx(classes.menuButton)}>
-            <Badge badgeContent={lastMessageId - lastCheck} color="secondary">
+            <Badge badgeContent={lastMessageId - Math.max(lastCheck, oldestMessageId)} color="secondary">
               <NotificationsIcon className={classes.menuIcons} />
             </Badge>
           </IconButton>

--- a/packages/react-renderer-demo/src/app/src/components/notification-panel.js
+++ b/packages/react-renderer-demo/src/app/src/components/notification-panel.js
@@ -35,6 +35,7 @@ const messageList = [
 ];
 
 export const lastMessageId = messageList[0].id;
+export const oldestMessageId = messageList[messageList.length - 1].id - 1;
 
 const useStyles = makeStyles((theme) => ({
   paper: {


### PR DESCRIPTION
On the first render the last checked message is set to latest to not show empty badge.

Also, there is a enhancement which will count the right number of notifications, when we delete one of them. 

Before

![counterbefore](https://user-images.githubusercontent.com/32869456/78896237-72d97080-7a70-11ea-90e1-137cf0d36402.gif)

After

![counterafter](https://user-images.githubusercontent.com/32869456/78896245-753bca80-7a70-11ea-8886-5d48e719b206.gif)
