### PR TITLE
PF3 datepicker test timezone fix

### DIFF
--- a/globalSetup.js
+++ b/globalSetup.js
@@ -1,0 +1,3 @@
+export default () => {
+  process.env.TZ = 'UTC';
+};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     },
     "modulePathIgnorePatterns": [
       "<rootDir>/templates/"
-    ]
+    ],
+    "globalSetup": "<rootDir>/globalSetup.js"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.9.0",


### PR DESCRIPTION
Sets the global jest environment timezone to UTC.
Fix: #650 