### PR TITLE
Add headers to components' descriptions

### DIFF
--- a/packages/react-renderer-demo/src/components/mdx/mdx-components.js
+++ b/packages/react-renderer-demo/src/components/mdx/mdx-components.js
@@ -46,7 +46,7 @@ export const Heading = ({ level, children, component }) => {
   const router = useRouter();
   const classes = useHeadingStyles();
   const id = headerToId(children);
-  const path = `${router.pathname}#${id}`;
+  const path = `${router.asPath}#${id}`;
   return (
     <div id={id} className={classes.offset} data-scroll="true">
       <Typography id={`heading-${id}`} className={classes.heading} variant={`h${level}`} component={component}>

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/ant/ant-field-array.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/ant/ant-field-array.md
@@ -1,4 +1,4 @@
-**Props**
+## Props
 
 |Prop|Type|Description|
 |:---|:--:|----------:|
@@ -11,11 +11,11 @@
 |noItemsMessage|`node`|A message which is shown, when there are no items in the array.|
 |buttonLabels|`object`|`{add: 'ADD', remove: 'REMOVE'}` sets labels of buttons.|
 
-**Revert removal**
+## Revert removal
 
 Ant field array allow users to revert latest removal actions.
 
-**Naming**
+## Naming
 
 Fields can contain names, then the value will be handled as array of objects.
 
@@ -42,11 +42,11 @@ const fields = [
 [ value1, value2, ... ]
 ```
 
-**Custom component**
+## Custom component
 
 To implement a custom component, please take a look [here](/components/field-array).
 
-### Sub components props
+## Sub components props
 
 |name|type|default|target component|
 |----|----|-------|----------------|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/ant/ant-wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/ant/ant-wizard.md
@@ -2,7 +2,7 @@ import CommonWizard from '../wizard.md';
 
 This a custom component. OnSubmit will send only values from visited steps.
 
-**Props**
+## Props
 
 |Prop|Type|Default|Description|
 |-------------|-------------|-------------|-------------|
@@ -16,12 +16,12 @@ This a custom component. OnSubmit will send only values from visited steps.
 |NextButtonProps| object | {} | Props passed to the next button |
 |SubmitButtonProps| object | {} | Props passed to the submit button |
 
-**stepsInfo**
+### stepsInfo
 
 ```jsx
 stepsInfo: [
-  { title: 'Add a source', subTitle: 'Source' }, 
-  { title: 'Configure a source' }, 
+  { title: 'Add a source', subTitle: 'Source' },
+  { title: 'Configure a source' },
   { title: 'Summary' }
 ]
 ```
@@ -30,7 +30,7 @@ Supplying `stepsInfo` will create a steps component on top of the form displayin
 
 The object items will be passed as props to a step component. See [here](https://ant.design/components/steps/#Steps.Step).
 
-**Default buttonLabels**
+### Default buttonLabels
 
 ```jsx
 {

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-date-picker.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-date-picker.md
@@ -1,6 +1,6 @@
 Please check the [original component](https://blueprintjs.com/docs/#datetime/datepicker), it accepts the same props.
 
-**Props**
+## Props
 
 DatePicker is wrapped in a form group, so it accepts all [form group props](/mappers/component-api#formgroupwrappedcomponents).
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-dual-list-select.md
@@ -1,6 +1,6 @@
 This a custom component with a custom design.
 
-**Props**
+## Props
 
 Dual list select is wrapped in a form group, so it accepts all [form group props](/mappers/component-api#formgroupwrappedcomponents).
 
@@ -22,7 +22,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |filterValueText|String|'Remove your filter to see all selected'|Placeholder for value when there is no filtered value|
 |filterOptionsText|String|'Remove your filter to see all options'|Placeholder for options when there is no filtered option|
 
-**Options**
+### Options
 
 |Props|Type|Description|
 |-----|----|-----------|
@@ -30,7 +30,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |label|node|ListItemText primary text|
 |MenuItemProps|object|Props passed to MenuItem|
 
-**Customization**
+### Customization
 
 |Props|
 |-----|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-field-array.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-field-array.md
@@ -1,6 +1,6 @@
 Blueprint component mapper provides an experimental implementation of field array.
 
-**Props**
+## Props
 
 |Prop|Type|Description|
 |:---|:--:|----------:|
@@ -19,7 +19,7 @@ Blueprint component mapper provides an experimental implementation of field arra
 |FormGroupProps|`object`|Props passed to the form group component.|
 |FieldArrayProps|`object`|Props passed to the root div.|
 
-**Naming**
+## Naming
 
 Fields can contain names, then the value will be handled as array of objects.
 
@@ -46,6 +46,6 @@ const fields = [
 [ value1, value2, ... ]
 ```
 
-**Custom component**
+## Custom component
 
 To implement a custom component, please take a look [here](/components/field-array).

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/blueprint-wizard.md
@@ -2,7 +2,7 @@ import CommonWizard from '../wizard.md';
 
 This a custom component. OnSubmit will send only values from visited steps.
 
-**Props**
+## Props
 
 |Prop|Type|Default|Description|
 |-------------|-------------|-------------|-------------|
@@ -15,7 +15,7 @@ This a custom component. OnSubmit will send only values from visited steps.
 |NextButtonProps| object | {} | Props passed to the next button |
 |SubmitButtonProps| object | {} | Props passed to the submit button |
 
-**Default buttonLabels**
+### Default buttonLabels
 
 ```jsx
 {

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/mui/mui-dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/mui/mui-dual-list-select.md
@@ -1,6 +1,6 @@
 This a custom component with a custom design.
 
-**Props**
+## Props
 
 Dual list select is wrapped in a form group, so it accepts all [form group props](/mappers/component-api#formgroupwrappedcomponents).
 
@@ -23,7 +23,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |filterOptionsText|String|'Remove your filter to see all options'|Placeholder for options when there is no filtered option|
 |checkboxVariant|bool|false|Change list item to checkboxes|
 
-**Options**
+### Options
 
 |Props|Type|Description|
 |-----|----|-----------|
@@ -37,7 +37,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |ListItemTextProps|object|Props passed to ListItemText|
 |ListItemSecondaryActionProps|object|Props passed to ListItemSecondaryAction|
 
-**Customization**
+### Customization
 
 MUI DualListSelect provides fully customization. When the props offers Right/Left variant, you can pass props to `RightXXX` or to `LeftXXX` props. Example: `ListGridProps` is Right/Left, so there are two more props: `RightListGridProps` and `LeftListGridProps`. These props overrides the standard props, except `className`, that are being combined. All these props are objects.
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/mui/mui-field-array.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/mui/mui-field-array.md
@@ -17,7 +17,7 @@ MUI component mapper provides an experimental implementation of field array.
 
 MUI field array allow users to revert latest removal actions.
 
-**Naming**
+## Naming
 
 Fields can contain names, then the value will be handled as array of objects.
 
@@ -44,6 +44,6 @@ const fields = [
 [ value1, value2, ... ]
 ```
 
-**Custom component**
+## Custom component
 
 To implement a custom component, please take a look [here](/components/field-array).

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/mui/mui-slider.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/mui/mui-slider.md
@@ -1,6 +1,6 @@
 Please check the [original component](https://material-ui.com/components/slider/#slider), it accepts the same props.
 
-**Props**
+## Props
 
 Slider is wrapped in a form group, so it accepts all [form group props](/mappers/component-api#formgroupwrappedcomponents).
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-field-array.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-field-array.md
@@ -2,6 +2,6 @@ This component mapper does not provide field array component.
 
 In case of need, please contact us or open a PR.
 
-**Custom component**
+## Custom component
 
 To implement a custom component, please take a look [here](/components/field-array).

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-select.md
@@ -1,4 +1,4 @@
-**PF3 Async Select**
+## PF3 Async Select
 
 PF3 Select allows to load the options asynchronously.
 
@@ -8,7 +8,7 @@ PF3 Select allows to load the options asynchronously.
 |loadingMessage|`string`|A message shown during the loading.|
 |noValueUpdates|`bool`|When set on true, the select won't deselect values not found in options.|
 
-**loadOptions example**
+## loadOptions example
 
 Currently now, PF3 select supports only loading on mounting.
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-slider.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-slider.md
@@ -1,6 +1,6 @@
 Please check the [original component](https://patternfly-react-pf3.surge.sh/?path=/story/patternfly-react-forms-and-controls-slider--slider), it accepts the same props, except the `label` and `input`, see below.
 
-**Props**
+## Props
 
 Slider is wrapped in a form group, so it accepts all [form group props](/mappers/component-api#formgroupwrappedcomponents).
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf3/pf3-wizard.md
@@ -2,7 +2,7 @@ import CommonWizard from '../wizard.md';
 
 This a custom component. OnSubmit will send only values from visited steps.
 
-**Props**
+## Props
 
 | Prop  | Type | Default |  Description |
 | ------------- | ------------- | ------------- | ------------- |
@@ -11,7 +11,7 @@ This a custom component. OnSubmit will send only values from visited steps.
 | stepsInfo  | object  | undefined  | Information for stepper  |
 | inModal  | bool  | false  | If form is in a modal (will add a cancel icon to the header)  |
 
-**Default buttonLabels**
+### Default buttonLabels
 
 ```jsx
 {
@@ -32,7 +32,7 @@ You can rewrite only selection of them, e.g.
 
 (Others will stay default)
 
-**Format of stepsInfo**
+### Format of stepsInfo
 
 ```jsx
 [
@@ -47,7 +47,7 @@ You can rewrite only selection of them, e.g.
 
 <CommonWizard />
 
-**Useful links**
+## Useful links
 
 [PF3 wizard implementation](https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-3/patternfly-react/src/components/Wizard)
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-dual-list.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-dual-list.md
@@ -1,6 +1,6 @@
 This a custom component with a custom design. Things can be changed, after official PF4 release.
 
-**Props**
+## Props
 
 Dual list select is wrapped in a form group, so it accepts all [form group props](/mappers/component-api#formgroupwrappedcomponents).
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-field-array.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-field-array.md
@@ -1,6 +1,6 @@
 PF4 component mapper provides an experimental implementation of field array.
 
-**Props**
+## Props
 
 |Prop|Type|Description|
 |:---|:--:|----------:|
@@ -12,7 +12,7 @@ PF4 component mapper provides an experimental implementation of field array.
 |maxItems|`number`|Add button is disabled, if the length of the array is equal or bigger.|
 |noItemsMessage|`node`|A message which is shown, when there are no items in the array.|
 
-**Naming**
+## Naming
 
 Fields can contain names, then the value will be handled as array of objects.
 
@@ -39,6 +39,6 @@ const fields = [
 [ value1, value2, ... ]
 ```
 
-**Custom component**
+## Custom component
 
 To implement a custom component, please take a look [here](/components/field-array).

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-select.md
@@ -1,4 +1,4 @@
-**Menu portaling**
+## Menu portaling
 
 In order to show menu properly in dialogs like modals, you can use `menuIsPortal`. This will append menu as portal to body.
 
@@ -6,7 +6,7 @@ In order to show menu properly in dialogs like modals, you can use `menuIsPortal
 |---------|----|-----------|
 |menuIsPortal|`bool`|Append menu to body instead of to select wrapper.See more [here](https://react-select.com/advanced#portaling)|
 
-**PF4 Async Select**
+## PF4 Async Select
 
 PF4 Select allows to load the options asynchronously.
 
@@ -17,7 +17,7 @@ PF4 Select allows to load the options asynchronously.
 |updatingMessage|`node`|A message shown during the loading|
 |noValueUpdates|`bool`|When set on true, the select won't deselect values not found in options.|
 
-**loadOptions example**
+### loadOptions example
 
 `loadOptions` receives a search input text as an argument.
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-tabs.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-tabs.md
@@ -1,8 +1,8 @@
-**Props**
+## Props
 
 Accepts same props as the original component.
 
-**Tab item props**
+### Tab item props
 
 |name|type|default|target component|
 |----|----|-------|----------------|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/pf4-wizard.md
@@ -4,7 +4,7 @@ This a custom component. OnSubmit will send only values from visited steps.
 
 Don't forget hide form controls by setting \`showFormControls\` to \`false\` as a prop of the renderer component.
 
-**Props**
+## Props
 
 | Prop  | Type | Default |  Description |
 | ------------- | ------------- | ------------- | ------------- |
@@ -20,7 +20,7 @@ Don't forget hide form controls by setting \`showFormControls\` to \`false\` as 
 
 Also accepts these props from the original component: `titleId`, `descriptionId`, `hideClose`, `hasNoBodyPadding`, `navAriaLabel` and `closeButtonAriaLabel`.
 
-**Default buttonLabels**
+### Default buttonLabels
 
 ```jsx
 {
@@ -40,7 +40,7 @@ You can rewrite only selection of them, e.g.
 
 (Others will stay default)
 
-**Crossroads**
+### Crossroads
 
 With the help of `crossroads` you can manually defined which fields change next steps, it will cause that the wizard navigation is always refreshed, when one of the crossroads name is changed.
 
@@ -48,7 +48,7 @@ Ex.: `crossroads: ['name', 'nested.password']`
 
 <CommonWizard />
 
-**Buttons**
+### Buttons
 
 Each step can implement its own buttons.
 
@@ -85,7 +85,7 @@ The components receives these props:
 |StepTemplate|Custom component for rendering wizard body content.|
 
 
-**How to do substeps**
+## How to do substeps
 
 Field in Wizard fields should contain `substepOf` <`string`> which is title of the primary step. Steps with the same substepOf are grouped together by the title of primary step.
 
@@ -129,7 +129,7 @@ Schema: [
 Progressive Wizard works same way. It checks if previous step has the same \`substepOf\` value and if so, it grouped them together.
 If the value is different, a new primary step is created with the step as a substep.
 
-**React node as substepOf**
+### React node as substepOf
 
 You can put a React node as `substepOf`. In this case you have to provide an object with keys `name: string` and `title?: ReactNode`.
 
@@ -159,7 +159,7 @@ Schema: [
 ]
 ```
 
-**StepTemplate**
+## StepTemplate
 
 To override default wizard body content, you can use `StepTemplate` prop, either in the wizard definition or in the step definition.
 
@@ -218,13 +218,13 @@ Don't forget to use `hasNoBodyPadding` in wizard/step definition, to disable pad
 }
 ```
 
-**First step**
+## First step
 
 First step should have on the first position of the `fields` array.
 
-**Variants of Wizard**
+## Variants of Wizard
 
-Simple wizard
+### Simple wizard
 
 - steps navigation is visible, user can jump back and forward (after visiting the step)
 - does not contain any conditional steps
@@ -233,7 +233,7 @@ Simple wizard
 
 ![simplewizard](https://user-images.githubusercontent.com/32869456/58427234-56725680-809f-11e9-8e22-3ce7286b30d2.gif)
 
-Progressive wizard
+### Progressive wizard
 
 - steps are visible as user visits them
 - user can jump only back
@@ -243,7 +243,7 @@ Progressive wizard
 
 ![progressivewizard](https://user-images.githubusercontent.com/32869456/58427241-5b370a80-809f-11e9-8e79-a4a829b8d181.gif)
 
-**Useful links**
+## Useful links
 
 [PF4 wizard implementation](https://www.patternfly.org/v4/documentation/react/components/wizard/)
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-checkbox-multiple.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-checkbox-multiple.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-checkbox.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-checkbox.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-date-picker.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-date-picker.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-dual-list-select.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |OptionsListProps|object|`{}`|[Segment](https://react.semantic-ui.com/elements/segment/)|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-field-array.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-field-array.md
@@ -1,6 +1,6 @@
 SUIR component mapper provides an experimental implementation of field array.
 
-**Props**
+## Props
 
 |Prop|Type|Description|
 |:---|:--:|----------:|
@@ -13,11 +13,11 @@ SUIR component mapper provides an experimental implementation of field array.
 |noItemsMessage|`node`|A message which is shown, when there are no items in the array.|
 |buttonLabels|`object`|`{add: 'ADD', remove: 'REMOVE'}` sets labels of buttons.|
 
-**Revert removal**
+## Revert removal
 
 SUIR field array allow users to revert latest removal actions.
 
-**Naming**
+## Naming
 
 Fields can contain names, then the value will be handled as array of objects.
 
@@ -44,11 +44,11 @@ const fields = [
 [ value1, value2, ... ]
 ```
 
-**Custom component**
+## Custom component
 
 To implement a custom component, please take a look [here](/components/field-array).
 
-### Sub components props
+## Sub components props
 
 |name|type|default|target component|
 |----|----|-------|----------------|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-radio.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-radio.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-select.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-slider.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-slider.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-sub-form.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-sub-form.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |HeaderProps|object|`{}`|[Header](https://react.semantic-ui.com/elements/header/)|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-switch.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-switch.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-tabs.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-tabs.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |TabProps|`{}`|[Tab](https://react.semantic-ui.com/modules/tab/)|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-text-field.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-text-field.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-textarea.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-textarea.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-time-picker.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/suir-time-picker.md
@@ -1,4 +1,4 @@
-### Sub components props
+## Sub components props
 |name|type|default|target component|
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/wizard.md
@@ -1,4 +1,4 @@
-**Docs for steps**
+## Docs for steps
 
 |Props|Type|Description|
 |----|-------------|----------------|
@@ -6,7 +6,7 @@
 |nextStep|object/stepKey of next step/function|See below|
 |fields|array|As usual|
 
-**nextStep**
+### nextStep
 
 A) **string** - no branching, name of the next step
 
@@ -39,7 +39,7 @@ another option is to use custom function. The custom function receives as the fi
 nextStep: ({ values }) => (values.aws === '123' &&& values.password === 'secret') ? 'secretStep' : 'genericStep'
 ```
 
-**initialState**
+### initialState
 
 It is possible to set the initial state of the wizard component. This can be useful when an application returns users to a specific step.
 
@@ -64,7 +64,7 @@ How to get the state from existing wizard? The state is passed to both `onCancel
 A) `onSubmit` - `(values, formApi, wizardState) => ...`
 B) `onCancel` - `(values, wizardState) => ...`
 
-**WizardContext**
+### WizardContext
 
 Wizard share its configuration and props via `WizardContext`.
 


### PR DESCRIPTION
With latest changes in DocSearch config, we can safely use headers in components' descriptions!