### PR TITLE
feat(state): add form level validate

### DIFF
--- a/packages/form-state-manager/src/tests/utils/validate.test.js
+++ b/packages/form-state-manager/src/tests/utils/validate.test.js
@@ -2,67 +2,166 @@ import { fieldLevelValidator } from '../../utils/validate';
 import createManagerApi from '../../utils/manager-api';
 
 describe('validate', () => {
-  it('should validate sync field level function', () => {
-    const managerApi = createManagerApi(jest.fn());
-    const validator = (value) => (value === 'foo' ? 'failed' : undefined);
-    expect(fieldLevelValidator(validator, 'foo', {}, managerApi)).toEqual('failed');
-    expect(fieldLevelValidator(validator, 'bar', {}, managerApi)).toBeUndefined();
-  });
+  describe('field level', () => {
+    it('should validate sync field level function', () => {
+      const managerApi = createManagerApi(jest.fn());
+      const validator = (value) => (value === 'foo' ? 'failed' : undefined);
+      expect(fieldLevelValidator(validator, 'foo', {}, managerApi)).toEqual('failed');
+      expect(fieldLevelValidator(validator, 'bar', {}, managerApi)).toBeUndefined();
+    });
 
-  it('should fail async field level validation', () => {
-    jest.useFakeTimers();
-    const managerApi = createManagerApi(jest.fn());
-    const validator = () =>
-      new Promise((_res, reject) =>
-        setTimeout(() => {
-          return reject('failed');
-        }, 50)
-      );
-    const promise = fieldLevelValidator(validator, 'foo', {}, managerApi);
-    jest.runAllTimers();
-    expect(managerApi().validating).toBe(true);
-    return promise.catch((result) => {
-      expect(result).toEqual('failed');
+    it('should fail async field level validation', () => {
+      jest.useFakeTimers();
+      const managerApi = createManagerApi(jest.fn());
+      const validator = () =>
+        new Promise((_res, reject) =>
+          setTimeout(() => {
+            return reject('failed');
+          }, 50)
+        );
+      const promise = fieldLevelValidator(validator, 'foo', {}, managerApi);
+      jest.runAllTimers();
+      expect(managerApi().validating).toBe(true);
+      return promise.catch((result) => {
+        expect(result).toEqual('failed');
+        /**
+         * we need to call setImmediate to synchronize the jest test
+         */
+        setImmediate(() => {
+          expect(managerApi().validating).toBe(false);
+        });
+      });
+    });
+
+    it('should correctly keep validating flag set until all async validators are resolved', (done) => {
+      jest.useFakeTimers();
+      const managerApi = createManagerApi(jest.fn());
+      const slowValidator = () => new Promise((resolve) => setTimeout(() => resolve('first'), 1000));
+      const fasterValidator = () => new Promise((_res, reject) => setTimeout(() => reject('second'), 10));
       /**
-       * we need to call setImmediate to synchronize the jest test
+       * Trigger first slower validator
        */
+      fieldLevelValidator(slowValidator, 'foo', {}, managerApi);
+      expect(managerApi().validating).toBe(true);
+      /**
+       * advance time by less than i takes the first validator to resolve
+       */
+      jest.advanceTimersByTime(200);
+      /**
+       * Trigger second faster validator
+       */
+      fieldLevelValidator(fasterValidator, 'foo', {}, managerApi);
+      expect(managerApi().validating).toBe(true);
+      /**
+       * Advance timer just enough to resolve the second promise but keep the first pending.
+       */
+      jest.advanceTimersByTime(11);
+      expect(managerApi().validating).toBe(true);
+      /**
+       * Run enough time to resolve the slower first validator
+       */
+      jest.runAllTimers();
       setImmediate(() => {
         expect(managerApi().validating).toBe(false);
+        done();
       });
     });
   });
 
-  it('should correctly keep validating flag set until all async validators are resolved', (done) => {
-    jest.useFakeTimers();
-    const managerApi = createManagerApi(jest.fn());
-    const slowValidator = () => new Promise((resolve) => setTimeout(() => resolve('first'), 1000));
-    const fasterValidator = () => new Promise((_res, reject) => setTimeout(() => reject('second'), 10));
-    /**
-     * Trigger first slower validator
-     */
-    fieldLevelValidator(slowValidator, 'foo', {}, managerApi);
-    expect(managerApi().validating).toBe(true);
-    /**
-     * advance time by less than i takes the first validator to resolve
-     */
-    jest.advanceTimersByTime(200);
-    /**
-     * Trigger second faster validator
-     */
-    fieldLevelValidator(fasterValidator, 'foo', {}, managerApi);
-    expect(managerApi().validating).toBe(true);
-    /**
-     * Advance timer just enough to resolve the second promise but keep the first pending.
-     */
-    jest.advanceTimersByTime(11);
-    expect(managerApi().validating).toBe(true);
-    /**
-     * Run enough time to resolve the slower first validator
-     */
-    jest.runAllTimers();
-    setImmediate(() => {
+  describe('form level', () => {
+    it('should validate sync form level function', () => {
+      const validate = jest.fn().mockImplementation(({ value }) => (value === 'foo' ? 'failed' : undefined));
+
+      const managerApi = createManagerApi({ validate });
+
+      managerApi().registerField({ name: 'field' });
+      expect(validate).not.toHaveBeenCalled();
+
+      managerApi().change('field', 'different');
+      expect(validate).toHaveBeenCalledWith({ field: 'different' });
+    });
+
+    it('should validate async form level function', async () => {
+      jest.useFakeTimers();
+
+      const validate = jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve('first'), 1000)));
+
+      const managerApi = createManagerApi({ validate });
+
+      managerApi().registerField({ name: 'field' });
+      expect(validate).not.toHaveBeenCalled();
+
+      managerApi().change('field', 'different');
+      expect(validate).toHaveBeenCalledWith({ field: 'different' });
+      expect(managerApi().validating).toEqual(true);
+
+      await jest.runAllTimers();
+
+      expect(managerApi().validating).toEqual(false);
+    });
+
+    it('should stack async form validations', async () => {
+      jest.useFakeTimers();
+
+      const validate = jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve('first'), 1000)));
+
+      const managerApi = createManagerApi({ validate });
+
+      managerApi().registerField({ name: 'field' });
+      expect(validate).not.toHaveBeenCalled();
+
+      managerApi().change('field', 'different');
+      expect(validate).toHaveBeenCalledWith({ field: 'different' });
+      expect(managerApi().validating).toEqual(true);
+
+      await jest.advanceTimersByTime(500); //wait a little to trigger second valiaton
+
+      managerApi().change('field', 'different2');
+      expect(validate).toHaveBeenCalledWith({ field: 'different2' });
+
+      await jest.advanceTimersByTime(510); // finish first validation
+
+      expect(managerApi().validating).toEqual(true);
+
+      await jest.runAllTimers(); // finish second validation
+
+      expect(managerApi().validating).toEqual(false);
+    });
+  });
+
+  describe('combination', () => {
+    it('should stack field and form async validations', async () => {
+      jest.useFakeTimers();
+
+      const finishFirst = jest.fn();
+
+      const formValidate = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => {
+              finishFirst();
+              resolve('first');
+            }, 1000)
+          )
+      );
+      const fieldValidator = () => new Promise((resolve) => setTimeout(() => resolve('second'), 1500));
+
+      const managerApi = createManagerApi({ validate: formValidate });
+
+      managerApi().change('field', 'foo');
+      fieldLevelValidator(fieldValidator, 'foo', {}, managerApi);
+
+      expect(managerApi().validating).toBe(true);
+      expect(formValidate).toHaveBeenCalledWith({ field: 'foo' });
+
+      await jest.advanceTimersByTime(1000); // finish field validation
+
+      expect(managerApi().validating).toBe(true);
+      expect(finishFirst).toHaveBeenCalled();
+
+      await jest.advanceTimersByTime(500); // finish form validation
+
       expect(managerApi().validating).toBe(false);
-      done();
     });
   });
 });

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -1,6 +1,7 @@
 import AnyObject from './any-object';
 import { FormEvent } from 'react';
 import FieldConfig from './field-config';
+import { FormValidator } from './validate';
 
 export type Change = (name: string, value?: any) => void;
 export type HandleSubmit = (event: FormEvent) => void;
@@ -12,6 +13,7 @@ export type GetFieldValue = (name: string) => any;
 export type GetFieldState = (name: string) => AnyObject | undefined;
 export type Focus = (name: string) => void;
 export type Blur = (name: string) => void;
+export type UpdateValid = (valid: boolean) => void;
 
 export interface AsyncWatcherRecord {
   [key: number]: Promise<unknown>;
@@ -37,6 +39,7 @@ export interface ManagerState {
   getFieldValue: GetFieldValue;
   getFieldState: GetFieldState;
   registerAsyncValidator: (validator: Promise<unknown>) => void;
+  updateValid: UpdateValid;
   registeredFields: Array<string>;
   fieldListeners: AnyObject;
   active: string | undefined;
@@ -68,6 +71,7 @@ export interface CreateManagerApiConfig {
   onSubmit: OnSubmit;
   clearOnUnmount?: boolean;
   initializeOnMount?: boolean;
+  validate?: FormValidator;
 }
 
 declare type CreateManagerApi = (CreateManagerApiConfig: CreateManagerApiConfig) => ManagerApi;

--- a/packages/form-state-manager/src/types/validate.d.ts
+++ b/packages/form-state-manager/src/types/validate.d.ts
@@ -3,9 +3,17 @@ import { ManagerApi } from './manager-api';
 
 export type Validator = (value: any, allValues: AnyObject) => undefined | string | Promise<string | undefined>;
 
+export type FormValidator = (allValues: AnyObject) => undefined | string | Promise<string | undefined>;
+
 export type FieldLevelValidator = (
   validator: Validator,
   value: any,
+  allValues: AnyObject,
+  managerApi: ManagerApi
+) => string | undefined | Promise<string | undefined>;
+
+export type FormLevelValidator = (
+  validator: FormValidator,
   allValues: AnyObject,
   managerApi: ManagerApi
 ) => string | undefined | Promise<string | undefined>;

--- a/packages/form-state-manager/src/utils/validate.ts
+++ b/packages/form-state-manager/src/utils/validate.ts
@@ -1,11 +1,23 @@
 import AnyObject from '../types/any-object';
-import { FieldLevelValidator } from '../types/validate';
+import { FieldLevelValidator, FormLevelValidator } from '../types/validate';
 
 export const isPromise = (obj: AnyObject | PromiseLike<unknown> | string | undefined): boolean =>
   !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
 
 export const fieldLevelValidator: FieldLevelValidator = (validator, value, allValues, managerApi) => {
   const result = validator(value, allValues);
+  if (isPromise(result)) {
+    const asyncResult = result as Promise<string | undefined>;
+    managerApi().registerAsyncValidator(asyncResult);
+    asyncResult.then(() => undefined).catch((error) => error);
+    return result;
+  }
+
+  return result;
+};
+
+export const formLevelValidator: FormLevelValidator = (validator, allValues, managerApi) => {
+  const result = validator(allValues);
   if (isPromise(result)) {
     const asyncResult = result as Promise<string | undefined>;
     managerApi().registerAsyncValidator(asyncResult);


### PR DESCRIPTION
part of https://github.com/data-driven-forms/react-forms/issues/687

- add form.validate that is being called on each change 
   - in the future, it should be probably configurable with `validateOnBlur` (see https://github.com/data-driven-forms/react-forms/issues/690)
- does not sets the error