### PR TITLE
fix(mui): add default field array

### DIFF
--- a/packages/mui-component-mapper/demo/demo-schemas/field-array-schema.js
+++ b/packages/mui-component-mapper/demo/demo-schemas/field-array-schema.js
@@ -7,7 +7,7 @@ const arraySchemaDDF = {
       fieldKey: 'field_array',
       label: 'Nice people',
       description: 'This allow you to add nice people to the list dynamically',
-      itemDefault: { name: 'enter a name', lastName: 'enter a last name' },
+      defaultItem: { name: 'enter a name', lastName: 'enter a last name' },
       fields: [
         {
           component: 'text-field',

--- a/packages/mui-component-mapper/demo/demo-schemas/field-array-schema.js
+++ b/packages/mui-component-mapper/demo/demo-schemas/field-array-schema.js
@@ -1,0 +1,78 @@
+const arraySchemaDDF = {
+  title: 'FieldArray',
+  fields: [
+    {
+      component: 'field-array',
+      name: 'nicePeople',
+      fieldKey: 'field_array',
+      label: 'Nice people',
+      description: 'This allow you to add nice people to the list dynamically',
+      itemDefault: { name: 'enter a name', lastName: 'enter a last name' },
+      fields: [
+        {
+          component: 'text-field',
+          name: 'name',
+          label: 'Name',
+          placeholder: 'Borek',
+          isRequired: true,
+          validate: [
+            {
+              type: 'required'
+            }
+          ]
+        },
+        {
+          component: 'text-field',
+          name: 'lastName',
+          label: 'Last Name',
+          placeholder: 'Stavitel'
+        }
+      ]
+    },
+    {
+      component: 'field-array',
+      name: 'minItems',
+      label: 'A list with a minimal number of items',
+      validate: [{ type: 'min-items', threshold: 3 }],
+      fields: [
+        {
+          component: 'text-field',
+          label: 'Item'
+        }
+      ]
+    },
+    {
+      component: 'field-array',
+      name: 'number',
+      defaultItem: 5,
+      label: 'Default value with initialValues set',
+      fields: [
+        {
+          component: 'text-field',
+          label: 'Item',
+          type: 'number'
+        }
+      ]
+    },
+    {
+      component: 'field-array',
+      name: 'minMax',
+      minItems: 4,
+      maxItems: 6,
+      label: 'Min 4 item, max 6 items without validators',
+      fields: [
+        {
+          component: 'text-field',
+          isRequired: true,
+          validate: [
+            {
+              type: 'required'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+export default arraySchemaDDF;

--- a/packages/mui-component-mapper/demo/index.js
+++ b/packages/mui-component-mapper/demo/index.js
@@ -1,70 +1,58 @@
-/* eslint-disable */
-import React from "react";
-import ReactDOM from "react-dom";
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
 import FormRenderer, { componentTypes } from '@data-driven-forms/react-form-renderer';
 
 import Grid from '@material-ui/core/Grid';
-import { componentMapper, FormTemplate } from '../src'
+import { componentMapper, FormTemplate } from '../src';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Typography from '@material-ui/core/Typography';
 import demoSchema from '@data-driven-forms/common/src/demoschema';
+import fieldArraySchema from './demo-schemas/field-array-schema';
+
+import Button from '@material-ui/core/Button';
 
 const theme = createMuiTheme({
-    typography: {
-      useNextVariants: true,
-    },
-  });
+  typography: {
+    useNextVariants: true
+  }
+});
 
 const compositeMapper = {
-    ...componentMapper,
-    [componentTypes.SWITCH]: {
-        component: componentMapper[componentTypes.SWITCH],
-        FormControlLabelProps: {
-            labelPlacement: 'end'
-        }
+  ...componentMapper,
+  [componentTypes.SWITCH]: {
+    component: componentMapper[componentTypes.SWITCH],
+    FormControlLabelProps: {
+      labelPlacement: 'end'
     }
-}
-  
+  }
+};
 
-const schema = {
-    fields: [{
-        component: 'switch',
-        name: 'foo',
-        label: 'Foo'
-    }, {
-        component: 'text-field',
-        name: 'bar',
-        label: 'bar',
-        condition: {
-            when: 'foo',
-            is: true
-        }
-    }]
-}
+const App = () => {
+  const [schema, setSchema] = useState(fieldArraySchema);
 
-const App = () => (
-    <ThemeProvider theme={ theme }>
-        <Grid 
-            container
-            spacing={4}
-            justify="center"
-            alignItems="center"
-        >
-            <Grid item xs={12}>
-                <Typography variant="h3" >Material UI component mapper</Typography>
-            </Grid>
-            <Grid item xs={12}>
-                <FormRenderer
-                    onSubmit={console.log}
-                    componentMapper={compositeMapper}
-                    FormTemplate={props => <FormTemplate {...props} />}
-                    schema={schema}
-                    onCancel={() => console.log('canceling')}
-                />
-            </Grid>
+  return (
+    <ThemeProvider theme={theme}>
+      <Grid container spacing={4} justify="center" alignItems="center">
+        <Grid item xs={12}>
+          <Typography variant="h3">Material UI component mapper</Typography>
         </Grid>
+        <Grid item xs={12}>
+          <Button onClick={() => setSchema(demoSchema)}>Demo schema</Button>
+          <Button onClick={() => setSchema(fieldArraySchema)}>Field array</Button>
+        </Grid>
+        <Grid item xs={12}>
+          <FormRenderer
+            onSubmit={console.log}
+            componentMapper={compositeMapper}
+            FormTemplate={(props) => <FormTemplate {...props} />}
+            schema={schema}
+            onCancel={() => console.log('canceling')}
+          />
+        </Grid>
+      </Grid>
     </ThemeProvider>
-)
+  );
+};
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/mui-component-mapper/src/files/component-mapper.js
+++ b/packages/mui-component-mapper/src/files/component-mapper.js
@@ -11,6 +11,7 @@ import PlainText from './plain-text';
 import Select from './select';
 import Radio from './radio';
 import Wizard from './wizard';
+import FieldArray from './field-array';
 
 export const components = {
   TextField,
@@ -38,7 +39,8 @@ const componentMapper = {
   [componentTypes.TIME_PICKER]: TimePicker,
   [componentTypes.SWITCH]: Switch,
   [componentTypes.PLAIN_TEXT]: PlainText,
-  [componentTypes.WIZARD]: Wizard
+  [componentTypes.WIZARD]: Wizard,
+  [componentTypes.FIELD_ARRAY]: FieldArray
 };
 
 export default componentMapper;

--- a/packages/mui-component-mapper/src/files/field-array.js
+++ b/packages/mui-component-mapper/src/files/field-array.js
@@ -2,15 +2,11 @@ import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { useFormApi, FieldArray } from '@data-driven-forms/react-form-renderer';
 
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
+import { Grid, Button, Typography, FormControl, FormHelperText, IconButton } from '@material-ui/core';
+
 import { makeStyles } from '@material-ui/core/styles';
 import RedoIcon from '@material-ui/icons/Redo';
 import UndoIcon from '@material-ui/icons/Undo';
-import IconButton from '@material-ui/core/IconButton';
 
 import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 
@@ -157,13 +153,11 @@ const DynamicArray = ({ ...props }) => {
 
             const undo = () => {
               push(state.history[state.index - 1].value);
-
               dispatch({ type: 'undo' });
             };
 
             const redo = () => {
               remove(value.length - 1);
-
               dispatch({ type: 'redo' });
             };
 
@@ -198,7 +192,7 @@ const DynamicArray = ({ ...props }) => {
                   ) : (
                     map((name, index) => (
                       <ArrayItem
-                        key={`${name}-${index}`}
+                        key={name}
                         fields={formFields}
                         name={name}
                         fieldIndex={index}

--- a/packages/mui-component-mapper/src/files/field-array.js
+++ b/packages/mui-component-mapper/src/files/field-array.js
@@ -1,0 +1,183 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useFormApi, FieldArray } from '@data-driven-forms/react-form-renderer';
+
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import { makeStyles } from '@material-ui/core/styles';
+
+import { useFieldApi } from '@data-driven-forms/react-form-renderer';
+
+import FormFieldGrid from '../common/form-field-grid';
+import clsx from 'clsx';
+
+const useFielArrayStyles = makeStyles({
+  formControl: {
+    width: '100%'
+  },
+  centerText: {
+    display: 'flex',
+    justifyContent: 'center'
+  },
+  buttonsToEnd: {
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+  header: {
+    display: 'flex'
+  },
+  label: {
+    flexGrow: 1
+  },
+  fieldArrayGroup: {
+    marginBottom: 32
+  }
+});
+
+const ArrayItem = ({ fields, fieldIndex, name, remove, length, minItems, removeLabel }) => {
+  const { renderForm } = useFormApi();
+  const classes = useFielArrayStyles();
+
+  const editedFields = fields.map((field, index) => {
+    const computedName = field.name ? `${name}.${field.name}` : name;
+    return { ...field, name: computedName, key: `${computedName}-${index}` };
+  });
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Grid container spacing={3}>
+          {renderForm([editedFields])}
+        </Grid>
+      </Grid>
+      <Grid item xs={12} className={classes.buttonsToEnd}>
+        <Button color="secondary" onClick={() => remove(fieldIndex)} disabled={length <= minItems}>
+          {removeLabel}
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};
+
+ArrayItem.propTypes = {
+  name: PropTypes.string,
+  fieldIndex: PropTypes.number.isRequired,
+  fields: PropTypes.arrayOf(PropTypes.object),
+  remove: PropTypes.func.isRequired,
+  length: PropTypes.number,
+  minItems: PropTypes.number,
+  removeLabel: PropTypes.node.isRequired
+};
+
+const defaultButtonLabels = {
+  add: 'ADD',
+  remove: 'REMOVE'
+};
+
+const DynamicArray = ({ ...props }) => {
+  const {
+    arrayValidator,
+    label,
+    description,
+    fields: formFields,
+    defaultItem,
+    meta,
+    minItems,
+    maxItems,
+    noItemsMessage,
+    FormFieldGridProps,
+    FormControlProps,
+    buttonLabels,
+    ...rest
+  } = useFieldApi(props);
+
+  const combinedButtonLabels = {
+    ...defaultButtonLabels,
+    ...buttonLabels
+  };
+
+  const classes = useFielArrayStyles();
+
+  const { dirty, submitFailed, error } = meta;
+  const isError = (dirty || submitFailed) && error && typeof error === 'string';
+
+  return (
+    <FormFieldGrid {...FormFieldGridProps} className={clsx(classes.fieldArrayGroup, FormFieldGridProps.classname)}>
+      <FormControl component="fieldset" error={isError} {...FormControlProps} className={clsx(classes.formControl, FormControlProps.className)}>
+        <FieldArray key={rest.input.name} name={rest.input.name} validate={arrayValidator}>
+          {({ fields: { map, value = [], push, remove } }) => (
+            <Grid container spacing={3}>
+              {label && (
+                <Grid item xs={12} className={classes.header}>
+                  <Typography variant="h6" className={classes.label}>
+                    {label}
+                  </Typography>
+                  <Button color="primary" onClick={() => push(defaultItem)} disabled={value.length >= maxItems}>
+                    {combinedButtonLabels.add}
+                  </Button>
+                </Grid>
+              )}
+              {description && (
+                <Grid item xs={12}>
+                  <Typography variant="subtitle1">{description}</Typography>
+                </Grid>
+              )}
+              {value.length <= 0 && (
+                <Grid item xs={12}>
+                  <Typography variant="body1" gutterBottom className={classes.centerText}>
+                    {noItemsMessage}
+                  </Typography>
+                </Grid>
+              )}
+              <Grid item xs={12}>
+                {map((name, index) => (
+                  <ArrayItem
+                    key={`${name}-${index}`}
+                    fields={formFields}
+                    name={name}
+                    fieldIndex={index}
+                    remove={remove}
+                    length={value.length}
+                    minItems={minItems}
+                    removeLabel={combinedButtonLabels.remove}
+                  />
+                ))}
+                {isError && (
+                  <Grid item xs={12}>
+                    <FormHelperText>{error}</FormHelperText>
+                  </Grid>
+                )}
+              </Grid>
+            </Grid>
+          )}
+        </FieldArray>
+      </FormControl>
+    </FormFieldGrid>
+  );
+};
+
+DynamicArray.propTypes = {
+  label: PropTypes.node,
+  description: PropTypes.node,
+  fields: PropTypes.arrayOf(PropTypes.object).isRequired,
+  defaultItem: PropTypes.any,
+  minItems: PropTypes.number,
+  maxItems: PropTypes.number,
+  noItemsMessage: PropTypes.node,
+  FormControlProps: PropTypes.object,
+  FormFieldGridProps: PropTypes.object,
+  buttonLabels: PropTypes.object
+};
+
+DynamicArray.defaultProps = {
+  maxItems: Infinity,
+  minItems: 0,
+  noItemsMessage: 'No items added',
+  FormControlProps: {},
+  FormFieldGridProps: {}
+};
+
+export default DynamicArray;

--- a/packages/mui-component-mapper/src/tests/field-array.test.js
+++ b/packages/mui-component-mapper/src/tests/field-array.test.js
@@ -1,0 +1,534 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import FormRenderer, { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { mount } from 'enzyme';
+import { Button, FormHelperText, IconButton, Typography } from '@material-ui/core';
+
+import { componentMapper, FormTemplate } from '../index';
+import { reducer } from '../files/field-array';
+
+describe('<FieldArray/>', () => {
+  let initialProps;
+  let onSubmit;
+  let wrapper;
+
+  beforeEach(() => {
+    onSubmit = jest.fn();
+    initialProps = {
+      componentMapper,
+      FormTemplate,
+      onSubmit: (values) => onSubmit(values)
+    };
+  });
+
+  it('renders with label and description + custom labels', async () => {
+    initialProps = {
+      ...initialProps,
+      schema: {
+        fields: [
+          {
+            component: componentTypes.FIELD_ARRAY,
+            name: 'nicePeople',
+            label: 'I am label',
+            description: 'I am description',
+            noItemsMessage: 'I have no items',
+            buttonLabels: {
+              add: 'CUSTOM ADD',
+              remove: 'CUSTOM REMOVE'
+            },
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD,
+                name: 'name'
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    await act(async () => {
+      wrapper = mount(<FormRenderer {...initialProps} />);
+    });
+
+    expect(wrapper.find(Typography)).toHaveLength(3);
+    expect(
+      wrapper
+        .find(Typography)
+        .first()
+        .text()
+    ).toEqual('I am label');
+    expect(
+      wrapper
+        .find(Typography)
+        .at(1)
+        .text()
+    ).toEqual('I am description');
+    expect(
+      wrapper
+        .find(Typography)
+        .last()
+        .text()
+    ).toEqual('I have no items');
+
+    expect(
+      wrapper
+        .find(Button)
+        .first()
+        .text()
+    ).toEqual('CUSTOM ADD');
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find(Button)
+        .at(1)
+        .text()
+    ).toEqual('CUSTOM REMOVE');
+    expect(wrapper.find(Typography)).toHaveLength(2);
+  });
+
+  it('allow to add/remove named fields', async () => {
+    initialProps = {
+      ...initialProps,
+      schema: {
+        fields: [
+          {
+            component: componentTypes.FIELD_ARRAY,
+            name: 'nicePeople',
+            defaultItem: { name: 'enter a name', lastName: 'enter a last name' },
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD,
+                name: 'name'
+              },
+              {
+                component: componentTypes.TEXT_FIELD,
+                name: 'lastName'
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    await act(async () => {
+      wrapper = mount(<FormRenderer {...initialProps} />);
+    });
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({});
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: [{ name: 'enter a name', lastName: 'enter a last name' }]
+    });
+
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .at(1) // remove button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: []
+    });
+  });
+
+  it('allow to add/remove unnamed (array) fields', async () => {
+    initialProps = {
+      ...initialProps,
+      schema: {
+        fields: [
+          {
+            component: componentTypes.FIELD_ARRAY,
+            name: 'nicePeople',
+            defaultItem: 'defaultItem',
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    await act(async () => {
+      wrapper = mount(<FormRenderer {...initialProps} />);
+    });
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({});
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: ['defaultItem']
+    });
+
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .at(1) // remove button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: []
+    });
+  });
+
+  it('allow to add/remove within minItems/maxItems range', async () => {
+    initialProps = {
+      ...initialProps,
+      schema: {
+        fields: [
+          {
+            component: componentTypes.FIELD_ARRAY,
+            name: 'nicePeople',
+            defaultItem: 'defaultItem',
+            minItems: 1,
+            maxItems: 2,
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    await act(async () => {
+      wrapper = mount(<FormRenderer {...initialProps} />);
+    });
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: ['defaultItem']
+    });
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: ['defaultItem', 'defaultItem']
+    });
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: ['defaultItem', 'defaultItem']
+    });
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .at(1) // remove button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: ['defaultItem']
+    });
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .at(1) // remove button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: ['defaultItem']
+    });
+  });
+
+  it('shows error', async () => {
+    initialProps = {
+      ...initialProps,
+      schema: {
+        fields: [
+          {
+            component: componentTypes.FIELD_ARRAY,
+            name: 'nicePeople',
+            validate: [{ type: validatorTypes.MIN_ITEMS, threshold: 3 }],
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    await act(async () => {
+      wrapper = mount(<FormRenderer {...initialProps} />);
+    });
+
+    expect(wrapper.find(FormHelperText)).toHaveLength(0);
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    onSubmit.mockClear();
+
+    expect(wrapper.find(FormHelperText)).toHaveLength(1);
+    expect(wrapper.find(FormHelperText).text()).toEqual('Must have at least 3 items.');
+  });
+
+  it('allow to revert removal', async () => {
+    initialProps = {
+      ...initialProps,
+      schema: {
+        fields: [
+          {
+            component: componentTypes.FIELD_ARRAY,
+            name: 'nicePeople',
+            defaultItem: { name: 'enter a name', lastName: 'enter a last name' },
+            fields: [
+              {
+                component: componentTypes.TEXT_FIELD
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    await act(async () => {
+      wrapper = mount(<FormRenderer {...initialProps} />);
+    });
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: [{ name: 'enter a name', lastName: 'enter a last name' }]
+    });
+
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .at(1) // remove button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: []
+    });
+
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(IconButton)
+        .at(0) // undo button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: [{ name: 'enter a name', lastName: 'enter a last name' }]
+    });
+
+    onSubmit.mockClear();
+
+    await act(async () => {
+      wrapper
+        .find(IconButton)
+        .at(1) // redo button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: []
+    });
+
+    await act(async () => {
+      wrapper
+        .find(IconButton)
+        .at(0) // undo button
+        .simulate('click');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      nicePeople: [{ name: 'enter a name', lastName: 'enter a last name' }]
+    });
+
+    await act(async () => {
+      wrapper
+        .find(Button)
+        .first() // add buton
+        .simulate('click');
+    });
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find(IconButton)
+        .at(1) // redo button
+        .props().disabled // 'add' action resets history
+    ).toEqual(true);
+  });
+
+  it('reducer - default state', () => {
+    const initialState = { aa: 'aa' };
+
+    expect(reducer(initialState, { type: 'nonsense' })).toEqual(initialState);
+  });
+});

--- a/packages/react-renderer-demo/src/app/pages/component-example/field-array.js
+++ b/packages/react-renderer-demo/src/app/pages/component-example/field-array.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+import ComponentText from '@docs/components/component-example-text';
+import useComponentExample from '../../src/hooks/use-component-example';
+
+import Pf4FieldArray from '@data-driven-forms/pf4-component-mapper/dist/cjs/field-array';
+import MuiFieldArray from '@data-driven-forms/mui-component-mapper/dist/cjs/field-array';
+import Pf4TextField from '@data-driven-forms/pf4-component-mapper/dist/cjs/text-field';
+import MuiTextField from '@data-driven-forms/mui-component-mapper/dist/cjs/text-field';
+
+const mappers = {
+  pf4: {
+    [componentTypes.FIELD_ARRAY]: Pf4FieldArray,
+    [componentTypes.TEXT_FIELD]: Pf4TextField
+  },
+  pf3: {
+    [componentTypes.FIELD_ARRAY]: () => <h2>Not implemented</h2>,
+    [componentTypes.TEXT_FIELD]: () => <h2>Not implemented</h2>
+  },
+  mui: {
+    [componentTypes.FIELD_ARRAY]: MuiFieldArray,
+    [componentTypes.TEXT_FIELD]: MuiTextField
+  }
+};
+
+export default () => {
+  const [component, baseStructure, activeMapper] = useComponentExample();
+  return <ComponentText component={component} baseStructure={baseStructure} activeMapper={activeMapper} componentMapper={mappers[activeMapper]} />;
+};

--- a/packages/react-renderer-demo/src/app/pages/renderer/dynamic-fields.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/dynamic-fields.md
@@ -65,19 +65,13 @@ EXACT_LENGTH: ({threshold})
 ```
 
 
-# PF4 implementation
+# Implementation
 
-PF4 component mapper provides an experimental implementation of PF4 field arrays.
+PF4 and MUI component mapper provides an experimental implementation of field arrays.
 
-|Prop|Type|Description|
-|:---|:--:|----------:|
-|label|`node`|Label of the array.|
-|description|`node`|Description of the array.|
-|fields|`array`|A group of fields, which are being added to the array.|
-|defaultItem|`any`|Default item which is inserted into a newly created fields group. If you have nested names, don't forget you need to insert an object!|
-|minItems|`number`|Remove button is disabled, if the length of the array is equal or smaller.|
-|maxItems|`number`|Add button is disabled, if the length of the array is equal or bigger.|
-|noItemsMessage|`node`|A message which is shown, when there are no items in the array.|
+[PF4 Field Array](/component-example/field-array?mapper=pf4)
+
+[MUI Field Array](/component-example/field-array?mapper=mui)
 
 <RawComponent source="field-array/pf4-demo" />
 

--- a/packages/react-renderer-demo/src/app/src/components/navigation/examples-definitions.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/examples-definitions.js
@@ -4,7 +4,9 @@ import TabsText from './examples-texts/tabs';
 import CustomComponentText from './examples-texts/custom-component';
 import WizardText from './examples-texts/wizard';
 import SelectText from './examples-texts/select';
+import FieldArray from './examples-texts/field-array';
 import DualListSelect from './examples-texts/dual-list-select';
+import arraySchemaDDF from './field-array-schema';
 
 const formGroupVariants = [
   {
@@ -494,6 +496,14 @@ Vestibulum vulputate inceptos himenaeos.`
         }
       ]
     }
+  },
+  {
+    component: componentTypes.FIELD_ARRAY,
+    link: componentTypes.FIELD_ARRAY,
+    linkText: 'Field Array',
+    ContentText: FieldArray,
+    value: arraySchemaDDF,
+    variants: []
   },
   {
     component: componentTypes.WIZARD,

--- a/packages/react-renderer-demo/src/app/src/components/navigation/examples-texts/field-array.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/examples-texts/field-array.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import MuiFieldArray from '@docs/doc-components/mui-field-array.md';
+import PF4FieldArray from '@docs/doc-components/pf4-field-array.md';
+import PF3FieldArray from '@docs/doc-components/pf3-field-array.md';
+
+import PropTypes from 'prop-types';
+
+const DocFieldArray = ({ activeMapper }) =>
+  activeMapper === 'mui' ? <MuiFieldArray /> : activeMapper === 'pf4' ? <PF4FieldArray /> : <PF3FieldArray />;
+
+DocFieldArray.propTypes = {
+  activeMapper: PropTypes.string
+};
+
+export default DocFieldArray;

--- a/packages/react-renderer-demo/src/app/src/components/navigation/field-array-schema.js
+++ b/packages/react-renderer-demo/src/app/src/components/navigation/field-array-schema.js
@@ -1,0 +1,78 @@
+const arraySchemaDDF = {
+  fields: [
+    {
+      component: 'field-array',
+      name: 'nicePeople',
+      label: 'Nice people',
+      description: 'This allow you to add nice people to the list dynamically',
+      defaultItem: { name: 'enter a name', lastName: 'enter a last name' },
+      fields: [
+        {
+          component: 'text-field',
+          name: 'name',
+          label: 'Name',
+          placeholder: 'Borek',
+          isRequired: true,
+          validate: [
+            {
+              type: 'required'
+            }
+          ]
+        },
+        {
+          component: 'text-field',
+          name: 'lastName',
+          label: 'Last Name',
+          placeholder: 'Stavitel'
+        }
+      ]
+    },
+    {
+      component: 'field-array',
+      name: 'minItems',
+      label: 'A list with a minimal number of items',
+      validate: [{ type: 'min-items', threshold: 3 }],
+      fields: [
+        {
+          component: 'text-field',
+          label: 'Item'
+        }
+      ]
+    },
+    {
+      component: 'field-array',
+      name: 'number',
+      initialValue: [1, 2, 3, 4],
+      defaultItem: 5,
+      label: 'Default value with initialValues set',
+      fields: [
+        {
+          component: 'text-field',
+          label: 'Item',
+          type: 'number'
+        }
+      ]
+    },
+    {
+      component: 'field-array',
+      name: 'minMax',
+      minItems: 4,
+      maxItems: 6,
+      label: 'Min 4 item, max 6 items without validators',
+      initialValue: [null, null, null, null],
+      fields: [
+        {
+          component: 'text-field',
+          isRequired: true,
+          validate: [
+            {
+              type: 'required'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+export default arraySchemaDDF;

--- a/packages/react-renderer-demo/src/app/src/doc-components/mui-field-array.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/mui-field-array.md
@@ -1,4 +1,4 @@
-MUI component mapper provides an experimental implementation of PF4 field arrays.
+MUI component mapper provides an experimental implementation of field array.
 
 **Props**
 

--- a/packages/react-renderer-demo/src/app/src/doc-components/mui-field-array.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/mui-field-array.md
@@ -1,0 +1,49 @@
+MUI component mapper provides an experimental implementation of PF4 field arrays.
+
+**Props**
+
+|Prop|Type|Description|
+|:---|:--:|----------:|
+|label|`node`|Label of the array.|
+|description|`node`|Description of the array.|
+|fields|`array`|A group of fields, which are being added to the array.|
+|defaultItem|`any`|Default item which is inserted into a newly created fields group. If you have nested names, don't forget you need to insert an object!|
+|minItems|`number`|Remove button is disabled, if the length of the array is equal or smaller.|
+|maxItems|`number`|Add button is disabled, if the length of the array is equal or bigger.|
+|noItemsMessage|`node`|A message which is shown, when there are no items in the array.|
+|buttonLabels|`object`|`{add: 'ADD', remove: 'REMOVE'}` sets labels of buttons.|
+
+**Revert removal**
+
+MUI field array allow users to revert latest removal actions.
+
+**Naming**
+
+Fields can contain names, then the value will be handled as array of objects.
+
+```jsx
+const fields = [
+    { name: 'name', ... },
+    { name: 'lastname', ... }
+]
+
+[
+    { name: value1.name, lastname: value1.lastname },
+    { name: value2.name, lastname: value2.lastname },
+    ...
+]
+```
+
+Or you can put a single field with no name. In this case, values are stored as a simple array.
+
+```jsx
+const fields = [
+    { component: 'text-field' }
+]
+
+[ value1, value2, ... ]
+```
+
+**Custom component**
+
+To implement a custom component, please take a look [here](/renderer/dynamic-fields).

--- a/packages/react-renderer-demo/src/app/src/doc-components/pf3-field-array.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/pf3-field-array.md
@@ -1,0 +1,7 @@
+PF3 component mapper does not provide field array component.
+
+In case of need, please contact us or open a PR.
+
+**Custom component**
+
+To implement a custom component, please take a look [here](/renderer/dynamic-fields).

--- a/packages/react-renderer-demo/src/app/src/doc-components/pf4-field-array.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/pf4-field-array.md
@@ -1,4 +1,4 @@
-PF4 component mapper provides an experimental implementation of PF4 field arrays.
+PF4 component mapper provides an experimental implementation of field array.
 
 **Props**
 

--- a/packages/react-renderer-demo/src/app/src/doc-components/pf4-field-array.md
+++ b/packages/react-renderer-demo/src/app/src/doc-components/pf4-field-array.md
@@ -1,0 +1,44 @@
+PF4 component mapper provides an experimental implementation of PF4 field arrays.
+
+**Props**
+
+|Prop|Type|Description|
+|:---|:--:|----------:|
+|label|`node`|Label of the array.|
+|description|`node`|Description of the array.|
+|fields|`array`|A group of fields, which are being added to the array.|
+|defaultItem|`any`|Default item which is inserted into a newly created fields group. If you have nested names, don't forget you need to insert an object!|
+|minItems|`number`|Remove button is disabled, if the length of the array is equal or smaller.|
+|maxItems|`number`|Add button is disabled, if the length of the array is equal or bigger.|
+|noItemsMessage|`node`|A message which is shown, when there are no items in the array.|
+
+**Naming**
+
+Fields can contain names, then the value will be handled as array of objects.
+
+```jsx
+const fields = [
+    { name: 'name', ... },
+    { name: 'lastname', ... }
+]
+
+[
+    { name: value1.name, lastname: value1.lastname },
+    { name: value2.name, lastname: value2.lastname },
+    ...
+]
+```
+
+Or you can put a single field with no name. In this case, values are stored as a simple array.
+
+```jsx
+const fields = [
+    { component: 'text-field' }
+]
+
+[ value1, value2, ... ]
+```
+
+**Custom component**
+
+To implement a custom component, please take a look [here](/renderer/dynamic-fields).


### PR DESCRIPTION
Same as PF4

![image](https://user-images.githubusercontent.com/32869456/79779418-aa7ecd00-833a-11ea-9100-a837a9b9bc65.png)

I have remove the `hr` from mockups, because it actually looks as an another MUI field. :smiley: 

+ Allows to revert `remove` actions

![materialuifieldarray](https://user-images.githubusercontent.com/32869456/79776195-a9976c80-8335-11ea-8532-4761791da699.gif)

TODO:
- [x] docs
- [x] tests

closes #421 