### PR TITLE
Make dev setup more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -292,7 +291,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/blueprint-component-mapper/README.md
+++ b/packages/blueprint-component-mapper/README.md
@@ -129,7 +129,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -170,7 +169,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/mui-component-mapper/README.md
+++ b/packages/mui-component-mapper/README.md
@@ -132,7 +132,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -173,7 +172,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/parsers/README.md
+++ b/packages/parsers/README.md
@@ -104,7 +104,6 @@ yarn test --watchAll packages/parsers
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -136,7 +135,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/pf3-component-mapper/README.md
+++ b/packages/pf3-component-mapper/README.md
@@ -128,7 +128,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -169,7 +168,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/pf4-component-mapper/README.md
+++ b/packages/pf4-component-mapper/README.md
@@ -130,7 +130,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -171,7 +170,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/react-form-renderer/README.md
+++ b/packages/react-form-renderer/README.md
@@ -251,7 +251,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -292,7 +291,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/react-renderer-demo/src/pages/development-setup.md
+++ b/packages/react-renderer-demo/src/pages/development-setup.md
@@ -43,7 +43,6 @@ yarn dev
 ## How to clean?
 
 ```bash
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -82,7 +81,7 @@ All packages are releasing together and they share the version number.
 
 # Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 # Generating a mapper template
 

--- a/packages/suir-component-mapper/README.md
+++ b/packages/suir-component-mapper/README.md
@@ -129,7 +129,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -170,7 +169,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/templates/component-mapper/README.md
+++ b/templates/component-mapper/README.md
@@ -127,7 +127,6 @@ yarn start
 4. How to clean?
 
 ```console
-rm yarn.lock
 yarn lerna clean # will delete all node_modules
 ```
 
@@ -168,7 +167,7 @@ All packages are releasing together and they share the version number.
 
 #### Changes to documentation
 
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
+If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 


### PR DESCRIPTION
- rm yarn.lock should be the last option, we should not probably encourage it as a routine
- demo repository is unclear, changet to the full name