### PR TITLE
Add mobile friendly table of content

### DIFF
--- a/packages/react-renderer-demo/src/components/code-editor/index.js
+++ b/packages/react-renderer-demo/src/components/code-editor/index.js
@@ -7,6 +7,7 @@ import vsTheme from 'prism-react-renderer/themes/vsDark';
 
 const useStyles = makeStyles({
   pre: {
+    maxWidth: '100vw',
     textAlign: 'left',
     margin: '1em 0',
     padding: '0.5em',

--- a/packages/react-renderer-demo/src/helpers/list-of-contents-select.js
+++ b/packages/react-renderer-demo/src/helpers/list-of-contents-select.js
@@ -14,6 +14,9 @@ import MenuList from '@material-ui/core/MenuList';
 import Grid from '@material-ui/core/Grid';
 import Hidden from '@material-ui/core/Hidden';
 
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+
 import { headerToId } from './list-of-contents';
 
 const reqSource = require.context('!raw-loader!@docs/pages', true, /\.md/);
@@ -44,8 +47,13 @@ Item.propTypes = {
 
 const contentStyles = makeStyles(() => ({
   button: {
-    paddingLeft: 0,
+    paddingRight: 0,
     marginTop: '-24px'
+  },
+  wrapper: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'flex-end'
   }
 }));
 
@@ -69,30 +77,35 @@ const ListOfContents = ({ file }) => {
   return (
     <Grid item xs={12} md={false}>
       <Hidden implementation="css" mdUp>
-        <Button
-          ref={anchorRef}
-          className={styles.button}
-          aria-controls={open ? 'menu-list-grow' : undefined}
-          aria-haspopup="true"
-          onClick={() => setOpen((prevOpen) => !prevOpen)}
-        >
-          Show content
-        </Button>
-        <Popper open={open} role={undefined} transition disablePortal anchorEl={anchorRef.current}>
-          {({ TransitionProps }) => (
-            <Grow {...TransitionProps} style={{ transformOrigin: 'center top' }}>
-              <Paper>
-                <ClickAwayListener onClickAway={() => setOpen(false)}>
-                  <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={handleListKeyDown}>
-                    {found.map((text) => (
-                      <Item key={text} text={text} setOpen={setOpen} />
-                    ))}
-                  </MenuList>
-                </ClickAwayListener>
-              </Paper>
-            </Grow>
-          )}
-        </Popper>
+        <div className={styles.wrapper}>
+          <ClickAwayListener onClickAway={() => setOpen(false)}>
+            <div>
+              <Button
+                ref={anchorRef}
+                className={styles.button}
+                aria-controls={open ? 'menu-list-grow' : undefined}
+                aria-haspopup="true"
+                onClick={() => setOpen((prevOpen) => !prevOpen)}
+                endIcon={!open ? <KeyboardArrowRightIcon /> : <KeyboardArrowDownIcon />}
+              >
+                Show content
+              </Button>
+              <Popper open={open} role={undefined} transition disablePortal anchorEl={anchorRef.current}>
+                {({ TransitionProps }) => (
+                  <Grow {...TransitionProps} style={{ transformOrigin: 'center top' }}>
+                    <Paper>
+                      <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={handleListKeyDown}>
+                        {found.map((text) => (
+                          <Item key={text} text={text} setOpen={setOpen} />
+                        ))}
+                      </MenuList>
+                    </Paper>
+                  </Grow>
+                )}
+              </Popper>
+            </div>
+          </ClickAwayListener>
+        </div>
       </Hidden>
     </Grid>
   );

--- a/packages/react-renderer-demo/src/helpers/list-of-contents-select.js
+++ b/packages/react-renderer-demo/src/helpers/list-of-contents-select.js
@@ -1,0 +1,105 @@
+import React, { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import { useRouter } from 'next/router';
+
+import Button from '@material-ui/core/Button';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Grow from '@material-ui/core/Grow';
+import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
+
+import Grid from '@material-ui/core/Grid';
+import Hidden from '@material-ui/core/Hidden';
+
+import { headerToId } from './list-of-contents';
+
+const reqSource = require.context('!raw-loader!@docs/pages', true, /\.md/);
+
+const itemStyles = makeStyles(() => ({
+  a: {
+    textDecoration: 'none',
+    color: 'inherit'
+  }
+}));
+
+const Item = ({ text, setOpen }) => {
+  const router = useRouter();
+  const labelText = text.replace(/#/g, '');
+  const styles = itemStyles();
+
+  return (
+    <MenuItem onClick={() => setOpen(false)} component="a" className={styles.a} href={`${router.pathname}#${headerToId(text)}`} title={labelText}>
+      {labelText}
+    </MenuItem>
+  );
+};
+
+Item.propTypes = {
+  text: PropTypes.string.isRequired,
+  setOpen: PropTypes.func.isRequired
+};
+
+const contentStyles = makeStyles(() => ({
+  button: {
+    paddingLeft: 0,
+    marginTop: '-24px'
+  }
+}));
+
+const ListOfContents = ({ file }) => {
+  const [open, setOpen] = useState(false);
+  const styles = contentStyles();
+  const anchorRef = useRef(null);
+
+  const handleListKeyDown = (event) => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  const text = reqSource(`./${file}.md`).default;
+
+  const regex = /^#+ .*/gm;
+  const found = text.match(regex) || [];
+
+  return (
+    <Grid item xs={12} md={false}>
+      <Hidden implementation="css" mdUp>
+        <Button
+          ref={anchorRef}
+          className={styles.button}
+          aria-controls={open ? 'menu-list-grow' : undefined}
+          aria-haspopup="true"
+          onClick={() => setOpen((prevOpen) => !prevOpen)}
+        >
+          Show content
+        </Button>
+        <Popper open={open} role={undefined} transition disablePortal anchorEl={anchorRef.current}>
+          {({ TransitionProps }) => (
+            <Grow {...TransitionProps} style={{ transformOrigin: 'center top' }}>
+              <Paper>
+                <ClickAwayListener onClickAway={() => setOpen(false)}>
+                  <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={handleListKeyDown}>
+                    {found.map((text) => (
+                      <Item key={text} text={text} setOpen={setOpen} />
+                    ))}
+                  </MenuList>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+      </Hidden>
+    </Grid>
+  );
+};
+
+ListOfContents.propTypes = {
+  file: PropTypes.string.isRequired
+};
+
+export default ListOfContents;

--- a/packages/react-renderer-demo/src/helpers/list-of-contents.js
+++ b/packages/react-renderer-demo/src/helpers/list-of-contents.js
@@ -8,6 +8,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import { useRouter } from 'next/router';
 import StickyBox from 'react-sticky-box';
+import Hidden from '@material-ui/core/Hidden';
 
 const reqSource = require.context('!raw-loader!@docs/pages', true, /\.md/);
 
@@ -113,24 +114,26 @@ const ListOfContents = ({ file }) => {
   const regex = /^#+ .*/gm;
   const found = text.match(regex) || [];
   return (
-    <StickyBox offsetTop={96} offsetBottom={20}>
-      <div className={classes.fixedContainer}>
-        <Typography className={classes.contentHeader} component="h3">
-          Content
-        </Typography>
-        <List dense>
-          {found.map((text) => (
-            <ListItem
-              onClick={() => setActive(headerToId(text))}
-              className={clsx(classes.listItem, { [classes.listItemActive]: headerToId(text) === activeItem })}
-              key={text}
-            >
-              <ListItemText className={classes.listItemText} primary={<ListHeader text={text} />} />
-            </ListItem>
-          ))}
-        </List>
-      </div>
-    </StickyBox>
+    <Hidden implementation="css" smDown>
+      <StickyBox offsetTop={96} offsetBottom={20}>
+        <div className={classes.fixedContainer}>
+          <Typography className={classes.contentHeader} component="h3">
+            Content
+          </Typography>
+          <List dense>
+            {found.map((text) => (
+              <ListItem
+                onClick={() => setActive(headerToId(text))}
+                className={clsx(classes.listItem, { [classes.listItemActive]: headerToId(text) === activeItem })}
+                key={text}
+              >
+                <ListItemText className={classes.listItemText} primary={<ListHeader text={text} />} />
+              </ListItem>
+            ))}
+          </List>
+        </div>
+      </StickyBox>
+    </Hidden>
   );
 };
 

--- a/packages/react-renderer-demo/src/next.config.js
+++ b/packages/react-renderer-demo/src/next.config.js
@@ -63,7 +63,8 @@ module.exports = withBundleAnalyzer(
           '@docs/examples': path.resolve(__dirname, './examples'),
           '@docs/list-of-contents': path.resolve(__dirname, './helpers/list-of-contents'),
           '@docs/code-example': path.resolve(__dirname, './components/code-example'),
-          '@docs/hooks': path.resolve(__dirname, './hooks')
+          '@docs/hooks': path.resolve(__dirname, './hooks'),
+          '@docs/list-of-contents-select': path.resolve(__dirname, './helpers/list-of-contents-select')
         };
 
         config.optimization.minimizer = [

--- a/packages/react-renderer-demo/src/pages/mappers/blueprint-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/mappers/blueprint-component-mapper.md
@@ -1,7 +1,10 @@
 import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="mappers/blueprint-component-mapper" />
 <Grid item xs={12} md={10}>
 
 # BlueprintJS

--- a/packages/react-renderer-demo/src/pages/mappers/mui-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/mappers/mui-component-mapper.md
@@ -1,7 +1,10 @@
 import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="mappers/mui-component-mapper" />
 <Grid item xs={12} md={10}>
 
 # MaterialUI mapper

--- a/packages/react-renderer-demo/src/pages/mappers/pf3-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/mappers/pf3-component-mapper.md
@@ -1,7 +1,10 @@
 import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="mappers/pf3-component-mapper" />
 <Grid item xs={12} md={10}>
 
 # PatternFly 3 mapper

--- a/packages/react-renderer-demo/src/pages/mappers/pf4-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/mappers/pf4-component-mapper.md
@@ -1,7 +1,10 @@
 import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="mappers/pf4-component-mapper" />
 <Grid item xs={12} md={10}>
 
 # PatternFly 4 mapper

--- a/packages/react-renderer-demo/src/pages/mappers/suir-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/mappers/suir-component-mapper.md
@@ -1,7 +1,10 @@
 import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="mappers/suir-component-mapper" />
 <Grid item xs={12} md={10}>
 
 # Semantic UI react

--- a/packages/react-renderer-demo/src/pages/migration-guide.md
+++ b/packages/react-renderer-demo/src/pages/migration-guide.md
@@ -4,7 +4,11 @@ import Link from '@material-ui/core/Link';
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="migration-guide" />
 <Grid item xs={12} md={10}>
 
 # Migration guide to version 2

--- a/packages/react-renderer-demo/src/pages/renderer/action-mapper.md
+++ b/packages/react-renderer-demo/src/pages/renderer/action-mapper.md
@@ -3,7 +3,12 @@ import ListOfContents from '@docs/list-of-contents';
 import CodeExample from '@docs/code-example';
 
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/action-mapper" />
+
 <Grid item xs={12} md={10}>
 
 # Action Mapper

--- a/packages/react-renderer-demo/src/pages/renderer/cleared-value.md
+++ b/packages/react-renderer-demo/src/pages/renderer/cleared-value.md
@@ -3,7 +3,11 @@ import CodeExample from '@docs/code-example'
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/cleared-value" />
 <Grid item xs={12} md={10}>
 
 # Cleared value

--- a/packages/react-renderer-demo/src/pages/renderer/component-api.md
+++ b/packages/react-renderer-demo/src/pages/renderer/component-api.md
@@ -3,7 +3,11 @@ import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
 import ExampleLink from '@docs/components/common/example-link';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/component-api" />
 <Grid item xs={12} md={10}>
 
 # Components API

--- a/packages/react-renderer-demo/src/pages/renderer/component-mapping.md
+++ b/packages/react-renderer-demo/src/pages/renderer/component-mapping.md
@@ -3,7 +3,11 @@ import Grid from '@material-ui/core/Grid'
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/component-mapping" />
 <Grid item xs={12} md={10}>
 
 # ComponentMapper

--- a/packages/react-renderer-demo/src/pages/renderer/condition.md
+++ b/packages/react-renderer-demo/src/pages/renderer/condition.md
@@ -4,7 +4,11 @@ import ListOfContents from '@docs/list-of-contents';
 import CodeExample from '@docs/code-example';
 
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/condition" />
 <Grid item xs={12} md={10}>
 
 # Conditional fields

--- a/packages/react-renderer-demo/src/pages/renderer/data-types.md
+++ b/packages/react-renderer-demo/src/pages/renderer/data-types.md
@@ -3,7 +3,11 @@ import CodeExample from '@docs/code-example';
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/data-types" />
 <Grid item xs={12} md={10}>
 
 # Introduction

--- a/packages/react-renderer-demo/src/pages/renderer/development-setup.md
+++ b/packages/react-renderer-demo/src/pages/renderer/development-setup.md
@@ -1,8 +1,12 @@
 import Grid from '@material-ui/core/Grid'
 
 import ListOfContents from '@docs/list-of-contents';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/development-setup" />
+
 <Grid item xs={12} md={10}>
 
 # Development setup

--- a/packages/react-renderer-demo/src/pages/renderer/dynamic-fields.md
+++ b/packages/react-renderer-demo/src/pages/renderer/dynamic-fields.md
@@ -3,7 +3,11 @@ import CodeExamples from '@docs/code-example';
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/dynamic-fields" />
 <Grid item xs={12} md={10}>
 
 # Dynamic fields

--- a/packages/react-renderer-demo/src/pages/renderer/field-provider.md
+++ b/packages/react-renderer-demo/src/pages/renderer/field-provider.md
@@ -5,7 +5,11 @@ import Grid from '@material-ui/core/Grid'
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/field-provider" />
 <Grid item xs={12} md={10}>
 
 # Custom components

--- a/packages/react-renderer-demo/src/pages/renderer/file-input.md
+++ b/packages/react-renderer-demo/src/pages/renderer/file-input.md
@@ -3,7 +3,11 @@ import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
 import CodeExample from '@docs/code-example';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/file-input" />
 <Grid item xs={12} md={10}>
 
 # File input

--- a/packages/react-renderer-demo/src/pages/renderer/form-template.md
+++ b/packages/react-renderer-demo/src/pages/renderer/form-template.md
@@ -3,7 +3,11 @@ import CodeExample from '@docs/code-example';
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/form-template" />
 <Grid item xs={12} md={10}>
 
 # FormTemplate

--- a/packages/react-renderer-demo/src/pages/renderer/get-started.md
+++ b/packages/react-renderer-demo/src/pages/renderer/get-started.md
@@ -3,7 +3,11 @@ import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
 import CodeExample from '@docs/code-example';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/get-started" />
 <Grid item xs={12} md={10}>
 
 # Getting started

--- a/packages/react-renderer-demo/src/pages/renderer/global-component-props.md
+++ b/packages/react-renderer-demo/src/pages/renderer/global-component-props.md
@@ -3,7 +3,11 @@ import Grid from '@material-ui/core/Grid'
 import CodeExample from '@docs/code-example'
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/global-component-props" />
 <Grid item xs={12} md={10}>
 
 # Global component props

--- a/packages/react-renderer-demo/src/pages/renderer/initialize-mount.md
+++ b/packages/react-renderer-demo/src/pages/renderer/initialize-mount.md
@@ -3,7 +3,11 @@ import CodeExample from '@docs/code-example';
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/initialize-mount" />
 <Grid item xs={12} md={10}>
 
 # Initialize On Mount

--- a/packages/react-renderer-demo/src/pages/renderer/installation.md
+++ b/packages/react-renderer-demo/src/pages/renderer/installation.md
@@ -2,7 +2,11 @@ import Grid from '@material-ui/core/Grid'
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/installation" />
 <Grid item xs={12} md={10}>
 
 # Installation

--- a/packages/react-renderer-demo/src/pages/renderer/renderer-api.md
+++ b/packages/react-renderer-demo/src/pages/renderer/renderer-api.md
@@ -2,7 +2,11 @@ import Grid from '@material-ui/core/Grid'
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/renderer-api" />
 <Grid item xs={12} md={10}>
 
 # Form Renderer API

--- a/packages/react-renderer-demo/src/pages/renderer/schema-validator.md
+++ b/packages/react-renderer-demo/src/pages/renderer/schema-validator.md
@@ -2,7 +2,11 @@ import Grid from '@material-ui/core/Grid'
 import CodeExample from '@docs/code-example';
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/schema-validator" />
 <Grid item xs={12} md={10}>
 
 # Schema validation

--- a/packages/react-renderer-demo/src/pages/renderer/unmounting.md
+++ b/packages/react-renderer-demo/src/pages/renderer/unmounting.md
@@ -3,7 +3,11 @@ import CodeExample from '@docs/code-example'
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/unmounting" />
 <Grid item xs={12} md={10}>
 
 # Description

--- a/packages/react-renderer-demo/src/pages/renderer/validators.md
+++ b/packages/react-renderer-demo/src/pages/renderer/validators.md
@@ -3,7 +3,11 @@ import CodeExample from '@docs/code-example';
 
 import ListOfContents from '@docs/list-of-contents';
 
+import ListOfContentsMobile from '@docs/list-of-contents-select';
+
 <Grid container item>
+
+<ListOfContentsMobile file="renderer/validators" />
 <Grid item xs={12} md={10}>
 
 # Validate field

--- a/packages/react-renderer-demo/src/pages/testing.md
+++ b/packages/react-renderer-demo/src/pages/testing.md
@@ -1,8 +1,11 @@
 import Grid from '@material-ui/core/Grid'
 import ListOfContents from '@docs/list-of-contents';
 import CodeExample from '@docs/code-example';
+import ListOfContentsMobile from '@docs/list-of-contents-select';
 
 <Grid container item>
+
+<ListOfContentsMobile file="testing" />
 <Grid item xs={12} md={10}>
 
 # Testing


### PR DESCRIPTION
On mobile phone the content is put to the end of pages and it's not very useful (especially on long screens):

![image](https://user-images.githubusercontent.com/32869456/85012669-a6690300-b163-11ea-8c83-2c4f25cc62cf.png)

This PR hides this list on smaller screen and puts a menu to the top of the page:

![showcontent](https://user-images.githubusercontent.com/32869456/85012641-9a7d4100-b163-11ea-9229-7ee40d42e62c.gif)

+ fix a bug when the code editor was bigger than the viewport.