### PR TITLE
Add fallback to empty notification response

### DIFF
--- a/packages/react-renderer-demo/src/components/notification-panel.js
+++ b/packages/react-renderer-demo/src/components/notification-panel.js
@@ -41,6 +41,10 @@ const getNotifications = () => {
   return fetch(`https://data-driven-forms.firebaseio.com/notifications.json${query}`)
     .then((data) => data.json())
     .then((data) => {
+      if (!data) {
+        return [];
+      }
+
       if (typeof data !== 'object') {
         return [];
       }


### PR DESCRIPTION
This prevents notifications issues when the response is `null` or empty.

Eventually, we will migrate to something else