### PR TITLE
feat(manager): create subscription based state manager

### DIFF
--- a/packages/form-state-manager/demo/index.js
+++ b/packages/form-state-manager/demo/index.js
@@ -1,11 +1,42 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
 import FormStateManager from '../src/files/form-state-manager';
+import useField from '../src/files/use-field';
+
+const TextField = ({ label, id, ...props }) => {
+  const { input, ...rest } = useField(props);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', margin: 16 }}>
+      <label htmlFor={id}>{label}</label>
+      <input id={id} {...input} {...rest} />
+    </div>
+  );
+};
+
+TextField.propTypes = {
+  label: PropTypes.node.isRequired,
+  id: PropTypes.string.isRequired
+};
 
 const App = () => {
   return (
     <div style={{ padding: 20 }}>
-      <FormStateManager />
+      <FormStateManager onSubmit={console.log}>
+        {({ handleSubmit, ...state }) => {
+          return (
+            <form onSubmit={handleSubmit}>
+              <h1>There will be children</h1>
+              <TextField label="Field 1" name="field-1" id="field-1" type="text" />
+              <TextField label="Field 2" name="field-2" id="field-2" type="text" />
+              <div style={{ margin: 16 }}>
+                <button type="submit">Submit</button>
+              </div>
+            </form>
+          );
+        }}
+      </FormStateManager>
     </div>
   );
 };

--- a/packages/form-state-manager/src/files/form-manager-context.js
+++ b/packages/form-state-manager/src/files/form-manager-context.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const FormManagerContext = createContext({});
+
+export default FormManagerContext;

--- a/packages/form-state-manager/src/files/form-state-manager.js
+++ b/packages/form-state-manager/src/files/form-state-manager.js
@@ -1,11 +1,32 @@
-import React from 'react';
+import React, { useReducer } from 'react';
+import PropTypes from 'prop-types';
 
-const FormStateManager = () => {
+import FormManagerContext from './form-manager-context';
+import stateManagerReducer, { initialState, REGISTER_FIELD, UNREGISTER_FIELD } from '../utils/state-manager-reducer';
+import getFormValues from '../utils/get-form-values';
+
+const registerField = (dispatch, field) => dispatch({ type: REGISTER_FIELD, ...field });
+const unRegisterField = (dispatch, field) => dispatch({ type: UNREGISTER_FIELD, ...field });
+
+const FormStateManager = ({ children, onSubmit }) => {
+  const [state, dispatch] = useReducer(stateManagerReducer, initialState);
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    return onSubmit(getFormValues(state));
+  };
+
+  console.log({ state });
+
   return (
-    <div>
-      <h1>This is form state manager</h1>
-    </div>
+    <FormManagerContext.Provider value={{ values: state.values, dispatch, handleSubmit, registerField, unRegisterField }}>
+      <FormManagerContext.Consumer>{(state) => children(state)}</FormManagerContext.Consumer>
+    </FormManagerContext.Provider>
   );
+};
+
+FormStateManager.propTypes = {
+  children: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired
 };
 
 export default FormStateManager;

--- a/packages/form-state-manager/src/files/use-field.js
+++ b/packages/form-state-manager/src/files/use-field.js
@@ -1,0 +1,15 @@
+import useSubscription from '../utils/use-subscription';
+
+const useField = ({ name, ...rest }) => {
+  const [value, onChange] = useSubscription({ name });
+  return {
+    input: {
+      name,
+      onChange,
+      value: value || ''
+    },
+    ...rest
+  };
+};
+
+export default useField;

--- a/packages/form-state-manager/src/utils/get-form-values.js
+++ b/packages/form-state-manager/src/utils/get-form-values.js
@@ -1,0 +1,10 @@
+import set from 'lodash/set';
+import get from 'lodash/get';
+
+const getFormValues = (state) =>
+  state.registeredFields.reduce((acc, name) => {
+    console.log(state.fieldListeners?.[name]?.getFieldState());
+    return set(acc, name, state.fieldListeners?.[name]?.getFieldState().value || get(state.values, name));
+  }, {});
+
+export default getFormValues;

--- a/packages/form-state-manager/src/utils/state-manager-reducer.js
+++ b/packages/form-state-manager/src/utils/state-manager-reducer.js
@@ -1,0 +1,69 @@
+export const REGISTER_FIELD = 'REGISTER_FIELD';
+export const UNREGISTER_FIELD = 'UNREGISTER_FIELD';
+
+const registerField = (state, { name, getFieldState }) => ({
+  ...state,
+  registeredFields: [...state.registeredFields, name],
+  fieldListeners: {
+    ...state.fieldListeners,
+    [name]: {
+      /**
+       * There can be multiple listeners checking the same field
+       * We need to check if we can destroy all listeners before we remove all of them
+       */
+      count: state.fieldListeners?.[name]?.count + 1 || 1,
+      getFieldState
+    }
+  }
+});
+
+const checkLastSubscrition = (fieldListeners, name) => fieldListeners?.[name]?.count === 1;
+
+const unregisterField = (state, { name, persistOnUnmount, value }) => {
+  const isLast = checkLastSubscrition(state.fieldListeners, name);
+  if (!isLast) {
+    return {
+      ...state,
+      fieldListeners: {
+        ...state.fieldListeners,
+        [name]: {
+          ...state.fieldListeners[name],
+          count: state.fieldListeners[name].count - 1
+        }
+      }
+    };
+  }
+
+  const newState = { ...state };
+  if (persistOnUnmount) {
+    newState.values = { ...newState.values, [name]: value };
+  }
+
+  newState.registeredFields = newState.registeredFields.filter((fieldName) => fieldName !== name);
+  delete newState.fieldListeners[name];
+
+  return newState;
+};
+
+const mutators = {
+  [REGISTER_FIELD]: registerField,
+  [UNREGISTER_FIELD]: unregisterField
+};
+
+const stateManagerReducer = (state, { type, ...action }) => {
+  if (!mutators[type]) {
+    return state;
+  }
+
+  console.log({ type, action });
+
+  return mutators[type](state, action);
+};
+
+export const initialState = {
+  values: {},
+  registeredFields: [],
+  fieldListeners: {}
+};
+
+export default stateManagerReducer;

--- a/packages/form-state-manager/src/utils/use-subscription.js
+++ b/packages/form-state-manager/src/utils/use-subscription.js
@@ -1,0 +1,73 @@
+import { useEffect, useState, useContext } from 'react';
+import FormManagerContext from '../files/form-manager-context';
+
+class FieldState {
+  constructor(value) {
+    this.value = value;
+  }
+
+  setValue = (value) => {
+    this.value = value;
+  };
+
+  getFieldState = () => ({ value: this.value });
+}
+
+const sanitizeValue = (event) => {
+  if (Array.isArray(event)) {
+    return event;
+  }
+
+  if (typeof event === 'object' && Object.prototype.hasOwnProperty.call(event, 'target')) {
+    if (event.target === null) {
+      return event;
+    }
+
+    return event.target.type === 'checkbox' ? event.target.checked : event.target.value;
+  }
+
+  return event;
+};
+
+const useSubscription = ({ name, initialValue, subscription = {} }) => {
+  const { registerField, unRegisterField, dispatch } = useContext(FormManagerContext);
+  const [state, setState] = useState({
+    value: initialValue,
+    name,
+    /**
+     * We need this to send field values and state if the field is not subscribed to every event
+     * We pass the getFieldState function reference to the state manager and it will retrieve field data on demmand
+     * This way we don't have to mutate the manager context on each field render and render only changed fields when necessary
+     */
+    fieldState: new FieldState(initialValue) // TODO update the whole field state inside the instance
+  });
+
+  const handleChange = (event) => {
+    const sanitizedValue = sanitizeValue(event);
+    setState((prevState) => ({ ...prevState, value: sanitizedValue }));
+    state.fieldState.setValue(sanitizedValue);
+  };
+
+  let valueToReturn = state.value;
+
+  useEffect(() => {
+    registerField(dispatch, { ...state, getFieldState: state.fieldState.getFieldState });
+
+    return () => {
+      unRegisterField(dispatch, state);
+    };
+  }, []);
+
+  const onChange = (event) => {
+    try {
+      event.persist();
+      return handleChange(event);
+    } catch {
+      return handleChange(event);
+    }
+  };
+
+  return [valueToReturn, onChange];
+};
+
+export default useSubscription;


### PR DESCRIPTION
### Changes
Added initial implementation of state manager context, `useField` and `useSubscriotion` hooks. This will render fields on demand not on every state change.
- fields are currently only subscribed to their state mutation
- form context only extracts field values on form submit
  - we are using class instance (closure) per field to hold its internal state
  - class method reference is registered on the field mount to context and called on-demand to retrieve the field state (currently only on submit)
  - the instance must be synchronized when the field state changes

#### Example of independent rendering using the profiler tool:
![state-manager-subscription](https://user-images.githubusercontent.com/22619452/88052662-db99b400-cb5a-11ea-9dec-7d50cd68ab51.gif)

Note: I am thinking about writing this purely in TS. We should make the decision ASAP so it won't be much work if we decide to do it later. TS will help a lot with all of these interfaces and functions.
