### PR TITLE
fix(mui): change empty value in select from '' to null

### DIFF
--- a/packages/mui-component-mapper/src/files/select.js
+++ b/packages/mui-component-mapper/src/files/select.js
@@ -116,7 +116,7 @@ const InternalSelect = ({
         options={options}
         multiple={isMulti}
         getOptionLabel={(option) => getOptionLabel(option, options)}
-        value={typeof internalValue === 'undefined' ? '' : internalValue}
+        value={typeof internalValue === 'undefined' ? null : internalValue}
         onChange={(_event, option) => onChange(createValue(option, isMulti))}
         loading={isFetching}
       />


### PR DESCRIPTION
close #531 

- the autocomplete considers `''` as a value, so the select is by default 'filled'
- changed to `null` (`undefined` is uncontrolled)
- Also tested on the latest iPadOS. The double click is now gone. (see video below)
- everything else seems working well

**Before**

Notice that the clearable button is shown immediately with no value selected.

![before](https://user-images.githubusercontent.com/32869456/83383916-63c6cd00-a3e6-11ea-842f-444e45bf1f92.gif)

**After**

![after](https://user-images.githubusercontent.com/32869456/83383920-67f2ea80-a3e6-11ea-9210-b9c5ef23103c.gif)

**iPadOS** (well... :smile_cat: )

![ezgif com-optimize](https://user-images.githubusercontent.com/32869456/83384229-20209300-a3e7-11ea-9279-d57807606d18.gif)

