### PR TITLE
Use pf4 select component

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/select-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/select-schema.js
@@ -164,5 +164,6 @@ const selectSchema = {
 };
 
 export default {
-  ...selectSchema
+  ...selectSchema,
+  fields: [selectSchema.fields[0]]
 };

--- a/packages/pf4-component-mapper/demo/index.js
+++ b/packages/pf4-component-mapper/demo/index.js
@@ -24,7 +24,7 @@ const fieldArrayState = { schema: arraySchemaDDF, additionalOptions: {
 class App extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {schema: wizardSchema, additionalOptions: {}} 
+        this.state = {schema: selectSchema, additionalOptions: {}} 
     }
 
     render() {

--- a/packages/pf4-component-mapper/src/common/select/input.js
+++ b/packages/pf4-component-mapper/src/common/select/input.js
@@ -1,30 +1,22 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Divider } from '@patternfly/react-core';
 
 import './input.scss';
 
 const Input = ({ inputRef, isSearchable, isDisabled, getInputProps, value, ...props }) => {
   const inputProps = getInputProps({ disabled: isDisabled });
   return (
-    <Fragment>
-      <div className="pf-c-select__menu-search">
-        <input
-          autoFocus
-          value=""
-          {...props}
-          {...(!isSearchable && { tabIndex: '-1' })}
-          className="pf-c-form-control pf-m-search"
-          ref={inputRef}
-          {...{
-            ...inputProps,
-            value: inputProps.value || '',
-            onChange: inputProps.onChange || Function
-          }}
-        />
-      </div>
-      <Divider />
-    </Fragment>
+    <input
+      value=""
+      {...props}
+      className="pf-c-form-control pf-c-select__toggle-typeahead"
+      ref={inputRef}
+      {...{
+        ...inputProps,
+        value: inputProps.value || '',
+        onChange: inputProps.onChange || Function
+      }}
+    />
   );
 };
 

--- a/packages/pf4-component-mapper/src/common/select/menu.js
+++ b/packages/pf4-component-mapper/src/common/select/menu.js
@@ -1,7 +1,6 @@
-import React, { useEffect, useState, Fragment } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import Option from './option';
-import Input from './input';
 import EmptyOption from './empty-options';
 
 const getScrollParent = (element) => {
@@ -36,7 +35,7 @@ const getMenuPosition = (selectBase) => {
   return selectBase.getBoundingClientRect();
 };
 
-const MenuPortal = ({ selectToggleRef, menuPortalTarget, children, isSearchable }) => {
+const MenuPortal = ({ selectToggleRef, menuPortalTarget, children }) => {
   const [position, setPosition] = useState(getMenuPosition(selectToggleRef.current));
   useEffect(() => {
     const scrollParentElement = getScrollParent(selectToggleRef.current);
@@ -52,12 +51,10 @@ const MenuPortal = ({ selectToggleRef, menuPortalTarget, children, isSearchable 
     };
   }, [selectToggleRef]);
 
-  const top = isSearchable ? position.top + position.height + 64 : position.top + position.height;
+  const top = position.top + position.height;
   const portalDiv = (
     <div
-      className={`pf-c-select ddorg_pf4-component-mapper__select-portal-menu${
-        isSearchable ? ' ddorg_pf4-component-mapper__select-portal-menu-searchable' : ''
-      }`}
+      className="pf-c-select ddorg_pf4-component-mapper__select-portal-menu"
       style={{ borderTop: '4px solid white', zIndex: 401, position: 'absolute', top, left: position.left, width: position.width }}
     >
       {children}
@@ -71,7 +68,6 @@ const Menu = ({
   noResultsMessage,
   noOptionsMessage,
   filterOptions,
-  inputRef,
   isSearchable,
   filterValue,
   options,
@@ -88,7 +84,6 @@ const Menu = ({
   const filteredOptions = isSearchable ? filterOptions(options, filterValue) : options;
   const menuItems = (
     <ul className="pf-c-select__menu">
-      {!menuIsPortal && isSearchable && <Input inputRef={inputRef} getInputProps={getInputProps} />}
       {filteredOptions.length === 0 && (
         <EmptyOption
           isSearchable={isSearchable}
@@ -112,16 +107,9 @@ const Menu = ({
   );
   if (menuIsPortal) {
     return (
-      <Fragment>
-        {isSearchable && (
-          <ul className="pf-c-select__menu">
-            <Input inputRef={inputRef} getInputProps={getInputProps} />
-          </ul>
-        )}
-        <MenuPortal isSearchable={isSearchable} menuPortalTarget={menuPortalTarget} selectToggleRef={selectToggleRef}>
-          {menuItems}
-        </MenuPortal>
-      </Fragment>
+      <MenuPortal menuPortalTarget={menuPortalTarget} selectToggleRef={selectToggleRef}>
+        {menuItems}
+      </MenuPortal>
     );
   }
 

--- a/packages/pf4-component-mapper/src/common/select/menu.scss
+++ b/packages/pf4-component-mapper/src/common/select/menu.scss
@@ -1,0 +1,8 @@
+.pf-c-select__menu.ddorg__pf4-component-mapper__select-menu-portal {
+  margin-top: 2px;
+  position: relative;
+  width: calc(100% - 2px);
+  min-width: calc(100% - 2px);
+  left: 1px;
+  border-bottom: 1px solid #ddd;
+}

--- a/packages/pf4-component-mapper/src/common/select/select-styles.scss
+++ b/packages/pf4-component-mapper/src/common/select/select-styles.scss
@@ -12,18 +12,11 @@
   animation: spin 2s linear infinite;
 }
 
-.ddorg_pf4-component-mapper__select-portal-menu.ddorg_pf4-component-mapper__select-portal-menu-searchable {
-  &::before {
-    position: absolute;
-    bottom: -4px;
-    height: 4px;
-    left: 0;
-    right: 0;
-    background: white;
-    border-bottom-width: var(--pf-global--BorderWidth--sm);
-    border-bottom-color: var(--pf-global--BorderColor--dark-100);
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    content: "";
-  }
+.pf-c-select_toggle-wrapper.ddorg__pf4-component-mapper__select-toggle-wrapper {
+  flex: 1;
+  display: flex;
+}
+
+.ddorg__pf4-component-mapper__select-toggle.pf-m-typeahead {
+  padding-left: 0;
 }

--- a/packages/pf4-component-mapper/src/common/select/value-container.js
+++ b/packages/pf4-component-mapper/src/common/select/value-container.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import Input from './input';
 
-const ValueContainer = ({ value, placeholder }) => {
+const ValueContainer = ({ value, isMulti, placeholder, getInputProps, isSearchable, inputRef }) => {
+  if (isMulti && isSearchable) {
+    return (
+      <Fragment>
+        {value}
+        <Input placeholder={placeholder} inputRef={inputRef} getInputProps={getInputProps} />
+      </Fragment>
+    );
+  }
+
+  if (!isMulti && isSearchable) {
+    return <Input placeholder={placeholder} inputRef={inputRef} getInputProps={getInputProps} />;
+  }
+
   return <span className="pf-c-select__toggle-text">{value || placeholder}</span>;
 };
 
 ValueContainer.propTypes = {
   value: PropTypes.node,
-  placeholder: PropTypes.node
+  placeholder: PropTypes.node,
+  isMulti: PropTypes.bool,
+  getInputProps: PropTypes.func.isRequired,
+  isSearchable: PropTypes.bool,
+  inputRef: PropTypes.object
 };
 
 export default ValueContainer;


### PR DESCRIPTION
This just ate my whole day!

### Changes
- use typeahead styling for PF4 select
- add top cropping of the menu if the element is of the scrollable parent element (bottom is not needed since the the menu should overflow the parent)
- add scroll overflow to the menu to prevent window overflow

![zkurveny-select](https://user-images.githubusercontent.com/22619452/87689098-192bc500-c788-11ea-9d89-60769888c237.gif)
