### PR TITLE
fix(all): include prop-types in dependencies

### DIFF
--- a/packages/blueprint-component-mapper/package.json
+++ b/packages/blueprint-component-mapper/package.json
@@ -42,7 +42,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -73,6 +72,7 @@
     "@blueprintjs/select": "^3.12.3"
   },
   "dependencies": {
-    "clsx": "^1.1.0"
+    "clsx": "^1.1.0",
+    "prop-types": "^15.7.2"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -42,7 +41,8 @@
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "clsx": "^1.0.4",
     "lodash": "^4.17.15",
-    "react-select": "^3.0.8"
+    "react-select": "^3.0.8",
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/packages/mui-component-mapper/package.json
+++ b/packages/mui-component-mapper/package.json
@@ -43,7 +43,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -65,6 +64,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.9.14",
     "material-ui-pickers": "^2.2.4",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/packages/pf3-component-mapper/package.json
+++ b/packages/pf3-component-mapper/package.json
@@ -47,7 +47,6 @@
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.12.0",
     "patternfly-react": "^2.28.2",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -79,6 +78,7 @@
   },
   "dependencies": {
     "clsx": "^1.0.4",
+    "prop-types": "^15.7.2",
     "react-day-picker": "^7.3.2",
     "react-select": "^3.0.8"
   },

--- a/packages/pf4-component-mapper/package.json
+++ b/packages/pf4-component-mapper/package.json
@@ -46,7 +46,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -78,6 +77,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly-next": "^1.0.175",
+    "prop-types": "^15.7.2",
     "react-final-form-arrays": "2.0.3",
     "react-select": "^3.0.4"
   },

--- a/packages/react-form-renderer/package.json
+++ b/packages/react-form-renderer/package.json
@@ -40,7 +40,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -67,6 +66,7 @@
     "final-form-arrays": "^3.0.2",
     "final-form-focus": "^1.1.2",
     "lodash": "^4.17.15",
+    "prop-types": "^15.7.2",
     "react-final-form": "^6.4.0",
     "react-final-form-arrays": "^3.1.1"
   },

--- a/packages/suir-component-mapper/package.json
+++ b/packages/suir-component-mapper/package.json
@@ -39,7 +39,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -65,6 +64,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "clsx": "^1.0.4",
+    "prop-types": "^15.7.2",
     "react-jss": "^10.1.1"
   }
 }

--- a/templates/component-mapper/package.json
+++ b/templates/component-mapper/package.json
@@ -44,7 +44,6 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.10.0",
-    "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.12.1",
@@ -73,5 +72,6 @@
   "peerDependencies": {
   },
   "dependencies": {
+    "prop-types": "^15.7.2"
   }
 }


### PR DESCRIPTION
`PropTypes.elementType` cause consumer apps to crash if they used an older version of `prop-types` package.