### PR TITLE
[DOCS] Added TS example to docs.

### DIFF
--- a/packages/react-renderer-demo/src/examples/components/ts-example.js
+++ b/packages/react-renderer-demo/src/examples/components/ts-example.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const TsExample = () => {
+  return (
+    <iframe
+      src="https://codesandbox.io/embed/beautiful-silence-9hluy?fontsize=14&hidenavigation=1&theme=dark"
+      style={{ width: '100%', height: 500, border: 0, borderRadius: 4, overflow: 'hidden' }}
+      title="ddorg-react-form-renderer-ts-example"
+      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+      sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+    ></iframe>
+  );
+};
+
+export default TsExample;

--- a/packages/react-renderer-demo/src/pages/typescript.md
+++ b/packages/react-renderer-demo/src/pages/typescript.md
@@ -1,7 +1,19 @@
 import DocPage from '@docs/doc-page';
+import TsExample from '@docs/examples/components/ts-example'
 
 <DocPage>
 
 # TypeScript
+
+React form renderer and component mappers include Typescript typings. Each exported file has its own definitions.
+
+## Basic TypeScript example
+
+<TsExample />
+
+
+You can learn more about Renderer and its prop types [here](/components/renderer).
+
+Mapper component prop types are listed in the mappers section of the documentation. You can start with [checkbox](/mappers/checkbox).
 
 </DocPage>


### PR DESCRIPTION
closes #593 

Used codesanbox embed editor (stackblitz TS template did not work with extended types for some reason).

![screenshot-localhost_3000-2020 06 29-15_04_11](https://user-images.githubusercontent.com/22619452/86008945-d47afc80-ba19-11ea-9951-8cca847b8e68.png)
