### PR TITLE
Add TSlib as dep to demo stackblitz template

### DIFF
--- a/packages/react-renderer-demo/src/stackblitz-templates/pf4-templates.js
+++ b/packages/react-renderer-demo/src/stackblitz-templates/pf4-templates.js
@@ -69,5 +69,6 @@ export const pf4Dependencies = {
   '@data-driven-forms/pf4-component-mapper': 'latest',
   '@patternfly/react-core': 'latest',
   '@patternfly/react-icons': 'latest',
-  'prop-types': 'latest'
+  'prop-types': 'latest',
+  tslib: '^2.0.0'
 };


### PR DESCRIPTION
Fixes missing dep in PF4 examples