### PR TITLE
Make babel transform plugin result's code snippet unswitchable

### DIFF
--- a/packages/react-renderer-demo/src/pages/optimization.md
+++ b/packages/react-renderer-demo/src/pages/optimization.md
@@ -80,6 +80,7 @@ module.exports = {
 Result:
 
 ```jsx
+--- { "switchable": false } ---
 import { useField } from '@data-driven-forms/react-form-renderer';
 // ^^ this will be converted to >>
 import useField from '@data-driven-forms/react-form-renderer/dist/cjs/use-field';


### PR DESCRIPTION
This example is specifically made for UMD

**After**

![image](https://user-images.githubusercontent.com/32869456/86732677-e15aaa00-c030-11ea-9a6c-e5a4139bb9e7.png)
