### PR TITLE
Fix canReset use in getStarted

### DIFF
--- a/packages/react-renderer-demo/src/app/examples/components/get-started/get-started.js
+++ b/packages/react-renderer-demo/src/app/examples/components/get-started/get-started.js
@@ -42,15 +42,16 @@ const schema = {
   ]
 };
 
+const FormTemplateCanReset = (props) => <FormTemplate {...props} canReset />;
+
 const GetStartedForm = () => (
   <div className="pf4">
     <FormRender
       componentMapper={componentMapper}
-      FormTemplate={FormTemplate}
+      FormTemplate={FormTemplateCanReset}
       schema={schema}
       onSubmit={console.log}
       onCancel={() => console.log('Cancel action')}
-      canReset
     />
   </div>
 );

--- a/packages/react-renderer-demo/src/app/pages/migration-guide.md
+++ b/packages/react-renderer-demo/src/app/pages/migration-guide.md
@@ -40,6 +40,7 @@ Thank you for your understanding.
     -   buttonClassName
     -   renderFormButtons
     -   buttonsLabels
+    -   canReset
 -   => All these props are now managed by mapper's form templates!
 
 -   FormTemplate receives these props:


### PR DESCRIPTION
- fix using `canReset` in get started demo
- add `canReset` to the list of moved props in the migration guide