### PR TITLE
Use package title in the main component heading

### DIFF
--- a/packages/react-renderer-demo/src/components/component-example-text.js
+++ b/packages/react-renderer-demo/src/components/component-example-text.js
@@ -7,12 +7,12 @@ import avalableMappers from '../helpers/available-mappers';
 const ComponentExampleText = ({ linkText, schema, variants, component, activeMapper, ContentText }) => (
   <React.Fragment>
     <Heading level="4" component="h1">
-      {linkText}
+      {`${avalableMappers.find(({ mapper }) => mapper === activeMapper).title} ${linkText}`}
     </Heading>
     <ComponentExample variants={variants} schema={schema} activeMapper={activeMapper} component={component} />
+    <br />
     {avalableMappers.map(({ mapper, title }) => (
       <div key={mapper} hidden={activeMapper !== mapper}>
-        <Heading level="5" component="h2">{`${title} ${linkText}`}</Heading>
         <ContentText activeMapper={activeMapper} component={component} />
       </div>
     ))}


### PR DESCRIPTION
- testing for algolia wait time
- `{`${avalableMappers.find(({ mapper }) => mapper === activeMapper).title} ${linkText}`}` is because there is a function that creates header id and it need to have only string child