### PR TITLE
Make PF4 wizard more translatable

### DIFF
--- a/packages/common/src/wizard/reducer.js
+++ b/packages/common/src/wizard/reducer.js
@@ -13,8 +13,10 @@ const createSchema = ({ formOptions, fields }) => {
     schema = [
       ...schema,
       {
+        name: field.name,
         title: field.title,
-        substepOf: field.substepOf,
+        substepOf: field.substepOf?.name || field.substepOf,
+        substepOfTitle: field.substepOf?.title || field.substepOf,
         index,
         primary: !schema[schema.length - 1] || !field.substepOf || field.substepOf !== schema[schema.length - 1].substepOf
       }

--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -24,7 +24,7 @@ const fieldArrayState = { schema: arraySchemaDDF, additionalOptions: {
 class App extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {schema: selectSchema, additionalOptions: {}} 
+        this.state = {schema: wizardSchema, additionalOptions: {}} 
     }
 
     render() {

--- a/packages/pf4-component-mapper/src/files/wizard.d.ts
+++ b/packages/pf4-component-mapper/src/files/wizard.d.ts
@@ -47,11 +47,16 @@ export interface WizardButtonsProps {
   selectNext: SelectNextFunction;
 }
 
+export interface SubstepOfObject {
+  name: string;
+  title?: ReactNode;
+}
+
 export interface WizardField {
   name: string | number;
   fields: Field[];
   nextStep?: WizardNextStep;
-  substepOf?: string | number;
+  substepOf?: string | number | SubstepOfObject;
   title?: ReactNode;
   showTitle?: boolean;
   customTitle?: ReactNode;

--- a/packages/pf4-component-mapper/src/files/wizard/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/files/wizard/wizard-nav.js
@@ -30,8 +30,8 @@ const WizardNavigationInternal = React.memo(
 
         return (
           <WizardNavItem
-            key={step.substepOf || step.title}
-            content={step.substepOf || step.title}
+            key={step.substepOf || step.name}
+            content={step.substepOfTitle || step.title}
             isCurrent={substeps ? activeStepIndex >= step.index && activeStepIndex < step.index + substeps.length : activeStepIndex === step.index}
             isDisabled={isValid ? maxStepIndex < step.index : step.index > activeStepIndex}
             onNavItemClick={(ind) => jumpToStep(ind, isValid)}
@@ -41,7 +41,7 @@ const WizardNavigationInternal = React.memo(
               <WizardNav returnList>
                 {substeps.map((substep) => (
                   <WizardNavItem
-                    key={substep.title}
+                    key={substep.name}
                     content={substep.title}
                     isCurrent={activeStepIndex === substep.index}
                     isDisabled={isValid ? maxStepIndex < substep.index : substep.index > activeStepIndex}

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -463,14 +463,18 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                               Array [
                                                 Object {
                                                   "index": 0,
+                                                  "name": "1",
                                                   "primary": true,
                                                   "substepOf": undefined,
+                                                  "substepOfTitle": undefined,
                                                   "title": "foo-step",
                                                 },
                                                 Object {
                                                   "index": 1,
+                                                  "name": "2",
                                                   "primary": true,
                                                   "substepOf": undefined,
+                                                  "substepOfTitle": undefined,
                                                   "title": "bar-step",
                                                 },
                                               ]
@@ -489,14 +493,18 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 Array [
                                                   Object {
                                                     "index": 0,
+                                                    "name": "1",
                                                     "primary": true,
                                                     "substepOf": undefined,
+                                                    "substepOfTitle": undefined,
                                                     "title": "foo-step",
                                                   },
                                                   Object {
                                                     "index": 1,
+                                                    "name": "2",
                                                     "primary": true,
                                                     "substepOf": undefined,
+                                                    "substepOfTitle": undefined,
                                                     "title": "bar-step",
                                                   },
                                                 ]
@@ -508,7 +516,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 content="foo-step"
                                                 isCurrent={true}
                                                 isDisabled={false}
-                                                key="foo-step"
+                                                key="1"
                                                 onNavItemClick={[Function]}
                                                 step={0}
                                               >
@@ -529,7 +537,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 content="bar-step"
                                                 isCurrent={false}
                                                 isDisabled={true}
-                                                key="bar-step"
+                                                key="2"
                                                 onNavItemClick={[Function]}
                                                 step={1}
                                               >
@@ -1660,14 +1668,18 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                           Array [
                                                             Object {
                                                               "index": 0,
+                                                              "name": "1",
                                                               "primary": true,
                                                               "substepOf": undefined,
+                                                              "substepOfTitle": undefined,
                                                               "title": "foo-step",
                                                             },
                                                             Object {
                                                               "index": 1,
+                                                              "name": "2",
                                                               "primary": true,
                                                               "substepOf": undefined,
+                                                              "substepOfTitle": undefined,
                                                               "title": "bar-step",
                                                             },
                                                           ]
@@ -1686,14 +1698,18 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                             Array [
                                                               Object {
                                                                 "index": 0,
+                                                                "name": "1",
                                                                 "primary": true,
                                                                 "substepOf": undefined,
+                                                                "substepOfTitle": undefined,
                                                                 "title": "foo-step",
                                                               },
                                                               Object {
                                                                 "index": 1,
+                                                                "name": "2",
                                                                 "primary": true,
                                                                 "substepOf": undefined,
+                                                                "substepOfTitle": undefined,
                                                                 "title": "bar-step",
                                                               },
                                                             ]
@@ -1705,7 +1721,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                             content="foo-step"
                                                             isCurrent={true}
                                                             isDisabled={false}
-                                                            key="foo-step"
+                                                            key="1"
                                                             onNavItemClick={[Function]}
                                                             step={0}
                                                           >
@@ -1726,7 +1742,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                             content="bar-step"
                                                             isCurrent={false}
                                                             isDisabled={true}
-                                                            key="bar-step"
+                                                            key="2"
                                                             onNavItemClick={[Function]}
                                                             step={1}
                                                           >

--- a/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/wizard.test.js
@@ -205,6 +205,63 @@ describe('<Wizard />', () => {
     expect(enterHandle.default).toHaveBeenCalledWith(event, formOptions, '1', findCurrentStep, handleNext, handleSubmit);
   });
 
+  it('should render correctly with objects as substepOf and nodes titles', () => {
+    schema = {
+      fields: [
+        {
+          name: 'wizard',
+          component: 'wizard',
+          inModal: true,
+          fields: [
+            {
+              title: <h1>Custom title</h1>,
+              name: 'first-step',
+              fields: [],
+              nextStep: 'middle-step',
+              substepOf: { name: 'summary', title: <h2>Custom title 2</h2> }
+            },
+            {
+              name: 'middle-step',
+              title: 'middle-step',
+              fields: [],
+              substepOf: 'summary',
+              nextStep: 'end'
+            },
+            {
+              name: 'end',
+              title: <h3>Custom title 3</h3>,
+              fields: []
+            }
+          ]
+        }
+      ]
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} schema={schema} />);
+
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .first()
+        .props().content
+    ).toEqual(<h2>Custom title 2</h2>);
+
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .first()
+        .children()
+        .find(WizardNavItem)
+    ).toHaveLength(2);
+
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .last()
+        .props().content
+    ).toEqual(<h3>Custom title 3</h3>);
+  });
+
   it('should render correctly in modal and unmount', () => {
     schema = {
       fields: [
@@ -315,8 +372,8 @@ describe('<Wizard />', () => {
       loading: false,
       maxStepIndex: 1,
       navSchema: [
-        { index: 0, primary: true, substepOf: undefined, title: 'foo-step' },
-        { index: 1, primary: true, substepOf: undefined, title: 'bar-step' }
+        { index: 0, name: '1', primary: true, substepOf: undefined, substepOfTitle: undefined, title: 'foo-step' },
+        { index: 1, name: '2', primary: true, substepOf: undefined, substepOfTitle: undefined, title: 'bar-step' }
       ],
       prevSteps: ['1'],
       registeredFieldsHistory: { 1: ['foo-field'] }

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-wizard.md
@@ -127,6 +127,36 @@ Schema: [
 Progressive Wizard works same way. It checks if previous step has the same \`substepOf\` value and if so, it grouped them together.
 If the value is different, a new primary step is created with the step as a substep.
 
+**React node as substepOf**
+
+You can put a React node as `substepOf`. In this case you have to provide an object with keys `name: string` and `title?: ReactNode`.
+
+```jsx
+<h2>Custom title</h2>      // name: Configuration
+  Security
+  Credentials
+Summary
+```
+
+```jsx
+Schema: [
+  {
+    name: 'security',
+    title: 'Security',
+    nextStep: 'credentials',
+    substepOf: { name: 'Configuration', title: <h2>Custom title</h2> }
+  },{
+    name: 'credentials',
+    title: 'Credentials',
+    nextStep: 'summary',
+    substepOf: 'Configuration' // title can be put only in the first step
+  },{
+    name: 'summary',
+    title: 'Summary'
+  },
+]
+```
+
 **First step**
 
 First step should have on the first position of the `fields` array.


### PR DESCRIPTION
- name of steps is used as keys (so titles supports ReactNodes)
- substepOf has new definition, can use ReactNode as title