### PR TITLE
fix(common): wizard check validating on enter

### DIFF
--- a/packages/common/src/wizard/enter-handler.js
+++ b/packages/common/src/wizard/enter-handler.js
@@ -15,9 +15,11 @@ const enterHandler = (e, formOptions, activeStep, findCurrentStep, handleNext, h
         nextStep = selectNext(schemaNextStep, formOptions.getState);
       }
 
-      if (formOptions.valid && nextStep && !hasCustomButtons) {
+      const canContinue = formOptions.valid && !formOptions.getState().validating;
+
+      if (canContinue && nextStep && !hasCustomButtons) {
         handleNext(nextStep, formOptions.getRegisteredFields);
-      } else if (formOptions.valid && !schemaNextStep && !hasCustomButtons) {
+      } else if (canContinue && !schemaNextStep && !hasCustomButtons) {
         handleSubmit();
       }
     }

--- a/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
@@ -200,9 +200,9 @@ describe('<WizardSTepButtons', () => {
         preventDefault: jest.fn()
       };
       formOptions = {
-        getState: jest.fn(),
         valid: true,
-        getRegisteredFields
+        getRegisteredFields,
+        getState: () => ({ validating: false })
       };
       activeStep = 'active-step';
       findCurrentStep = jest.fn().mockImplementation(() => ({ nextStep }));
@@ -230,6 +230,34 @@ describe('<WizardSTepButtons', () => {
 
     it('should be prevented if step has custom buttons', () => {
       findCurrentStep = jest.fn().mockImplementation(() => ({ buttons: true }));
+
+      handleEnter(event, formOptions, activeStep, findCurrentStep, handleNext, handleSubmit);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(handleNext).not.toHaveBeenCalled();
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should be prevented if form is not valid', () => {
+      formOptions = {
+        valid: false,
+        getRegisteredFields,
+        getState: () => ({ validating: false })
+      };
+
+      handleEnter(event, formOptions, activeStep, findCurrentStep, handleNext, handleSubmit);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(handleNext).not.toHaveBeenCalled();
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should be prevented if form is validating', () => {
+      formOptions = {
+        valid: true,
+        getRegisteredFields,
+        getState: () => ({ validating: true })
+      };
 
       handleEnter(event, formOptions, activeStep, findCurrentStep, handleNext, handleSubmit);
 


### PR DESCRIPTION
closes https://github.com/data-driven-forms/react-forms/issues/542

Enter cannot skip the validation anymore