### PR TITLE
fix(pf4): prevent portal menu warping on open

### DIFF
--- a/packages/pf4-component-mapper/src/common/select/select.js
+++ b/packages/pf4-component-mapper/src/common/select/select.js
@@ -85,6 +85,7 @@ const stateReducer = (state, changes, isMulti) => {
       return {
         ...state,
         ...changes,
+        highlightedIndex: undefined, // reset the item focus to prevent initial scroll and portal menu warping
         inputValue: undefined
       };
     case Downshift.stateChangeTypes.keyDownEnter:


### PR DESCRIPTION
### Changes
- reset the highlight index after an item selection

### Before
![menu-warp](https://user-images.githubusercontent.com/22619452/88633767-bb677900-d0b5-11ea-85e9-5c6e939ab4b6.gif)

### After
![menu-not-warp](https://user-images.githubusercontent.com/22619452/88633777-bdc9d300-d0b5-11ea-9a83-331dd584c958.gif)
