### PR TITLE
fix(pf4): allow more customization

### DIFF
--- a/packages/pf4-component-mapper/src/common/form-group.js
+++ b/packages/pf4-component-mapper/src/common/form-group.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import showError from './show-error';
 
-const FormGroup = ({ label, isRequired, helperText, meta, description, hideLabel, children, id }) => (
+const FormGroup = ({ label, isRequired, helperText, meta, description, hideLabel, children, id, FormGroupProps }) => (
   <Pf4FormGroup
     isRequired={isRequired}
     label={!hideLabel && label}
@@ -12,6 +12,7 @@ const FormGroup = ({ label, isRequired, helperText, meta, description, hideLabel
     helperText={helperText}
     helperTextInvalid={meta.error}
     {...showError(meta)}
+    {...FormGroupProps}
   >
     {description && (
       <TextContent>
@@ -30,12 +31,8 @@ FormGroup.propTypes = {
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired
-};
-
-FormGroup.defaultProps = {
-  isRequired: false,
-  description: undefined
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
+  FormGroupProps: PropTypes.object
 };
 
 export default FormGroup;

--- a/packages/pf4-component-mapper/src/files/checkbox.d.ts
+++ b/packages/pf4-component-mapper/src/files/checkbox.d.ts
@@ -1,6 +1,7 @@
 import { UseFieldApiComponentConfig, AnyObject } from "@data-driven-forms/react-form-renderer";
-import { CheckboxProps as PfCheckboxProps, FormGroupProps } from '@patternfly/react-core';
+import { CheckboxProps as PfCheckboxProps } from '@patternfly/react-core';
 import { ReactNode } from "react";
+import FormGroupProps from "./form-group";
 
 interface CheckboxOptions extends AnyObject {
   label?: ReactNode;

--- a/packages/pf4-component-mapper/src/files/checkbox.js
+++ b/packages/pf4-component-mapper/src/files/checkbox.js
@@ -7,9 +7,17 @@ import { Checkbox as Pf4Checkbox } from '@patternfly/react-core';
 import IsRequired from '../common/is-required';
 
 const SingleCheckbox = (props) => {
-  const { label, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(props);
   return (
-    <FormGroup isRequired={isRequired} helperText={helperText} meta={meta} description={description} hideLabel id={id || input.name}>
+    <FormGroup
+      isRequired={isRequired}
+      helperText={helperText}
+      meta={meta}
+      description={description}
+      hideLabel
+      id={id || input.name}
+      FormGroupProps={FormGroupProps}
+    >
       <Pf4Checkbox
         isChecked={input.checked}
         {...input}
@@ -30,7 +38,8 @@ SingleCheckbox.propTypes = {
   helperText: PropTypes.node,
   description: PropTypes.node,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 const Checkbox = ({ options, ...props }) => (options ? <MultipleChoiceList options={options} {...props} /> : <SingleCheckbox {...props} />);

--- a/packages/pf4-component-mapper/src/files/date-picker.js
+++ b/packages/pf4-component-mapper/src/files/date-picker.js
@@ -6,7 +6,9 @@ import FormGroup from '../common/form-group';
 import showError from '../common/show-error';
 
 const DatePicker = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
+    props
+  );
   return (
     <FormGroup
       label={label}
@@ -16,8 +18,9 @@ const DatePicker = (props) => {
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
+      FormGroupProps={FormGroupProps}
     >
-      <TextInput {...input} {...rest} type="date" id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} {...showError(meta)} />
+      <TextInput {...input} {...showError(meta)} {...rest} type="date" id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
     </FormGroup>
   );
 };
@@ -30,7 +33,8 @@ DatePicker.propTypes = {
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 export default DatePicker;

--- a/packages/pf4-component-mapper/src/files/dual-list-select.d.ts
+++ b/packages/pf4-component-mapper/src/files/dual-list-select.d.ts
@@ -1,6 +1,6 @@
 import { UseFieldApiComponentConfig, AnyObject } from "@data-driven-forms/react-form-renderer";
 import { ReactNode } from "react";
-import { FormGroupProps } from "@patternfly/react-core";
+import FormGroupProps from "./form-group";
 
 export interface DualListSelectOption extends AnyObject {
   value?: any;

--- a/packages/pf4-component-mapper/src/files/dual-list-select.js
+++ b/packages/pf4-component-mapper/src/files/dual-list-select.js
@@ -146,7 +146,8 @@ const DualList = ({
   filterValues,
   rightValues,
   handleValuesClick,
-  renderStatus
+  renderStatus,
+  FormGroupProps
 }) => (
   <FormGroup
     label={label}
@@ -156,6 +157,7 @@ const DualList = ({
     description={description}
     hideLabel={hideLabel}
     id={id || input.name}
+    FormGroupProps={FormGroupProps}
   >
     <Grid>
       <Grid>
@@ -314,7 +316,8 @@ DualList.propTypes = {
   filterValues: PropTypes.func,
   rightValues: PropTypes.array,
   handleValuesClick: PropTypes.func,
-  renderStatus: PropTypes.func
+  renderStatus: PropTypes.func,
+  FormGroupProps: PropTypes.object
 };
 
 DualList.defaultProps = {

--- a/packages/pf4-component-mapper/src/files/form-group.d.ts
+++ b/packages/pf4-component-mapper/src/files/form-group.d.ts
@@ -1,4 +1,6 @@
 import { ReactNode } from "react";
+import { FormGroupProps as PfFormGroupProps } from '@patternfly/react-core';
+
 
 export default interface FormGroupProps {
   description?: ReactNode;
@@ -7,4 +9,5 @@ export default interface FormGroupProps {
   label?: ReactNode;
   isRequired?: boolean;
   helperText?: ReactNode;
+  FormGroupProps?: PfFormGroupProps;
 }

--- a/packages/pf4-component-mapper/src/files/radio.js
+++ b/packages/pf4-component-mapper/src/files/radio.js
@@ -34,7 +34,7 @@ const Radio = ({ name, options, type, ...props }) => {
    * You cannot assign type radio to PF4 radio buttons input. It will break and will not set input value, only checked property
    * It has to be reqular input and we have change the radio value manully to the option value
    */
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id } = useFieldApi({
+  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps } = useFieldApi({
     name,
     ...props
   });
@@ -47,6 +47,7 @@ const Radio = ({ name, options, type, ...props }) => {
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
+      FormGroupProps={FormGroupProps}
     >
       {options.map((option) => (
         <RadioOption key={option.value} name={name} option={option} isReadOnly={isReadOnly} isDisabled={isDisabled} />
@@ -66,7 +67,8 @@ Radio.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.node, value: PropTypes.any })).isRequired,
-  type: PropTypes.any
+  type: PropTypes.any,
+  FormGroupProps: PropTypes.object
 };
 
 export default Radio;

--- a/packages/pf4-component-mapper/src/files/select.js
+++ b/packages/pf4-component-mapper/src/files/select.js
@@ -5,7 +5,9 @@ import FormGroup from '../common/form-group';
 import DataDrivenSelect from '../common/select/select';
 
 const Select = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
+    props
+  );
   return (
     <FormGroup
       label={label}
@@ -15,6 +17,7 @@ const Select = (props) => {
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
+      FormGroupProps={FormGroupProps}
     >
       <DataDrivenSelect {...input} {...rest} isDisabled={isDisabled || isReadOnly} />
     </FormGroup>
@@ -29,7 +32,8 @@ Select.propTypes = {
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 export default Select;

--- a/packages/pf4-component-mapper/src/files/slider.js
+++ b/packages/pf4-component-mapper/src/files/slider.js
@@ -7,10 +7,18 @@ import { Badge, Grid, GridItem } from '@patternfly/react-core';
 import './slider.scss';
 
 const Slider = (props) => {
-  const { label, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(props);
 
   return (
-    <FormGroup label={label} isRequired={isRequired} helperText={helperText} meta={meta} description={description} id={id || input.name}>
+    <FormGroup
+      label={label}
+      isRequired={isRequired}
+      helperText={helperText}
+      meta={meta}
+      description={description}
+      id={id || input.name}
+      FormGroupProps={FormGroupProps}
+    >
       <Grid gutter="md">
         <GridItem span={10}>
           <input
@@ -36,7 +44,8 @@ Slider.propTypes = {
   helperText: PropTypes.node,
   description: PropTypes.node,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 export default Slider;

--- a/packages/pf4-component-mapper/src/files/switch.js
+++ b/packages/pf4-component-mapper/src/files/switch.js
@@ -6,12 +6,34 @@ import FormGroup from '../common/form-group';
 import IsRequired from '../common/is-required';
 
 const Switch = (props) => {
-  const { label, offText, onText, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi({
+  const {
+    label,
+    offText,
+    onText,
+    isRequired,
+    helperText,
+    meta,
+    description,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi({
     ...props,
     type: 'checkbox'
   });
   return (
-    <FormGroup isRequired={isRequired} helperText={helperText} meta={meta} description={description} hideLabel id={id || input.name}>
+    <FormGroup
+      isRequired={isRequired}
+      helperText={helperText}
+      meta={meta}
+      description={description}
+      hideLabel
+      id={id || input.name}
+      FormGroupProps={FormGroupProps}
+    >
       <Pf4Switch
         {...rest}
         {...input}
@@ -33,7 +55,8 @@ Switch.propTypes = {
   isDisabled: PropTypes.bool,
   id: PropTypes.string,
   onText: PropTypes.node,
-  offText: PropTypes.node
+  offText: PropTypes.node,
+  FormGroupProps: PropTypes.object
 };
 
 export default Switch;

--- a/packages/pf4-component-mapper/src/files/text-field.js
+++ b/packages/pf4-component-mapper/src/files/text-field.js
@@ -6,7 +6,9 @@ import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 import showError from '../common/show-error';
 
 const TextField = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
+    props
+  );
   return (
     <FormGroup
       label={label}
@@ -16,8 +18,9 @@ const TextField = (props) => {
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
+      FormGroupProps={FormGroupProps}
     >
-      <TextInput {...input} {...rest} id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} {...showError(meta)} />
+      <TextInput {...input} {...showError(meta)} {...rest} id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
     </FormGroup>
   );
 };
@@ -30,7 +33,8 @@ TextField.propTypes = {
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 export default TextField;

--- a/packages/pf4-component-mapper/src/files/textarea.js
+++ b/packages/pf4-component-mapper/src/files/textarea.js
@@ -6,7 +6,9 @@ import FormGroup from '../common/form-group';
 import showError from '../common/show-error';
 
 const Textarea = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
+    props
+  );
   return (
     <FormGroup
       label={label}
@@ -16,8 +18,9 @@ const Textarea = (props) => {
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
+      FormGroupProps={FormGroupProps}
     >
-      <Pf4TextArea disabled={isDisabled || isReadOnly} {...input} id={id || input.name} {...rest} {...showError(meta)} />
+      <Pf4TextArea {...showError(meta)} disabled={isDisabled || isReadOnly} {...input} id={id || input.name} {...rest} />
     </FormGroup>
   );
 };
@@ -30,7 +33,8 @@ Textarea.propTypes = {
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 export default Textarea;

--- a/packages/pf4-component-mapper/src/files/time-picker.js
+++ b/packages/pf4-component-mapper/src/files/time-picker.js
@@ -6,7 +6,9 @@ import PropTypes from 'prop-types';
 import showError from '../common/show-error';
 
 const TimePicker = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, ...rest } = useFieldApi(props);
+  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
+    props
+  );
   return (
     <FormGroup
       label={label}
@@ -16,8 +18,9 @@ const TimePicker = (props) => {
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
+      FormGroupProps={FormGroupProps}
     >
-      <TextInput {...input} {...rest} type="time" id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} {...showError(meta)} />
+      <TextInput {...showError(meta)} {...input} {...rest} type="time" id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
     </FormGroup>
   );
 };
@@ -30,7 +33,8 @@ TimePicker.propTypes = {
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  FormGroupProps: PropTypes.object
 };
 
 export default TimePicker;

--- a/packages/pf4-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/__snapshots__/form-fields.test.js.snap
@@ -16,7 +16,6 @@ exports[`FormFields should render Checkbox correctly 1`] = `
         <FormGroup
           hideLabel={true}
           id="someIdKey"
-          isRequired={false}
           meta={
             Object {
               "active": false,
@@ -42,7 +41,6 @@ exports[`FormFields should render Checkbox correctly 1`] = `
         >
           <Component
             fieldId="someIdKey"
-            isRequired={false}
             label={false}
             validated="default"
           >
@@ -192,7 +190,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
           >
             <FormGroup
               id="Name of the field"
-              isRequired={false}
               meta={
                 Object {
                   "active": false,
@@ -225,7 +222,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
             >
               <Component
                 fieldId="Name of the field"
-                isRequired={false}
                 validated="default"
               >
                 <div
@@ -719,7 +715,6 @@ exports[`FormFields should render DatePicker correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -745,7 +740,6 @@ exports[`FormFields should render DatePicker correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -833,7 +827,6 @@ exports[`FormFields should render Radio correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -859,7 +852,6 @@ exports[`FormFields should render Radio correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -1096,7 +1088,6 @@ exports[`FormFields should render Switch correctly 1`] = `
       <FormGroup
         hideLabel={true}
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -1122,7 +1113,6 @@ exports[`FormFields should render Switch correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           label={false}
           validated="default"
         >
@@ -1216,7 +1206,6 @@ exports[`FormFields should render TextField correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -1242,7 +1231,6 @@ exports[`FormFields should render TextField correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -1315,7 +1303,6 @@ exports[`FormFields should render TextField with description correctly 1`] = `
       <FormGroup
         description="This is description"
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -1341,7 +1328,6 @@ exports[`FormFields should render TextField with description correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -1427,7 +1413,6 @@ exports[`FormFields should render TextField without id correctly 1`] = `
     >
       <FormGroup
         id="Name of the field"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -1453,7 +1438,6 @@ exports[`FormFields should render TextField without id correctly 1`] = `
       >
         <Component
           fieldId="Name of the field"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -1524,7 +1508,6 @@ exports[`FormFields should render Textarea correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -1550,7 +1533,6 @@ exports[`FormFields should render Textarea correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -1605,7 +1587,6 @@ exports[`FormFields should render TimePicker correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -1631,7 +1612,6 @@ exports[`FormFields should render TimePicker correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -1796,7 +1776,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
           >
             <FormGroup
               id="Name of the field"
-              isRequired={false}
               meta={
                 Object {
                   "active": false,
@@ -1830,7 +1809,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
             >
               <Component
                 fieldId="Name of the field"
-                isRequired={false}
                 validated="default"
               >
                 <div
@@ -2350,7 +2328,6 @@ exports[`FormFields should render disabled Radio correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -2376,7 +2353,6 @@ exports[`FormFields should render disabled Radio correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -2615,7 +2591,6 @@ exports[`FormFields should render disabled Switch correctly 1`] = `
       <FormGroup
         hideLabel={true}
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -2641,7 +2616,6 @@ exports[`FormFields should render disabled Switch correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           label={false}
           validated="default"
         >
@@ -2737,7 +2711,6 @@ exports[`FormFields should render disabled Switch correctly 2`] = `
       <FormGroup
         hideLabel={true}
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -2763,7 +2736,6 @@ exports[`FormFields should render disabled Switch correctly 2`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           label={false}
           validated="default"
         >
@@ -2858,7 +2830,6 @@ exports[`FormFields should render disabled Textarea correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -2884,7 +2855,6 @@ exports[`FormFields should render disabled Textarea correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -2947,7 +2917,6 @@ exports[`FormFields should render touched TextField id correctly 1`] = `
     >
       <FormGroup
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -2973,7 +2942,6 @@ exports[`FormFields should render touched TextField id correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           validated="default"
         >
           <div
@@ -3047,7 +3015,6 @@ exports[`FormFields should render with onText/OffText Switch correctly 1`] = `
       <FormGroup
         hideLabel={true}
         id="someIdKey"
-        isRequired={false}
         meta={
           Object {
             "active": false,
@@ -3073,7 +3040,6 @@ exports[`FormFields should render with onText/OffText Switch correctly 1`] = `
       >
         <Component
           fieldId="someIdKey"
-          isRequired={false}
           label={false}
           validated="default"
         >

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -758,7 +758,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                     >
                                                       <FormGroup
                                                         id="foo-field"
-                                                        isRequired={false}
                                                         meta={
                                                           Object {
                                                             "active": false,
@@ -784,7 +783,6 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                       >
                                                         <Component
                                                           fieldId="foo-field"
-                                                          isRequired={false}
                                                           validated="default"
                                                         >
                                                           <div
@@ -2068,7 +2066,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                 >
                                                                   <FormGroup
                                                                     id="foo-field"
-                                                                    isRequired={false}
                                                                     meta={
                                                                       Object {
                                                                         "active": false,
@@ -2094,7 +2091,6 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                   >
                                                                     <Component
                                                                       fieldId="foo-field"
-                                                                      isRequired={false}
                                                                       validated="default"
                                                                     >
                                                                       <div


### PR DESCRIPTION
- introduces FormGroupProps
- validated can be overwritten by props
- some types and props bugs fixed

example

```jsx
{
    component: 'text-field',
    name: 'validate',
    label: 'Async validation',
    validate: [asyncValidate, {
        type: 'required'
    }],
    resolveProps: (input, {
        meta
    }) => {
        console.log(meta.validating)

        if (meta.validating) {
            return {
                helperText: <span><Spinner size="md" />Validating</span>
            }
        }

        if (meta.valid) {
            return {
                helperText: "It's okay!",
                validated: 'success',
                FormGroupProps: {
                    validated: 'success'
                }
            }
        }

        return {}
    }
}
```

![poc](https://user-images.githubusercontent.com/32869456/88068542-a26c3e80-cb70-11ea-993b-e191ff09f99e.gif)