### PR TITLE
fix(renderer): move functionality from render to useField

### DIFF
--- a/packages/common/src/wizard/wizard.js
+++ b/packages/common/src/wizard/wizard.js
@@ -8,7 +8,7 @@ import flattenDeep from 'lodash/flattenDeep';
 import handleEnter from './enter-handler';
 import reducer, { DYNAMIC_WIZARD_TYPES, findCurrentStep } from './reducer';
 
-const Wizard = ({ fields, isDynamic, crossroads, Wizard, ...props }) => {
+const Wizard = ({ fields, isDynamic, crossroads, Wizard, component, ...props }) => {
   const formOptions = useFormApi();
 
   const [state, dispatch] = useReducer(reducer, {
@@ -94,7 +94,8 @@ Wizard.propTypes = {
   ).isRequired,
   isDynamic: PropTypes.bool,
   crossroads: PropTypes.arrayOf(PropTypes.string),
-  Wizard: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
+  Wizard: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  component: PropTypes.any
 };
 
 export default Wizard;

--- a/packages/mui-component-mapper/src/files/plain-text.js
+++ b/packages/mui-component-mapper/src/files/plain-text.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Typography } from '@material-ui/core';
 import PropTypes from 'prop-types';
 
-const PlainText = ({ label, name, ...props }) =>
+const PlainText = ({ label, name, component, ...props }) =>
   label.split('\n').map((paragraph, index) => (
     <Typography key={`${index}-${name}`} {...props}>
       {paragraph}
@@ -11,7 +11,8 @@ const PlainText = ({ label, name, ...props }) =>
 
 PlainText.propTypes = {
   label: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
+  component: PropTypes.any
 };
 
 PlainText.defaultProps = {

--- a/packages/mui-component-mapper/src/files/sub-form.js
+++ b/packages/mui-component-mapper/src/files/sub-form.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const SubForm = ({ fields, title, description, ...rest }) => {
+const SubForm = ({ fields, title, description, component, ...rest }) => {
   const { renderForm } = useFormApi();
   const classes = useStyles();
 
@@ -38,7 +38,8 @@ const SubForm = ({ fields, title, description, ...rest }) => {
 SubForm.propTypes = {
   fields: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   title: PropTypes.string,
-  description: PropTypes.string
+  description: PropTypes.string,
+  component: PropTypes.any
 };
 
 export default SubForm;

--- a/packages/pf3-component-mapper/src/files/button.js
+++ b/packages/pf3-component-mapper/src/files/button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button as PFButton } from 'patternfly-react';
 
-export const Button = ({ label, variant, dataType, validate, children, ...rest }) => (
+export const Button = ({ label, variant, dataType, validate, children, component, ...rest }) => (
   <PFButton bsStyle={variant} {...rest}>
     {label || children}
   </PFButton>
@@ -14,7 +14,8 @@ Button.propTypes = {
   className: PropTypes.string,
   dataType: PropTypes.any, // should be inside inner props or something
   validate: PropTypes.any, // should be inside inner props or something
-  children: PropTypes.any
+  children: PropTypes.any,
+  component: PropTypes.any
 };
 
 export default Button;

--- a/packages/pf3-component-mapper/src/files/sub-form.js
+++ b/packages/pf3-component-mapper/src/files/sub-form.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
-const SubForm = ({ fields, title, description, ...rest }) => {
+const SubForm = ({ fields, title, description, component, ...rest }) => {
   const formOptions = useFormApi();
   return (
     <div {...rest}>
@@ -16,7 +16,8 @@ const SubForm = ({ fields, title, description, ...rest }) => {
 SubForm.propTypes = {
   fields: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   title: PropTypes.string,
-  description: PropTypes.string
+  description: PropTypes.string,
+  component: PropTypes.any
 };
 
 export default SubForm;

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
@@ -390,7 +390,6 @@ exports[`FormFields <Switch /> should render Switch correctly 1`] = `
   >
     <Switch
       FieldProvider={[Function]}
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -535,7 +534,6 @@ exports[`FormFields <Switch /> should render Switch with label correctly 1`] = `
   >
     <Switch
       FieldProvider={[Function]}
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -692,7 +690,6 @@ exports[`FormFields <Switch /> should render Switch with onText (custom prop) co
   >
     <Switch
       FieldProvider={[Function]}
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -838,7 +835,6 @@ exports[`FormFields <Switch /> should render Switch with placeholder correctly 1
   >
     <Switch
       FieldProvider={[Function]}
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -984,7 +980,6 @@ exports[`FormFields <Switch /> should render disabled Switch correctly 1`] = `
   >
     <Switch
       FieldProvider={[Function]}
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -1133,7 +1128,6 @@ exports[`FormFields <Switch /> should render mini Switch correctly 1`] = `
     <Switch
       FieldProvider={[Function]}
       bsSize="mini"
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -1279,7 +1273,6 @@ exports[`FormFields <Switch /> should render readOnly Switch correctly 1`] = `
   >
     <Switch
       FieldProvider={[Function]}
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {
@@ -1428,7 +1421,6 @@ exports[`FormFields <Switch /> should render sm Switch correctly 1`] = `
     <Switch
       FieldProvider={[Function]}
       bsSize="mn"
-      dataType="someDataType"
       id="someIdKey"
       input={
         Object {

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
@@ -369,6 +369,7 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "before": Object {
@@ -523,6 +524,7 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                           hideField={false}
                                         >
                                           <InputAddonButtonGroup
+                                            component="input-addon-button-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -558,6 +560,7 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 1"
                                                         name="set1"
                                                         onClick={[Function]}
@@ -567,12 +570,14 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set1"
                                                           onClick={[Function]}
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set1"
                                                             onClick={[Function]}
@@ -596,6 +601,7 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 2"
                                                         name="set2"
                                                       >
@@ -604,11 +610,13 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set2"
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set2"
                                                             type="button"
@@ -1083,6 +1091,7 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "before": Object {
@@ -1250,6 +1259,7 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                                           hideField={false}
                                         >
                                           <InputAddonGroup
+                                            component="input-addon-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -1280,6 +1290,7 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                                                       hideField={false}
                                                     >
                                                       <PlainText
+                                                        component="plain-text"
                                                         label="-"
                                                         name="name1"
                                                         variant="span"
@@ -1318,6 +1329,7 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                                           hideField={false}
                                         >
                                           <InputAddonButtonGroup
+                                            component="input-addon-button-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -1346,6 +1358,7 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 3"
                                                         name="set3"
                                                       >
@@ -1354,11 +1367,13 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set3"
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set3"
                                                             type="button"
@@ -1697,6 +1712,7 @@ exports[`<Input Addon> should render single after input addon correctly 1`] = `
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "after": Object {
@@ -1825,6 +1841,7 @@ exports[`<Input Addon> should render single after input addon correctly 1`] = `
                                           hideField={false}
                                         >
                                           <PlainText
+                                            component="plain-text"
                                             label="-"
                                             name="name1"
                                             variant="span"
@@ -2139,6 +2156,7 @@ exports[`<Input Addon> should render single before input addon correctly 1`] = `
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "before": Object {
@@ -2247,6 +2265,7 @@ exports[`<Input Addon> should render single before input addon correctly 1`] = `
                                           hideField={false}
                                         >
                                           <PlainText
+                                            component="plain-text"
                                             label="-"
                                             name="name1"
                                             variant="span"
@@ -2573,6 +2592,7 @@ exports[`<Input Addon> should render single button after input addon correctly 1
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "after": Object {
@@ -2697,6 +2717,7 @@ exports[`<Input Addon> should render single button after input addon correctly 1
                                           hideField={false}
                                         >
                                           <Button
+                                            component="button"
                                             label="Set 3"
                                             name="set3"
                                           >
@@ -2705,11 +2726,13 @@ exports[`<Input Addon> should render single button after input addon correctly 1
                                               block={false}
                                               bsClass="btn"
                                               bsStyle="default"
+                                              component="button"
                                               disabled={false}
                                               name="set3"
                                             >
                                               <button
                                                 className="btn btn-default"
+                                                component="button"
                                                 disabled={false}
                                                 name="set3"
                                                 type="button"
@@ -3062,6 +3085,7 @@ exports[`<Input Addon> should render single button before input addon correctly 
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "before": Object {
@@ -3192,6 +3216,7 @@ exports[`<Input Addon> should render single button before input addon correctly 
                                           hideField={false}
                                         >
                                           <InputAddonButtonGroup
+                                            component="input-addon-button-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -3220,6 +3245,7 @@ exports[`<Input Addon> should render single button before input addon correctly 
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 2"
                                                         name="set2"
                                                       >
@@ -3228,11 +3254,13 @@ exports[`<Input Addon> should render single button before input addon correctly 
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set2"
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set2"
                                                             type="button"
@@ -3875,6 +3903,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                       hideField={false}
                     >
                       <TextField
+                        component="text-field"
                         inputAddon={
                           Object {
                             "after": Object {
@@ -4110,6 +4139,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                           hideField={false}
                                         >
                                           <InputAddonButtonGroup
+                                            component="input-addon-button-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -4145,6 +4175,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 1"
                                                         name="set1"
                                                         onClick={[Function]}
@@ -4154,12 +4185,14 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set1"
                                                           onClick={[Function]}
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set1"
                                                             onClick={[Function]}
@@ -4183,6 +4216,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 2"
                                                         name="set2"
                                                       >
@@ -4191,11 +4225,13 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set2"
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set2"
                                                             type="button"
@@ -4253,6 +4289,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                           hideField={false}
                                         >
                                           <InputAddonGroup
+                                            component="input-addon-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -4283,6 +4320,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                       hideField={false}
                                                     >
                                                       <PlainText
+                                                        component="plain-text"
                                                         label="-"
                                                         name="name1"
                                                         variant="span"
@@ -4321,6 +4359,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                           hideField={false}
                                         >
                                           <InputAddonButtonGroup
+                                            component="input-addon-button-group"
                                             fields={
                                               Array [
                                                 Object {
@@ -4349,6 +4388,7 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                       hideField={false}
                                                     >
                                                       <Button
+                                                        component="button"
                                                         label="Set 3"
                                                         name="set3"
                                                       >
@@ -4357,11 +4397,13 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
+                                                          component="button"
                                                           disabled={false}
                                                           name="set3"
                                                         >
                                                           <button
                                                             className="btn btn-default"
+                                                            component="button"
                                                             disabled={false}
                                                             name="set3"
                                                             type="button"

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/input-addon.test.js.snap
@@ -570,14 +570,12 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set1"
                                                           onClick={[Function]}
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set1"
                                                             onClick={[Function]}
@@ -610,13 +608,11 @@ exports[`<Input Addon> should render group button before input addon correctly 1
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set2"
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set2"
                                                             type="button"
@@ -1367,13 +1363,11 @@ exports[`<Input Addon> should render group mixed before input addon correctly 1`
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set3"
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set3"
                                                             type="button"
@@ -2726,13 +2720,11 @@ exports[`<Input Addon> should render single button after input addon correctly 1
                                               block={false}
                                               bsClass="btn"
                                               bsStyle="default"
-                                              component="button"
                                               disabled={false}
                                               name="set3"
                                             >
                                               <button
                                                 className="btn btn-default"
-                                                component="button"
                                                 disabled={false}
                                                 name="set3"
                                                 type="button"
@@ -3254,13 +3246,11 @@ exports[`<Input Addon> should render single button before input addon correctly 
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set2"
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set2"
                                                             type="button"
@@ -4185,14 +4175,12 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set1"
                                                           onClick={[Function]}
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set1"
                                                             onClick={[Function]}
@@ -4225,13 +4213,11 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set2"
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set2"
                                                             type="button"
@@ -4397,13 +4383,11 @@ exports[`<Input Addon> should render the ultimate input addon correctly 1`] = `
                                                           block={false}
                                                           bsClass="btn"
                                                           bsStyle="default"
-                                                          component="button"
                                                           disabled={false}
                                                           name="set3"
                                                         >
                                                           <button
                                                             className="btn btn-default"
-                                                            component="button"
                                                             disabled={false}
                                                             name="set3"
                                                             type="button"

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/wizard.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/wizard.test.js.snap
@@ -313,7 +313,6 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                         >
                           <WizardInternal
                             activeStepIndex={0}
-                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],
@@ -1097,7 +1096,6 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                         >
                           <WizardInternal
                             activeStepIndex={0}
-                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],
@@ -1993,7 +1991,6 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                         >
                           <WizardInternal
                             activeStepIndex={0}
-                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],
@@ -2841,7 +2838,6 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                         >
                           <WizardInternal
                             activeStepIndex={0}
-                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],

--- a/packages/pf3-component-mapper/src/tests/__snapshots__/wizard.test.js.snap
+++ b/packages/pf3-component-mapper/src/tests/__snapshots__/wizard.test.js.snap
@@ -273,6 +273,7 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                       hideField={false}
                     >
                       <WizardFinal
+                        component="wizard"
                         fields={
                           Array [
                             Object {
@@ -292,6 +293,7 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                       >
                         <Wizard
                           Wizard={[Function]}
+                          component="wizard"
                           fields={
                             Array [
                               Object {
@@ -311,6 +313,7 @@ exports[`<Wizard /> should render Wizard correctly 1`] = `
                         >
                           <WizardInternal
                             activeStepIndex={0}
+                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],
@@ -1044,6 +1047,7 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                       hideField={false}
                     >
                       <WizardFinal
+                        component="wizard"
                         fields={
                           Array [
                             Object {
@@ -1068,6 +1072,7 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                       >
                         <Wizard
                           Wizard={[Function]}
+                          component="wizard"
                           fields={
                             Array [
                               Object {
@@ -1092,6 +1097,7 @@ exports[`<Wizard /> should render Wizard with conditional steps correctly 1`] = 
                         >
                           <WizardInternal
                             activeStepIndex={0}
+                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],
@@ -1927,6 +1933,7 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                       hideField={false}
                     >
                       <WizardFinal
+                        component="wizard"
                         fields={
                           Array [
                             Object {
@@ -1956,6 +1963,7 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                       >
                         <Wizard
                           Wizard={[Function]}
+                          component="wizard"
                           fields={
                             Array [
                               Object {
@@ -1985,6 +1993,7 @@ exports[`<Wizard /> should render Wizard with stepsInfo correctly 1`] = `
                         >
                           <WizardInternal
                             activeStepIndex={0}
+                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],
@@ -2790,6 +2799,7 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                       hideField={false}
                     >
                       <WizardFinal
+                        component="wizard"
                         fields={
                           Array [
                             Object {
@@ -2810,6 +2820,7 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                       >
                         <Wizard
                           Wizard={[Function]}
+                          component="wizard"
                           fields={
                             Array [
                               Object {
@@ -2830,6 +2841,7 @@ exports[`<Wizard /> should render Wizard with title correctly 1`] = `
                         >
                           <WizardInternal
                             activeStepIndex={0}
+                            component="wizard"
                             currentStep={
                               Object {
                                 "fields": Array [],

--- a/packages/pf3-component-mapper/src/tests/form-fields.test.js
+++ b/packages/pf3-component-mapper/src/tests/form-fields.test.js
@@ -37,7 +37,6 @@ describe('FormFields', () => {
           value: ''
         },
         id: 'someIdKey',
-        dataType: 'someDataType',
         meta: {
           error: false,
           touched: false

--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -22,7 +22,7 @@ const fieldArrayState = { schema: arraySchemaDDF, additionalOptions: {
 class App extends React.Component {
     constructor(props) {
         super(props);
-        this.state = { schema: wizardSchema, additionalOptions: { showFormControls: false, wizard: true } }
+        this.state = fieldArrayState 
     }
 
     render() {

--- a/packages/pf4-component-mapper/src/files/sub-form.js
+++ b/packages/pf4-component-mapper/src/files/sub-form.js
@@ -4,7 +4,7 @@ import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { Title, Grid, GridItem, TextContent, Text, TextVariants } from '@patternfly/react-core';
 
-const SubForm = ({ fields, title, description, validate: _validate, ...rest }) => {
+const SubForm = ({ fields, title, description, validate: _validate, component, ...rest }) => {
   const formOptions = useFormApi();
 
   return (
@@ -33,7 +33,8 @@ SubForm.propTypes = {
   name: PropTypes.string,
   title: PropTypes.string,
   description: PropTypes.string,
-  validate: PropTypes.any
+  validate: PropTypes.any,
+  component: PropTypes.any
 };
 
 export default SubForm;

--- a/packages/pf4-component-mapper/src/files/tabs.js
+++ b/packages/pf4-component-mapper/src/files/tabs.js
@@ -4,7 +4,7 @@ import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 import { Tab, Tabs } from '@patternfly/react-core';
 
-const FormTabs = ({ fields, dataType, validate, ...rest }) => {
+const FormTabs = ({ fields, dataType, validate, component, ...rest }) => {
   const formOptions = useFormApi();
   const [activeTabKey, setActiveTabKey] = useState(0);
 
@@ -30,7 +30,8 @@ const FormTabs = ({ fields, dataType, validate, ...rest }) => {
 FormTabs.propTypes = {
   fields: PropTypes.array.isRequired,
   dataType: PropTypes.any,
-  validate: PropTypes.any
+  validate: PropTypes.any,
+  component: PropTypes.any
 };
 
 export default FormTabs;

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
@@ -6,12 +6,10 @@ exports[`FormFields should render Checkbox correctly 1`] = `
     onSubmit={[Function]}
   >
     <Checkbox
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
     >
       <SingleCheckbox
-        dataType="someDataType"
         id="someIdKey"
         name="Name of the field"
       >
@@ -96,7 +94,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
     onSubmit={[Function]}
   >
     <Checkbox
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
       options={
@@ -117,7 +114,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
       }
     >
       <MultipleChoiceList
-        dataType="someDataType"
         id="someIdKey"
         name="Name of the field"
         options={
@@ -140,7 +136,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
         <MultipleChoiceList
           Checkbox={[Function]}
           Wrapper={[Function]}
-          dataType="someDataType"
           id="someIdKey"
           name="Name of the field"
           options={
@@ -711,7 +706,6 @@ exports[`FormFields should render DatePicker correctly 1`] = `
     onSubmit={[Function]}
   >
     <DatePicker
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
     >
@@ -806,7 +800,6 @@ exports[`FormFields should render Radio correctly 1`] = `
     onSubmit={[Function]}
   >
     <Radio
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
       options={
@@ -1055,7 +1048,6 @@ exports[`FormFields should render Select correctly 1`] = `
     }
   >
     <Select
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
       options={
@@ -1085,7 +1077,6 @@ exports[`FormFields should render Switch correctly 1`] = `
     onSubmit={[Function]}
   >
     <Switch
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
     >
@@ -1240,7 +1231,6 @@ exports[`FormFields should render TextField correctly 1`] = `
     onSubmit={[Function]}
   >
     <TextField
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
     >
@@ -1334,7 +1324,6 @@ exports[`FormFields should render TextField with description correctly 1`] = `
     onSubmit={[Function]}
   >
     <TextField
-      dataType="someDataType"
       description="This is description"
       id="someIdKey"
       name="Name of the field"
@@ -1446,7 +1435,6 @@ exports[`FormFields should render TextField without id correctly 1`] = `
     onSubmit={[Function]}
   >
     <TextField
-      dataType="someDataType"
       name="Name of the field"
     >
       <FormGroup
@@ -1539,7 +1527,6 @@ exports[`FormFields should render Textarea correctly 1`] = `
     onSubmit={[Function]}
   >
     <Textarea
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
     >
@@ -1618,7 +1605,6 @@ exports[`FormFields should render TimePicker correctly 1`] = `
     onSubmit={[Function]}
   >
     <TimePicker
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
     >
@@ -1713,7 +1699,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
     onSubmit={[Function]}
   >
     <Checkbox
-      dataType="someDataType"
       disabled={true}
       id="someIdKey"
       name="Name of the field"
@@ -1735,7 +1720,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
       }
     >
       <MultipleChoiceList
-        dataType="someDataType"
         disabled={true}
         id="someIdKey"
         name="Name of the field"
@@ -1759,7 +1743,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
         <MultipleChoiceList
           Checkbox={[Function]}
           Wrapper={[Function]}
-          dataType="someDataType"
           disabled={true}
           id="someIdKey"
           name="Name of the field"
@@ -2342,7 +2325,6 @@ exports[`FormFields should render disabled Radio correctly 1`] = `
     onSubmit={[Function]}
   >
     <Radio
-      dataType="someDataType"
       disabled={true}
       id="someIdKey"
       name="Name of the field"
@@ -2592,7 +2574,6 @@ exports[`FormFields should render disabled Select correctly 1`] = `
     }
   >
     <Select
-      dataType="someDataType"
       id="someIdKey"
       isDisabled={true}
       name="Name of the field"
@@ -2623,7 +2604,6 @@ exports[`FormFields should render disabled Switch correctly 1`] = `
     onSubmit={[Function]}
   >
     <Switch
-      dataType="someDataType"
       id="someIdKey"
       isDisabled={true}
       name="Name of the field"
@@ -2780,7 +2760,6 @@ exports[`FormFields should render disabled Switch correctly 2`] = `
     onSubmit={[Function]}
   >
     <Switch
-      dataType="someDataType"
       id="someIdKey"
       isDisabled={true}
       name="Name of the field"
@@ -2937,7 +2916,6 @@ exports[`FormFields should render disabled Textarea correctly 1`] = `
     onSubmit={[Function]}
   >
     <Textarea
-      dataType="someDataType"
       id="someIdKey"
       isDisabled={true}
       name="Name of the field"
@@ -3019,7 +2997,6 @@ exports[`FormFields should render touched TextField id correctly 1`] = `
     onSubmit={[Function]}
   >
     <TextField
-      dataType="someDataType"
       id="someIdKey"
       meta={
         Object {
@@ -3119,7 +3096,6 @@ exports[`FormFields should render with onText/OffText Switch correctly 1`] = `
     onSubmit={[Function]}
   >
     <Switch
-      dataType="someDataType"
       id="someIdKey"
       name="Name of the field"
       offText="Turned off"

--- a/packages/pf4-component-mapper/src/tests/form-fields.test.js
+++ b/packages/pf4-component-mapper/src/tests/form-fields.test.js
@@ -22,8 +22,7 @@ import MultipleChoiceListCommon from '@data-driven-forms/common/src/multiple-cho
 describe('FormFields', () => {
   const props = {
     name: 'Name of the field',
-    id: 'someIdKey',
-    dataType: 'someDataType'
+    id: 'someIdKey'
   };
   const propsWithOptions = {
     ...props,

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -347,6 +347,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                   >
                     <WizardFunction
                       buttonLabels={Object {}}
+                      component="wizard"
                       fields={
                         Array [
                           Object {
@@ -384,6 +385,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                             "submit": "Submit",
                           }
                         }
+                        component="wizard"
                         fields={
                           Array [
                             Object {
@@ -421,6 +423,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                               "submit": "Submit",
                             }
                           }
+                          component="wizard"
                           currentStep={
                             Object {
                               "fields": Array [
@@ -714,6 +717,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 hideField={false}
                                               >
                                                 <TextField
+                                                  component="text-field"
                                                   name="foo-field"
                                                 >
                                                   <FormGroup
@@ -1418,6 +1422,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                   >
                     <WizardFunction
                       buttonLabels={Object {}}
+                      component="wizard"
                       fields={
                         Array [
                           Object {
@@ -1456,6 +1461,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                             "submit": "Submit",
                           }
                         }
+                        component="wizard"
                         fields={
                           Array [
                             Object {
@@ -1494,6 +1500,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                               "submit": "Submit",
                             }
                           }
+                          component="wizard"
                           currentStep={
                             Object {
                               "fields": Array [
@@ -2003,6 +2010,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                           hideField={false}
                                                         >
                                                           <TextField
+                                                            component="text-field"
                                                             name="foo-field"
                                                           >
                                                             <FormGroup

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -423,7 +423,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                               "submit": "Submit",
                             }
                           }
-                          component="wizard"
                           currentStep={
                             Object {
                               "fields": Array [
@@ -1500,7 +1499,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                               "submit": "Submit",
                             }
                           }
-                          component="wizard"
                           currentStep={
                             Object {
                               "fields": Array [

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -60,12 +60,34 @@ const conditionLogicDemo = {
   description: 'Write X in both',
   fields: [
     {
+      name: 'text_box_1',
+      label: 'Text Box 1',
+      title: 'Text Box',
+      component: 'text-field',
+      clearOnUnmount: true,
+      condition: {
+        sequence: [
+          { when: 'a', is: 'x', then: { visible: true, set: { password: 'defaultPassword' } }, else: { set: { password: 'no password' } } },
+          { when: 'b', is: 'x', then: { visible: true, set: { text_box_1: 'defaultText' } } }
+        ]
+      }
+    },
+    {
       name: 'a',
       label: 'a',
       title: 'a',
-      initialValue: '1',
-      dataType: 'number',
-      type: 'number',
+      component: 'text-field'
+    },
+    {
+      name: 'b',
+      label: 'b',
+      title: 'b',
+      component: 'text-field'
+    },
+    {
+      name: 'password',
+      label: 'password',
+      title: 'password',
       component: 'text-field'
     }
   ]

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -60,34 +60,12 @@ const conditionLogicDemo = {
   description: 'Write X in both',
   fields: [
     {
-      name: 'text_box_1',
-      label: 'Text Box 1',
-      title: 'Text Box',
-      component: 'text-field',
-      clearOnUnmount: true,
-      condition: {
-        sequence: [
-          { when: 'a', is: 'x', then: { visible: true, set: { password: 'defaultPassword' } }, else: { set: { password: 'no password' } } },
-          { when: 'b', is: 'x', then: { visible: true, set: { text_box_1: 'defaultText' } } }
-        ]
-      }
-    },
-    {
       name: 'a',
       label: 'a',
       title: 'a',
-      component: 'text-field'
-    },
-    {
-      name: 'b',
-      label: 'b',
-      title: 'b',
-      component: 'text-field'
-    },
-    {
-      name: 'password',
-      label: 'password',
-      title: 'password',
+      initialValue: '1',
+      dataType: 'number',
+      type: 'number',
       component: 'text-field'
     }
   ]

--- a/packages/react-form-renderer/src/files/field-provider.js
+++ b/packages/react-form-renderer/src/files/field-provider.js
@@ -3,22 +3,21 @@ import PropTypes from 'prop-types';
 
 import useFieldApi from '../files/use-field-api';
 
-const FieldProvider = ({ component, render, ...props }) => {
+const FieldProvider = ({ Component, render, ...props }) => {
   const fieldProviderProps = useFieldApi(props);
-  if (component) {
-    const FieldComponent = component;
-    return <FieldComponent {...fieldProviderProps} />;
+  if (Component) {
+    return <Component {...fieldProviderProps} />;
   }
 
   if (render) {
     return render({ ...fieldProviderProps });
   }
 
-  throw new Error('Field provider is missing either component or render prop.');
+  throw new Error('Field provider is missing either Component or render prop.');
 };
 
 FieldProvider.propTypes = {
-  component: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func]),
+  Component: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func]),
   render: PropTypes.func
 };
 

--- a/packages/react-form-renderer/src/form-renderer/assign-special-type.js
+++ b/packages/react-form-renderer/src/form-renderer/assign-special-type.js
@@ -1,0 +1,5 @@
+import componentTypes from '../files/component-types';
+
+const assignSpecialType = (componentType) => ([componentTypes.CHECKBOX, componentTypes.RADIO].includes(componentType) ? componentType : undefined);
+
+export default assignSpecialType;

--- a/packages/react-form-renderer/src/form-renderer/condition.js
+++ b/packages/react-form-renderer/src/form-renderer/condition.js
@@ -147,7 +147,7 @@ const Condition = React.memo(
 );
 
 const conditionProps = {
-  when: PropTypes.string,
+  when: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   is: PropTypes.oneOfType([PropTypes.array, PropTypes.string, PropTypes.object, PropTypes.number, PropTypes.bool]),
   isNotEmpty: PropTypes.bool,
   isEmpty: PropTypes.bool,

--- a/packages/react-form-renderer/src/form-renderer/condition.js
+++ b/packages/react-form-renderer/src/form-renderer/condition.js
@@ -151,7 +151,18 @@ const conditionProps = {
   is: PropTypes.oneOfType([PropTypes.array, PropTypes.string, PropTypes.object, PropTypes.number, PropTypes.bool]),
   isNotEmpty: PropTypes.bool,
   isEmpty: PropTypes.bool,
-  pattern: PropTypes.oneOf([PropTypes.string, PropTypes.instanceOf(RegExp)]),
+  pattern: (props, name, componentName) => {
+    if (typeof props[name] === 'string') {
+      return;
+    }
+
+    if (props[name] instanceof RegExp) {
+      return;
+    }
+
+    return new Error(`Invalid prop pattern supplied to condition in \`${componentName}\`. Validation failed.
+    pattern has to be RegExp or string. Received \`${typeof props[name]}\`.`);
+  },
   notMatch: PropTypes.any,
   then: PropTypes.shape({
     visible: PropTypes.bool,

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -1,16 +1,9 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { childrenPropTypes } from '@data-driven-forms/common/src/prop-types-templates';
-import { dataTypeValidator } from '../validators';
 import RendererContext from '../files/renderer-context';
 import Condition from './condition';
-import { memoize } from '../validators/helpers';
-import componentTypes from '../files/component-types';
-import composeValidators from '../files/compose-validators';
-import convertInitialValue from './convert-initial-value';
 import FormSpy from '../files/form-spy';
-
-const assignSpecialType = (componentType) => ([componentTypes.CHECKBOX, componentTypes.RADIO].includes(componentType) ? componentType : undefined);
 
 const FormFieldHideWrapper = ({ hideField, children }) => (hideField ? <div hidden>{children}</div> : children);
 
@@ -41,44 +34,14 @@ FormConditionWrapper.propTypes = {
   children: childrenPropTypes.isRequired
 };
 
-const prepareValidator = (validator, mapper) => (typeof validator === 'function' ? memoize(validator) : mapper[validator.type]({ ...validator }));
-
-const getValidate = (validate, dataType, mapper) => [
-  ...(validate ? validate.map((validator) => prepareValidator(validator, mapper)) : []),
-  ...(dataType ? [dataTypeValidator(dataType)()] : [])
-];
-
-const prepareArrayValidator = (validation) => (value = []) => {
-  if (!Array.isArray(value)) {
-    return;
-  }
-
-  const arrayValidator = composeValidators(validation);
-  let result = arrayValidator(value && value.length > 0 ? value : undefined);
-  if (typeof result === 'function') {
-    result = result(value);
-  }
-
-  return result;
-};
-
-const SingleField = ({ component, condition, hideField, validate, ...rest }) => {
-  const { componentMapper, validatorMapper } = useContext(RendererContext);
-
-  const validation = validate || rest.dataType ? getValidate(validate, rest.dataType, validatorMapper) : undefined;
+const SingleField = ({ component, condition, hideField, ...rest }) => {
+  const { componentMapper } = useContext(RendererContext);
 
   let componentProps = {
-    type: assignSpecialType(component),
-    ...rest,
-    ...(Object.prototype.hasOwnProperty.call(rest, 'initialValue') && Object.prototype.hasOwnProperty.call(rest, 'dataType')
-      ? { initialValue: convertInitialValue(rest.initialValue, rest.dataType) }
-      : {}),
-    ...(validation
-      ? componentTypes.FIELD_ARRAY === component
-        ? { arrayValidator: prepareArrayValidator(validation) }
-        : { validate: composeValidators(validation) }
-      : {})
+    component,
+    ...rest
   };
+
   const componentBinding = componentMapper[component];
   let Component;
   if (typeof componentBinding === 'object' && Object.prototype.hasOwnProperty.call(componentBinding, 'component')) {

--- a/packages/react-form-renderer/src/form-renderer/validator-helpers.js
+++ b/packages/react-form-renderer/src/form-renderer/validator-helpers.js
@@ -1,0 +1,25 @@
+import { memoize } from '../validators/helpers';
+import { dataTypeValidator } from '../validators';
+import composeValidators from '../files/compose-validators';
+
+export const prepareValidator = (validator, mapper) =>
+  typeof validator === 'function' ? memoize(validator) : mapper[validator.type]({ ...validator });
+
+export const getValidate = (validate, dataType, mapper) => [
+  ...(validate ? validate.map((validator) => prepareValidator(validator, mapper)) : []),
+  ...(dataType ? [dataTypeValidator(dataType)()] : [])
+];
+
+export const prepareArrayValidator = (validation) => (value = []) => {
+  if (!Array.isArray(value)) {
+    return;
+  }
+
+  const arrayValidator = composeValidators(validation);
+  let result = arrayValidator(value && value.length > 0 ? value : undefined);
+  if (typeof result === 'function') {
+    result = result(value);
+  }
+
+  return result;
+};

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -135,6 +135,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 hideField={false}
               >
                 <TextField
+                  component="text-field"
                   name="component1"
                 >
                   <div
@@ -163,6 +164,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 hideField={false}
               >
                 <Component
+                  component="select"
                   name="secret"
                 >
                   <div
@@ -354,6 +356,7 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                 hideField={false}
               >
                 <TextField
+                  component="text-field"
                   label="Visible"
                   name="visible"
                 >
@@ -388,6 +391,7 @@ exports[`<FormRenderer /> should render hidden field 1`] = `
                   hidden={true}
                 >
                   <TextField
+                    component="text-field"
                     label="Hidden"
                     name="hidden"
                   >

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -36,6 +36,7 @@ exports[`renderForm function #condition should render condition field only if co
           hideField={false}
         >
           <CustomComponent
+            component="custom-component"
             name="a"
           >
             <FieldProvider
@@ -100,6 +101,7 @@ exports[`renderForm function #condition should render condition field only if co
           hideField={false}
         >
           <CustomComponent
+            component="custom-component"
             name="c"
           >
             <FieldProvider
@@ -253,6 +255,7 @@ exports[`renderForm function #condition should render condition field only if on
           hideField={false}
         >
           <CustomComponent
+            component="custom-component"
             name="a"
           >
             <FieldProvider
@@ -317,6 +320,7 @@ exports[`renderForm function #condition should render condition field only if on
           hideField={false}
         >
           <CustomComponent
+            component="custom-component"
             name="b"
           >
             <FieldProvider
@@ -452,9 +456,11 @@ exports[`renderForm function should render single field from defined componentTy
           hideField={false}
         >
           <Component
+            component="text-field"
             name="foo"
           >
             <div
+              component="text-field"
               name="foo"
             >
               TextField
@@ -503,6 +509,7 @@ exports[`renderForm function should render single field from with custom compone
           hideField={false}
         >
           <CustomComponent
+            component="custom-component"
             name="foo"
           >
             <FieldProvider

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -40,7 +40,8 @@ exports[`renderForm function #condition should render condition field only if co
             name="a"
           >
             <FieldProvider
-              component={[Function]}
+              Component={[Function]}
+              component="custom-component"
               name="a"
             >
               <TextField
@@ -105,7 +106,8 @@ exports[`renderForm function #condition should render condition field only if co
             name="c"
           >
             <FieldProvider
-              component={[Function]}
+              Component={[Function]}
+              component="custom-component"
               name="c"
             >
               <TextField
@@ -259,7 +261,8 @@ exports[`renderForm function #condition should render condition field only if on
             name="a"
           >
             <FieldProvider
-              component={[Function]}
+              Component={[Function]}
+              component="custom-component"
               name="a"
             >
               <TextField
@@ -324,7 +327,8 @@ exports[`renderForm function #condition should render condition field only if on
             name="b"
           >
             <FieldProvider
-              component={[Function]}
+              Component={[Function]}
+              component="custom-component"
               name="b"
             >
               <TextField
@@ -513,7 +517,8 @@ exports[`renderForm function should render single field from with custom compone
             name="foo"
           >
             <FieldProvider
-              component={[Function]}
+              Component={[Function]}
+              component="custom-component"
               name="foo"
             >
               <TextField

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -744,6 +744,7 @@ describe('renderForm function', () => {
         {
           component,
           name: 'unmnounted',
+          key: 'unmnounted-1',
           label: 'Label 1',
           clearOnUnmount,
           condition: {
@@ -754,6 +755,7 @@ describe('renderForm function', () => {
         {
           component,
           name: 'unmnounted',
+          key: 'unmnounted-2',
           label: 'Label 2',
           clearOnUnmount,
           condition: {
@@ -1182,23 +1184,22 @@ describe('renderForm function', () => {
       const form = wrapper.find('form');
       form.simulate('submit');
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: INITIAL_VALUE }));
+      onSubmit.mockReset();
 
       mountInitializedField(wrapper);
       setInitializedToNewValue(wrapper);
+      form.simulate('submit');
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: NEW_VALUE, [SHOWER_FIELD]: SHOW_VALUE }));
       onSubmit.mockReset();
 
-      form.simulate('submit');
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: INITIAL_VALUE, [SHOWER_FIELD]: SHOW_VALUE }));
-      onSubmit.mockReset();
-
-      form.simulate('submit');
       unmountInitializedField(wrapper);
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: INITIAL_VALUE, [SHOWER_FIELD]: SHOW_VALUE }));
+      form.simulate('submit');
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: NEW_VALUE, [SHOWER_FIELD]: NOT_SHOW_VALUE }));
       onSubmit.mockReset();
 
-      form.simulate('submit');
       mountInitializedField(wrapper);
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: INITIAL_VALUE, [SHOWER_FIELD]: NOT_SHOW_VALUE }));
+      form.simulate('submit');
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: INITIAL_VALUE, [SHOWER_FIELD]: SHOW_VALUE }));
     });
 
     it('should not reset value after mount when set on fields', () => {
@@ -1262,12 +1263,12 @@ describe('renderForm function', () => {
       mountInitializedField(wrapper);
       setInitializedToNewValue(wrapper);
       wrapper.find('form').simulate('submit');
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [SHOWER_FIELD]: SHOW_VALUE, [INITIALIZED_FIELD]: SCHEMA_INITIAL_VALUE }));
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [SHOWER_FIELD]: SHOW_VALUE, [INITIALIZED_FIELD]: NEW_VALUE }));
       onSubmit.mockReset();
 
       unmountInitializedField(wrapper);
       wrapper.find('form').simulate('submit');
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [SHOWER_FIELD]: NOT_SHOW_VALUE, [INITIALIZED_FIELD]: SCHEMA_INITIAL_VALUE }));
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [SHOWER_FIELD]: NOT_SHOW_VALUE, [INITIALIZED_FIELD]: NEW_VALUE }));
       onSubmit.mockReset();
 
       mountInitializedField(wrapper);
@@ -1294,12 +1295,12 @@ describe('renderForm function', () => {
       mountInitializedField(wrapper);
       setInitializedToNewValue(wrapper);
       wrapper.find('form').simulate('submit');
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [SHOWER_FIELD]: SHOW_VALUE, [INITIALIZED_FIELD]: SCHEMA_INITIAL_VALUE }));
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [SHOWER_FIELD]: SHOW_VALUE, [INITIALIZED_FIELD]: NEW_VALUE }));
       onSubmit.mockReset();
 
       unmountInitializedField(wrapper);
       wrapper.find('form').simulate('submit');
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: SCHEMA_INITIAL_VALUE, [SHOWER_FIELD]: NOT_SHOW_VALUE }));
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [INITIALIZED_FIELD]: NEW_VALUE, [SHOWER_FIELD]: NOT_SHOW_VALUE }));
       onSubmit.mockReset();
 
       mountInitializedField(wrapper);
@@ -1328,6 +1329,7 @@ describe('renderForm function', () => {
           {
             component: componentTypes.TEXT_FIELD,
             name: 'unmounted',
+            key: 'unmounted-2',
             initialValue: true,
             initializeOnMount: true,
             condition: {
@@ -1500,7 +1502,7 @@ describe('renderForm function', () => {
     ).toEqual('standard label');
   });
 
-  describe('composite mapper component', () => {
+  it('composite mapper component', () => {
     const schema = {
       fields: [
         {

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -44,7 +44,7 @@ describe('renderForm function', () => {
 
   beforeEach(() => {
     const TextField = ({ input }) => <input {...input} id={input.name} />;
-    CustomComponent = ({ dataType, formOptions, ...props }) => <FieldProvider {...props} component={TextField} />;
+    CustomComponent = ({ dataType, formOptions, ...props }) => <FieldProvider {...props} Component={TextField} />;
   });
 
   it('should render single field from defined componentTypes', () => {

--- a/packages/react-renderer-demo/src/app/examples/tests/__snapshots__/custom-component-outside-renderer.test.js.snap
+++ b/packages/react-renderer-demo/src/app/examples/tests/__snapshots__/custom-component-outside-renderer.test.js.snap
@@ -5,7 +5,13 @@ exports[`<CustomComponent /> outside renderer should render component in error s
   label="custom-component"
   name="custom-component"
   sideEffect={[Function]}
-  validate={[Function]}
+  validate={
+    Array [
+      Object {
+        "type": "required",
+      },
+    ]
+  }
 >
   <div
     className="input-wrapper"
@@ -26,7 +32,7 @@ exports[`<CustomComponent /> outside renderer should render component in error s
       className="custom-error-block"
     >
       <span>
-        Required
+        required
       </span>
     </div>
   </div>

--- a/packages/react-renderer-demo/src/app/examples/tests/__snapshots__/custom-component-with-renderer.test.js.snap
+++ b/packages/react-renderer-demo/src/app/examples/tests/__snapshots__/custom-component-with-renderer.test.js.snap
@@ -2,10 +2,17 @@
 
 exports[`<CustomComponent /> with renderer should render component in error state to snapshot 1`] = `
 <CustomComponent
+  component="custom-component"
   label="Custom label"
   name="custom-component"
   sideEffect={[Function]}
-  validate={[Function]}
+  validate={
+    Array [
+      Object {
+        "type": "required",
+      },
+    ]
+  }
 >
   <div
     className="input-wrapper"
@@ -35,10 +42,11 @@ exports[`<CustomComponent /> with renderer should render component in error stat
 
 exports[`<CustomComponent /> with renderer should render component to snapshot 1`] = `
 <CustomComponent
+  component="custom-component"
   label="Custom label"
   name="custom-component"
   sideEffect={[Function]}
-  validate={[Function]}
+  validate={Array []}
 >
   <div
     className="input-wrapper"

--- a/packages/react-renderer-demo/src/app/examples/tests/custom-component-outside-renderer.test.js
+++ b/packages/react-renderer-demo/src/app/examples/tests/custom-component-outside-renderer.test.js
@@ -35,7 +35,14 @@ const FormWrapper = ({ props, children }) => (
   <Form onSubmit={() => {}} {...props}>
     {() => (
       <form>
-        <RendererContext.Provider value={{ formOptions: {} }}>{children}</RendererContext.Provider>
+        <RendererContext.Provider
+          value={{
+            formOptions: {},
+            validatorMapper: { required: () => (value) => (value ? undefined : 'required') }
+          }}
+        >
+          {children}
+        </RendererContext.Provider>
       </form>
     )}
   </Form>
@@ -53,7 +60,7 @@ describe('<CustomComponent /> outside renderer', () => {
   it('should render component in error state to snapshot', () => {
     const wrapper = mount(
       <FormWrapper>
-        <CustomComponent name="custom-component" label="custom-component" validate={(value) => (!value ? 'Required' : undefined)} />
+        <CustomComponent name="custom-component" label="custom-component" validate={[{ type: 'required' }]} />
       </FormWrapper>
     );
     expect(toJson(wrapper.find(CustomComponent))).toMatchSnapshot();

--- a/packages/react-renderer-demo/src/app/pages/renderer/component-mapping.md
+++ b/packages/react-renderer-demo/src/app/pages/renderer/component-mapping.md
@@ -56,13 +56,13 @@ const { input, isDisabled, label, helperText, description, meta } = useFieldApi(
 
 ### FieldProvider
 
-Or you can import `FieldProvider` component from Data Driven Forms. This component needs to obtain `render` or `component` prop.
+Or you can import `FieldProvider` component from Data Driven Forms. This component needs to obtain `render` or `Component` prop.
 
 
 ```jsx
 import { FieldProvider } from '@data-driven-forms/react-form-renderer'
 
-<FielProvider component={TextField}>
+<FielProvider Component={TextField}>
 
 // or
 


### PR DESCRIPTION
Some functionality left in render single field, but it should be moved to useField to make sense.

- `renderSingleField` does not do anything, only renders component and use action mapper to assign props
- `useField` now creates the validate, validatorArray, converting initialValue
- fixes some propTypes
- fixes wrong initializeOnMount tests
- **breaking**: FieldProvider uses `Component` instead of `component` (due to props naming conflict)