### PR TITLE
fix(pf4): prevent select filter trigger on value selection

### DIFF
--- a/packages/pf4-component-mapper/demo/demo-schemas/select-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/select-schema.js
@@ -36,8 +36,29 @@ const loadOptions = (inputValue = '') => {
   );
 };
 
+const loadOptionsLong = (inputValue = '') => {
+  const options = [...Array(99)].map((_v, index) => ({ label: `${index}`, value: `${index}` }));
+  return new Promise((res) =>
+    setTimeout(() => {
+      if (inputValue.length === 0) {
+        return res(options.slice(0, 80));
+      }
+
+      return res(options.filter(({ label }) => label.toLocaleLowerCase().includes(inputValue.toLocaleLowerCase())));
+    }, 1500)
+  );
+};
+
 const selectSchema = {
   fields: [
+    {
+      component: componentTypes.SELECT,
+      name: 'long-searchable-async-select',
+      label: 'Long searchable async select',
+      loadOptions: loadOptionsLong,
+      isSearchable: true,
+      menuIsPortal: true
+    },
     {
       component: componentTypes.SELECT,
       name: 'simple-portal-select',
@@ -165,5 +186,6 @@ const selectSchema = {
 };
 
 export default {
-  ...selectSchema
+  ...selectSchema,
+  fields: [selectSchema.fields[0]]
 };

--- a/packages/pf4-component-mapper/src/common/select/select.js
+++ b/packages/pf4-component-mapper/src/common/select/select.js
@@ -163,8 +163,11 @@ const InternalSelect = ({
       itemToString={(value) => itemToString(value, isMulti, showMore, handleShowMore, handleChange)}
       selectedItem={value || ''}
       stateReducer={(state, changes) => stateReducer(state, changes, isMulti)}
-      onInputValueChange={(inputValue) => {
-        if (onInputChange && typeof inputValue === 'string') {
+      onInputValueChange={(inputValue, { selectedItem }) => {
+        /**
+         * Prevent firing te load options callback when selecting value not filtering
+         */
+        if (onInputChange && typeof inputValue === 'string' && selectedItem?.label !== inputValue) {
           onInputChange(inputValue);
         }
       }}


### PR DESCRIPTION
this should fix both UX issues listed in https://github.com/RedHatInsights/catalog-ui/pull/682#pullrequestreview-456330633

It will no longer happen that the menu gets opened while in a loading state