### PR TITLE
First commit on new conditions handler

### DIFF
--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -9,17 +9,63 @@ const fileSchema = {
   fields: [
     {
       component: 'text-field',
-      name: 'file-upload',
-      type: 'file',
-      label: 'file upload'
-    }
-  ]
+      name: 'field1',
+      label: 'Field1',
+      initialValue: '"abc" to trigger condition "cond1"',
+      type: 'search',
+    },
+    {
+      component: 'text-field',
+      name: 'field2',
+      label: 'Field2',
+      initialValue: '"xyz" to trigger condition "cond1"',
+      type: 'search',
+      condition: {when: 'field2', is: 'aaa'},
+    },
+    {
+      component: 'text-field',
+      name: 'field3',
+      label: 'Field3',
+      initialValue: '"123" to trigger condition "cond2"',
+      type: 'search',
+    },
+    {
+      component: 'text-field',
+      name: 'field4',
+      label: 'Field4',
+      initialValue: 'Visible when field3="aa" (old style condition)',
+    },
+  ],
+  conditions: {
+    cond1: {
+      when: 'field1',
+      is: 'abc',
+      then: {
+        field3: {
+          disabled: true,
+          set: 'New value for field3',
+        },
+        field4: {
+          visible: false,
+        },
+      },
+    },
+    cond2: {
+      when: 'field3',
+      is: '123',
+      then: {
+        field1: {
+          hidden: true,
+        },
+      },
+    },
+  },
 };
 
 const App = () => {
   // const [values, setValues] = useState({});
   return (
-    <div style={{ padding: 20 }}>
+    <div style={{padding: 20}}>
       <FormRenderer
         componentMapper={componentMapper}
         onSubmit={(values, ...args) => console.log(values, args)}

--- a/packages/react-form-renderer/src/files/conditions-mapper.js
+++ b/packages/react-form-renderer/src/files/conditions-mapper.js
@@ -1,0 +1,89 @@
+/*
+  conditionsMapper will remap a conditions object and create an object with each depending fieldName as a key.
+
+  Since one field can be involed in more than one condition, an array of condition references will be created under each fieldName key
+
+  Since more than one field can be involved in the same condition, the same condition might be referenced from
+  several condition arrays.
+*/
+
+export const conditionsMapper = ({conditions}) => {
+  if (!conditions) return {};
+
+  function isObject(obj) {
+    return obj !== null && typeof obj === 'object' && !Array.isArray(obj);
+  }
+
+  function isArray(obj) {
+    return Array.isArray(obj);
+  }
+
+  function traverse({obj, fnc, key}) {
+    fnc && fnc({obj, key});
+
+    if (isArray(obj)) {
+      traverseArray({
+        obj,
+        fnc,
+        key,
+      });
+    } else if (isObject(obj)) {
+      traverseObject({
+        obj,
+        fnc,
+        key,
+      });
+    }
+  }
+
+  function traverseArray({obj, fnc, key}) {
+    for (var index = 0, len = obj.length; index < len; index++) {
+      const item = obj[index];
+      traverse({
+        obj: item,
+        fnc,
+        key: index,
+      });
+    }
+  }
+
+  function traverseObject({obj, fnc, key}) {
+    for (var index in obj) {
+      if (obj.hasOwnProperty(index)) {
+        const item = obj[index];
+        traverse({
+          obj: item,
+          fnc,
+          key: index,
+        });
+      }
+    }
+  }
+
+  const indexedConditions = {};
+  const conditionArray = Object.entries(conditions);
+
+  conditionArray
+    .map(([key, condition]) => {
+      return {
+        key: key,
+        ...condition,
+      };
+    })
+    .forEach(condition => {
+      traverse({
+        obj: condition,
+        fnc: ({obj, key}) => {
+          if (key === 'when') {
+            const fieldNames = isArray(obj) ? obj : [obj];
+            fieldNames.map(fieldName => {
+              indexedConditions[fieldName] = indexedConditions[fieldName] || [];
+              indexedConditions[fieldName].push(condition);
+            });
+          }
+        },
+      });
+    });
+
+  return indexedConditions;
+};

--- a/packages/react-form-renderer/src/files/form-renderer.js
+++ b/packages/react-form-renderer/src/files/form-renderer.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, {useState, useRef, useReducer} from 'react';
 import Form from './form';
 import arrayMutators from 'final-form-arrays';
 import PropTypes from 'prop-types';
@@ -9,6 +9,9 @@ import renderForm from '../form-renderer/render-form';
 import defaultSchemaValidator from './default-schema-validator';
 import SchemaErrorComponent from '../form-renderer/schema-error-component';
 import defaultValidatorMapper from './validator-mapper';
+import RegisterConditions from './register-conditions';
+import SetFieldValues from './set-field-values';
+import uiStateReducer from './ui-state-reducer';
 
 const FormRenderer = ({
   componentMapper,
@@ -26,15 +29,25 @@ const FormRenderer = ({
   ...props
 }) => {
   const [fileInputs, setFileInputs] = useState([]);
+  const [uiState, dispatchCondition] = useReducer(uiStateReducer, {
+    fields: {},
+    setFieldValues: {},
+  });
   const focusDecorator = useRef(createFocusDecorator());
   let schemaError;
 
-  const validatorMapperMerged = { ...defaultValidatorMapper, ...validatorMapper };
+  const validatorMapperMerged = {...defaultValidatorMapper, ...validatorMapper};
 
   try {
     const validatorTypes = Object.keys(validatorMapperMerged);
     const actionTypes = actionMapper ? Object.keys(actionMapper) : [];
-    defaultSchemaValidator(schema, componentMapper, validatorTypes, actionTypes, schemaValidatorMapper);
+    defaultSchemaValidator(
+      schema,
+      componentMapper,
+      validatorTypes,
+      actionTypes,
+      schemaValidatorMapper
+    );
   } catch (error) {
     schemaError = error;
     console.error(error);
@@ -45,18 +58,24 @@ const FormRenderer = ({
     return <SchemaErrorComponent name={schemaError.name} message={schemaError.message} />;
   }
 
-  const registerInputFile = (name) => setFileInputs((prevFiles) => [...prevFiles, name]);
+  const registerInputFile = name => setFileInputs(prevFiles => [...prevFiles, name]);
 
-  const unRegisterInputFile = (name) => setFileInputs((prevFiles) => [...prevFiles.splice(prevFiles.indexOf(name))]);
+  const unRegisterInputFile = name =>
+    setFileInputs(prevFiles => [...prevFiles.splice(prevFiles.indexOf(name))]);
 
   return (
     <Form
       {...props}
-      onSubmit={(values, formApi, ...args) => onSubmit(values, { ...formApi, fileInputs }, ...args)}
-      mutators={{ ...arrayMutators }}
+      onSubmit={(values, formApi, ...args) => onSubmit(values, {...formApi, fileInputs}, ...args)}
+      mutators={{...arrayMutators}}
       decorators={[focusDecorator.current]}
-      subscription={{ pristine: true, submitting: true, valid: true, ...subscription }}
-      render={({ handleSubmit, pristine, valid, form: { reset, mutators, getState, submit, ...form } }) => (
+      subscription={{pristine: true, submitting: true, valid: true, ...subscription}}
+      render={({
+        handleSubmit,
+        pristine,
+        valid,
+        form: {reset, mutators, getState, submit, registerField, ...form},
+      }) => (
         <RendererContext.Provider
           value={{
             componentMapper,
@@ -73,6 +92,9 @@ const FormRenderer = ({
                 reset();
               },
               getState,
+              registerField,
+              uiState,
+              dispatchCondition,
               valid,
               clearedValue,
               submit,
@@ -81,11 +103,14 @@ const FormRenderer = ({
               clearOnUnmount,
               renderForm,
               ...mutators,
-              ...form
-            }
+              ...form,
+            },
           }}
         >
+          <RegisterConditions schema={schema} />
+          <SetFieldValues />
           <FormTemplate formFields={renderForm(schema.fields)} schema={schema} />
+          <div>{JSON.stringify(uiState, null, 2)}</div>
         </RendererContext.Provider>
       )}
     />
@@ -98,34 +123,34 @@ FormRenderer.propTypes = {
   onReset: PropTypes.func,
   schema: PropTypes.object.isRequired,
   clearOnUnmount: PropTypes.bool,
-  subscription: PropTypes.shape({ [PropTypes.string]: PropTypes.bool }),
+  subscription: PropTypes.shape({[PropTypes.string]: PropTypes.bool}),
   clearedValue: PropTypes.any,
   componentMapper: PropTypes.shape({
-    [PropTypes.string]: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func])
+    [PropTypes.string]: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func]),
   }).isRequired,
   FormTemplate: PropTypes.func.isRequired,
   validatorMapper: PropTypes.shape({
-    [PropTypes.string]: PropTypes.func
+    [PropTypes.string]: PropTypes.func,
   }),
   actionMapper: PropTypes.shape({
-    [PropTypes.string]: PropTypes.func
+    [PropTypes.string]: PropTypes.func,
   }),
   schemaValidatorMapper: PropTypes.shape({
     components: PropTypes.shape({
-      [PropTypes.string]: PropTypes.func
+      [PropTypes.string]: PropTypes.func,
     }),
     validators: PropTypes.shape({
-      [PropTypes.string]: PropTypes.func
+      [PropTypes.string]: PropTypes.func,
     }),
     actions: PropTypes.shape({
-      [PropTypes.string]: PropTypes.func
-    })
-  })
+      [PropTypes.string]: PropTypes.func,
+    }),
+  }),
 };
 
 FormRenderer.defaultProps = {
   initialValues: {},
-  clearOnUnmount: false
+  clearOnUnmount: false,
 };
 
 export default FormRenderer;

--- a/packages/react-form-renderer/src/files/register-conditions.js
+++ b/packages/react-form-renderer/src/files/register-conditions.js
@@ -1,0 +1,59 @@
+import React, {useEffect} from 'react';
+import {useFormApi} from '../';
+import {Field} from 'react-final-form';
+
+import {conditionsMapper} from './conditions-mapper';
+import {parseCondition} from '../form-renderer/condition2';
+
+const RegisterConditions = ({schema}) => {
+  const {getState, registerField, dispatchCondition} = useFormApi();
+
+  useEffect(() => {
+    const indexedConditions = conditionsMapper({conditions: schema.conditions});
+    console.log(indexedConditions);
+
+    //We need an array of conditions, including the fieldName
+    const unsubscribeFields = Object.entries(indexedConditions)
+      .map(([fieldName, fieldValue]) => {
+        return {
+          fieldName,
+          ...fieldValue,
+        };
+      })
+      .map(field => {
+        console.log('creating field-listener for condition parsing: ' + field.fieldName);
+
+        return registerField(
+          field.fieldName,
+          fieldState => {
+            if (!fieldState || !fieldState.data || !fieldState.data.conditions) return;
+
+            console.log('Parsing conditions for field ' + field.fieldName);
+
+            fieldState.data.conditions.map(condition => {
+              const conditionResult = parseCondition(condition, getState().values);
+              dispatchCondition({
+                type: 'conditionResult',
+                source: condition.key,
+                uiState: conditionResult.uiState,
+              });
+            });
+          },
+          {value: true, data: true},
+          {
+            data: {
+              conditions: indexedConditions[field.fieldName]
+                ? indexedConditions[field.fieldName]
+                : null,
+            },
+          }
+        );
+      });
+
+    return () => unsubscribeFields.map(unsubscribeField => unsubscribeField());
+  }, [schema]);
+
+  return null;
+};
+
+export default RegisterConditions;

--- a/packages/react-form-renderer/src/files/set-field-values.js
+++ b/packages/react-form-renderer/src/files/set-field-values.js
@@ -1,0 +1,25 @@
+import React, {useEffect} from 'react';
+import lodashIsEmpty from 'lodash/isEmpty';
+
+import {useFormApi} from '../';
+
+const SetFieldValues = () => {
+  const {batch, change, uiState, dispatchCondition} = useFormApi();
+  useEffect(() => {
+    if (lodashIsEmpty(uiState.setFieldValues)) return;
+
+    setTimeout(() => {
+      batch(() => {
+        Object.entries(uiState.setFieldValues).forEach(([name, value]) => {
+          console.log('Setting new value for field ' + name);
+          change(name, value);
+        });
+        dispatchCondition({type: 'fieldValuesUpdated'});
+      });
+    });
+  }, [uiState.setFieldValues]);
+
+  return null;
+};
+
+export default SetFieldValues;

--- a/packages/react-form-renderer/src/files/ui-state-reducer.js
+++ b/packages/react-form-renderer/src/files/ui-state-reducer.js
@@ -1,0 +1,111 @@
+const uiStateReducer = (state, action) => {
+  switch (action.type) {
+    case 'conditionResult': {
+      const {
+        source,
+        uiState: {add, remove},
+      } = action;
+
+      const validAttributes = [
+        'visible',
+        'disabled',
+        'hidden',
+        'enabled',
+        'icon',
+        'help',
+        'colorBar',
+        'required',
+        'max',
+        'min',
+      ];
+
+      //enabled and hidden are not used internally, but accepted as input from the conditions object
+      const inversedTypes = {
+        enabled: 'disabled',
+        hidden: 'visible',
+      };
+
+      const removeItem = state => {
+        if (!remove) return;
+
+        Object.entries(remove).forEach(([key, item]) => {
+          //If the field/section doesn't exist, we don't need to do anymore
+          if (!state[key]) return;
+
+          validAttributes.forEach(type => {
+            //Don't process uiTypes if they don't exist in the dispatched message
+            if (item[type] === undefined) return;
+
+            const inversedType = inversedTypes[type];
+            type = inversedType || type;
+
+            if (remove[key][type]) {
+              const index = state[key][type].findIndex(item => item.source === source);
+              if (index !== -1) state[key][type].splice(index, 1);
+
+              //If this was the last item of this type, remove the type
+              if (state[key][type].length === 0) delete state[key][type];
+            }
+          });
+
+          //If no more uiStateType keys exists for this field, remove the field
+          if (Object.keys(state[key]).length === 0) delete state[key];
+        });
+      };
+
+      const addItem = state => {
+        if (!add) return;
+
+        Object.entries(add).forEach(([key, item]) => {
+          //Create the item object for this item if it doesn't exist
+          if (!state[key]) state[key] = {};
+
+          validAttributes.forEach(type => {
+            //Don't add uiTypes if they don't exist in the dispatched message
+            if (item[type] === undefined) return;
+
+            //Handle inversed types (disabled/enabled, visible/hidden)
+            const inversedType = inversedTypes[type];
+            const value = inversedType ? !item[type] : item[type];
+            type = inversedType || type;
+
+            if (!state[key][type]) {
+              //If this type doesn't exists for this item, we create a new array with only this source. No need to search fot the source
+              state[key][type] = [{source, value}];
+            } else {
+              const index = state[key][type].findIndex(item => item.source === source);
+              if (index !== -1) {
+                //If this type for this item from this source existed, update the state (could change if condition went from "then" to "else")
+                state[key][type][index].value = value;
+              } else {
+                //Otherwise, add the state from this source at the begining of the array (i.e. this will supress result from other sources)
+                state[key][type].unshift({source, value});
+              }
+            }
+          });
+
+          //Set-instructions are ephemeral and goes into a separate list which is emptied when processed
+          if (item.set) {
+            state.setFieldValues = {...state.fileldValues, [key]: item.set};
+          }
+        });
+      };
+
+      let mutatedState = state;
+      if (remove) {
+        removeItem(mutatedState);
+      }
+      //If uiStates should be added, go through all add fields and all possible types for these fields
+      if (add) {
+        addItem(mutatedState);
+      }
+      console.log(mutatedState);
+      return {...mutatedState};
+    }
+    case 'fieldValuesUpdated': {
+      return {...state, setFieldValues: {}};
+    }
+  }
+};
+
+export default uiStateReducer;

--- a/packages/react-form-renderer/src/form-renderer/condition2.js
+++ b/packages/react-form-renderer/src/form-renderer/condition2.js
@@ -1,0 +1,148 @@
+import React, {useEffect, useReducer} from 'react';
+import PropTypes from 'prop-types';
+import lodashIsEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+
+const isEmptyValue = value =>
+  typeof value === 'number' || value === true ? false : lodashIsEmpty(value);
+
+const fieldCondition = (value, {is, isNotEmpty, isEmpty, pattern, notMatch, flags}) => {
+  if (isNotEmpty) {
+    return !isEmptyValue(value);
+  }
+
+  if (isEmpty) {
+    return isEmptyValue(value);
+  }
+
+  if (pattern) {
+    const regExpPattern = RegExp(pattern, flags);
+
+    return notMatch ? !regExpPattern.test(value) : regExpPattern.test(value);
+  }
+
+  const isMatched = Array.isArray(is) ? !!is.includes(value) : value === is;
+
+  return notMatch ? !isMatched : isMatched;
+};
+
+export const parseCondition = (condition, values) => {
+  //Positive result is alwaus a triggering condition
+  //since a the clause always exists
+  let positiveResult = {
+    uiState: {
+      add: condition.then,
+      remove: condition.else,
+    },
+    triggered: true,
+  };
+
+  //if else clause exists, this is a triggered condition
+  //if no else clause exists, this is a non-triggering condition
+  let negativeResult = {
+    uiState: {
+      add: condition.else,
+      remove: condition.then,
+    },
+    triggered: condition.else ? true : false,
+  };
+
+  if (Array.isArray(condition)) {
+    return !condition
+      .map(condition => parseCondition(condition, values))
+      .some(({triggered}) => triggered === false)
+      ? positiveResult
+      : negativeResult;
+  }
+
+  if (condition.and) {
+    return !condition.and
+      .map(condition => parseCondition(condition, values))
+      .some(({triggered}) => triggered === false)
+      ? positiveResult
+      : negativeResult;
+  }
+
+  if (condition.or) {
+    return condition.or
+      .map(condition => parseCondition(condition, values))
+      .some(({triggered}) => triggered === true)
+      ? positiveResult
+      : negativeResult;
+  }
+
+  if (condition.not) {
+    return !parseCondition(condition.not, values).triggered ? positiveResult : negativeResult;
+  }
+
+  if (typeof condition.when === 'string') {
+    // console.log({values, when: condition.when});
+    return fieldCondition(get(values, condition.when), condition) ? positiveResult : negativeResult;
+  }
+
+  if (Array.isArray(condition.when)) {
+    return condition.when
+      .map(fieldName => fieldCondition(get(values, fieldName), condition))
+      .find(condition => !!condition)
+      ? positiveResult
+      : negativeResult;
+  }
+
+  return negativeResult;
+};
+
+const conditionProps = {
+  when: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  is: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.number,
+    PropTypes.bool,
+  ]),
+  isNotEmpty: PropTypes.bool,
+  isEmpty: PropTypes.bool,
+  pattern: (props, name, componentName) => {
+    if (typeof props[name] === 'string') {
+      return;
+    }
+
+    if (props[name] instanceof RegExp) {
+      return;
+    }
+
+    return new Error(`Invalid prop pattern supplied to condition in \`${componentName}\`. Validation failed.
+    pattern has to be RegExp or string. Received \`${typeof props[name]}\`.`);
+  },
+  notMatch: PropTypes.any,
+  then: PropTypes.shape({
+    visible: PropTypes.bool,
+    set: PropTypes.object,
+  }),
+  else: PropTypes.shape({
+    visible: PropTypes.bool,
+    set: PropTypes.object,
+  }),
+};
+
+const nestedConditions = {
+  or: PropTypes.oneOfType([
+    PropTypes.shape(conditionProps),
+    PropTypes.arrayOf(PropTypes.shape(conditionProps)),
+  ]),
+  and: PropTypes.oneOfType([
+    PropTypes.shape(conditionProps),
+    PropTypes.arrayOf(PropTypes.shape(conditionProps)),
+  ]),
+  not: PropTypes.oneOfType([
+    PropTypes.shape(conditionProps),
+    PropTypes.arrayOf(PropTypes.shape(conditionProps)),
+  ]),
+  sequence: PropTypes.arrayOf(PropTypes.shape(conditionProps)),
+};
+
+const conditionsProps = {
+  ...conditionProps,
+  ...nestedConditions,
+};


### PR DESCRIPTION
My proposal for a new conditions handler:
- conditions are defined "globally" instead of "locally" per field
- field listeners are registered only for fields involved in "when-clauses"
- the relevant conditions are added as custom data for each field listener (field.data.conditions)
- when conditions triggers, the resulting ui-effects are added to uiState for affected fields via uiStateReducer
- when conditions de-driggers, the ui-effects are removed
- uiState is available in useFormApi(). Any component can check the uiState to decide how/if it should render
- set-instructions in conditions are "one-shot". I.e. when the new field value is set, the set instruction is removed.

TODO:
- TypeScript (I don't know TS, so I'm not the right man to add typing)
- Backwards compability for old conditions structure  (should probably be handled at the top of RegisterConditions).
- My conditionParser differs some from the old one. I put mine in conditions2.js in order to not break other stuff.
- uiStateReducer originally user Immer in my code. I took some shortcuts with the immutability when I removed Immer. This should probably be addressed.
- Documentation
- Decide how to use uiState (hiding and disabling fields etc)
- Circular conditions are possible. It's kind of hard to walk into this problem, but it should probably be handled some way.

I'm sure there are lots to discuss before this reaches production.