### PR TITLE
Introduce resolve props

### DIFF
--- a/packages/react-form-renderer/src/files/field.d.ts
+++ b/packages/react-form-renderer/src/files/field.d.ts
@@ -2,12 +2,21 @@ import { Validator } from "./validators";
 import { ConditionDefinition } from './condition';
 import { DataType } from "./data-types";
 import { AnyObject } from "./common";
+import { FieldMetaState, FieldInputProps } from "react-final-form";
+import { FormOptions } from "./renderer-context";
 
 export type FieldAction = [string, ...any[]];
 
 export interface FieldActions {
   [key: string]: FieldAction;
 }
+
+export interface FieldApi<FieldValue, T extends HTMLElement = HTMLElement> {
+  meta: FieldMetaState<FieldValue>;
+  input: FieldInputProps<FieldValue, T>;
+}
+
+export type ResolvePropsFunction = (props: AnyObject, fieldApi: FieldApi<any>, formOptions: FormOptions) => AnyObject;
 
 interface Field extends AnyObject {
   name: string;
@@ -20,6 +29,7 @@ interface Field extends AnyObject {
   clearedValue?: any;
   clearOnUnmount?: boolean;
   actions?: FieldActions;
+  resolveProps?: ResolvePropsFunction;
 }
 
 export default Field;

--- a/packages/react-form-renderer/src/files/use-field-api.js
+++ b/packages/react-form-renderer/src/files/use-field-api.js
@@ -57,8 +57,8 @@ const reducer = (state, { type, specialType, validate, arrayValidator, initialVa
   }
 };
 
-const useFieldApi = ({ name, initializeOnMount, component, render, validate, ...props }) => {
-  const { actionMapper, validatorMapper, formOptions } = useContext(RendererContext);
+const useFieldApi = ({ name, initializeOnMount, component, render, validate, resolveProps, ...props }) => {
+  const { validatorMapper, formOptions } = useContext(RendererContext);
 
   const [{ type, initialValue, validate: stateValidate, arrayValidator }, dispatch] = useReducer(
     reducer,
@@ -154,17 +154,6 @@ const useFieldApi = ({ name, initializeOnMount, component, render, validate, ...
     []
   );
 
-  /**
-   * Map actions to props
-   */
-  let overrideProps = {};
-  if (props.actions) {
-    Object.keys(props.actions).forEach((prop) => {
-      const [action, ...args] = props.actions[prop];
-      overrideProps[prop] = actionMapper[action](...args);
-    });
-  }
-
   const { initialValue: _initialValue, clearOnUnmount, dataType, clearedValue, isEqual: _isEqual, ...cleanProps } = props;
 
   /**
@@ -172,7 +161,7 @@ const useFieldApi = ({ name, initializeOnMount, component, render, validate, ...
    */
   return {
     ...cleanProps,
-    ...overrideProps,
+    ...(resolveProps ? resolveProps(cleanProps, fieldProps, formOptions) : {}),
     ...fieldProps,
     ...(arrayValidator ? { arrayValidator } : {}),
     input: {

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -35,7 +35,7 @@ FormConditionWrapper.propTypes = {
 };
 
 const SingleField = ({ component, condition, hideField, ...rest }) => {
-  const { componentMapper } = useContext(RendererContext);
+  const { actionMapper, componentMapper } = useContext(RendererContext);
 
   let componentProps = {
     component,
@@ -47,15 +47,52 @@ const SingleField = ({ component, condition, hideField, ...rest }) => {
   if (typeof componentBinding === 'object' && Object.prototype.hasOwnProperty.call(componentBinding, 'component')) {
     const { component, ...mapperProps } = componentBinding;
     Component = component;
-    componentProps = { ...mapperProps, ...componentProps };
+    componentProps = {
+      ...mapperProps,
+      ...componentProps,
+      // merge mapper and field actions
+      ...(mapperProps.actions && rest.actions ? { actions: { ...mapperProps.actions, ...rest.actions } } : {}),
+      // merge mapper and field resolveProps
+      ...(mapperProps.resolveProps && rest.resolveProps
+        ? {
+            resolveProps: (...args) => ({
+              ...mapperProps.resolveProps(...args),
+              ...rest.resolveProps(...args)
+            })
+          }
+        : {})
+    };
   } else {
     Component = componentBinding;
+  }
+
+  /**
+   * Map actions to props
+   */
+  let overrideProps = {};
+  let mergedResolveProps; // new object has to be created because of references
+  if (componentProps.actions) {
+    Object.keys(componentProps.actions).forEach((prop) => {
+      const [action, ...args] = componentProps.actions[prop];
+      overrideProps[prop] = actionMapper[action](...args);
+    });
+
+    // Merge componentProps resolve props and actions resolve props
+    if (componentProps.resolveProps && overrideProps.resolveProps) {
+      mergedResolveProps = (...args) => ({
+        ...componentProps.resolveProps(...args),
+        ...overrideProps.resolveProps(...args)
+      });
+    }
+
+    // do not pass actions object to components
+    delete componentProps.actions;
   }
 
   return (
     <FormConditionWrapper condition={condition}>
       <FormFieldHideWrapper hideField={hideField}>
-        <Component {...componentProps} />
+        <Component {...componentProps} {...overrideProps} {...(mergedResolveProps && { resolveProps: mergedResolveProps })} />
       </FormFieldHideWrapper>
     </FormConditionWrapper>
   );
@@ -67,7 +104,11 @@ SingleField.propTypes = {
   hideField: PropTypes.bool,
   dataType: PropTypes.string,
   validate: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
-  initialValue: PropTypes.any
+  initialValue: PropTypes.any,
+  actions: PropTypes.shape({
+    [PropTypes.string]: PropTypes.func
+  }),
+  resolveProps: PropTypes.func
 };
 
 const renderForm = (fields) => fields.map((field) => (Array.isArray(field) ? renderForm(field) : <SingleField key={field.name} {...field} />));

--- a/packages/react-renderer-demo/src/components/navigation/schemas/schema.schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/schema.schema.js
@@ -29,6 +29,10 @@ const schemaNav = [
     linkText: 'Constants'
   },
   {
+    component: 'resolve-props',
+    linkText: 'Resolve props'
+  },
+  {
     subHeader: true,
     title: 'Validation',
     noRoute: true

--- a/packages/react-renderer-demo/src/examples/components/resolve-props.js
+++ b/packages/react-renderer-demo/src/examples/components/resolve-props.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import FormRenderer from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+
+import TextField from '@data-driven-forms/mui-component-mapper/dist/cjs/text-field';
+import FormTemplate from '@data-driven-forms/mui-component-mapper/dist/cjs/form-template';
+
+const schema = {
+  fields: [
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'name',
+      label: 'Validate me',
+      isRequired: true,
+      validate: [{ type: 'required' }],
+      helperText: 'This field will indicate successful validation after onBlur event',
+      resolveProps: (props, { meta, input }, formOptions) => {
+        if (meta.valid && meta.touched) {
+          return {
+            helperText: 'Validated',
+            style: {
+              background: 'greenyellow'
+            }
+          };
+        }
+
+        return {};
+      }
+    }
+  ]
+};
+
+const componentMapper = {
+  [componentTypes.TEXT_FIELD]: TextField
+};
+
+const ResolveProps = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+
+export default ResolveProps;

--- a/packages/react-renderer-demo/src/pages/schema/introduction.md
+++ b/packages/react-renderer-demo/src/pages/schema/introduction.md
@@ -31,7 +31,8 @@ Other attribues, such as title or description, can be used in [form templates](/
     dataType: 'string',
     hideField: true,
     initializeOnMount: true,
-    initialValue: 'default-login'
+    initialValue: 'default-login',
+    resolveProps: (props) => ({ label: props.label || 'default label' }),
     validate: [ ... ],
     // + component specific attributes
     ...componentSpecificAttributes
@@ -152,6 +153,16 @@ When `true`, the value will be re-initialized every time the component is mounte
 *any*
 
 Sets an initial value of the field. Read more [here](https://final-form.org/docs/react-final-form/types/FieldProps#initialvalue).
+
+---
+
+### resolveProps
+
+*function (props, {meta, input}, formOptions) => props*
+
+**Only applicable for fields connected to the form state.**
+
+A function allowing to compute field properties from the current state of the field. Read more [here](/schema/resolve-props).
 
 ---
 

--- a/packages/react-renderer-demo/src/pages/schema/resolve-props.md
+++ b/packages/react-renderer-demo/src/pages/schema/resolve-props.md
@@ -1,0 +1,73 @@
+import DocPage from '@docs/doc-page';
+import InputMeta from '../input-meta.md';
+import CodeExample from '@docs/code-example';
+
+<DocPage>
+
+# Resolve props
+
+*function (props, {meta, input}, formOptions) => props*
+
+**Only applicable for fields connected to the form state.**
+
+A function allowing to compute field properties from the current state of the field.
+
+## Schema
+
+```jsx
+const schema = {
+    fields: [{
+        component: 'text-field',
+        resolveProps: (props, {meta, input}, formOptions) => ({ helperText: input.value ? 'You set a value' : 'No value' })
+    }]
+}
+```
+
+## Arguments
+
+### Props
+
+All field props passed in the schema.
+
+### Meta and input
+
+<InputMeta />
+
+### FormOptions
+
+Object containing access to the form state. Read more [here](/hooks/use-form-api).
+
+## Rules
+
+I. `resolveProps` cannot return `actions`. You can access `actions`'s code in the `resolveProps` prop if you need it.
+
+II. Do not use `async` functions to get the props.
+
+III. Do not trigger any side effects, as it could introduce bugs.
+
+IV. `resolveProps` are merged together with following priority: `actions.resolveProps` (highest) > `field.resolveProps` > `mapper.resolveProps` (lowest)
+
+## Global resolveProps
+
+You can modify behavior for all components of the same type in your `componentMapper` via [global component props](/mappers/global-component-props).
+
+```jsx
+const componentMapper = {
+    'text-field': {
+        component: TextField,
+        resolveProps: () => { ... }
+    }
+}
+```
+
+## Change props according to state of other components
+
+You can get states of all other fields in the form via functions from `formOptions`. Don't forget to set the right [subscription](/components/renderer#optionalprops) to trigger `resolveProps` functions from changing other fields.
+
+## Example
+
+Following example shows how can be a behavior of components changed using `resolveProps`. In this example, the component will have different color and helper text after it is validated.
+
+<CodeExample mode="preview" source="components/resolve-props" />
+
+</DocPage>


### PR DESCRIPTION
closes #646

For more details read the documentation page

This PR
- add `resolveProps` for form-connected fields
- moves actionsMapper functionality to renderForm (so you can use actions for subForms etc.)
- allows to merge mapper's actions and field's actions

**Example of resolve props**

```jsx
{
    name: 'text_box_2',
    label: 'Validate me',
    isRequired: true,
    validate: [{
        type: 'required'
    }],
    component: components.TEXT_FIELD,
    resolveProps: (_props, {
        meta
    }) => {
        if (meta.valid && meta.touched) {
            return {
                helperText: 'Validated',
                validated: 'success'
            };
        }

        return {};
    }
}
```

![poc](https://user-images.githubusercontent.com/32869456/87561550-229c2b00-c6bd-11ea-941e-9b15c3063e09.gif)

