### PR TITLE
feat(manager): mutate error object on field-level validation.

### DIFF
--- a/packages/form-state-manager/src/files/form-state-manager.tsx
+++ b/packages/form-state-manager/src/files/form-state-manager.tsx
@@ -12,9 +12,10 @@ const FormStateManager: React.ComponentType<FormStateManagerProps> = ({
   subscription,
   clearedValue,
   initialValues,
-  initializeOnMount
+  initializeOnMount,
+  validate
 }) => {
-  const { current: managerApi } = useRef(createManagerApi({ onSubmit, clearOnUnmount, subscription, initialValues, initializeOnMount }));
+  const { current: managerApi } = useRef(createManagerApi({ onSubmit, clearOnUnmount, validate, subscription, initialValues, initializeOnMount }));
 
   const { change, handleSubmit, registerField, unregisterField, getState, getFieldValue, getFieldState, blur, focus } = managerApi();
 

--- a/packages/form-state-manager/src/tests/utils/use-subscription.test.js
+++ b/packages/form-state-manager/src/tests/utils/use-subscription.test.js
@@ -416,6 +416,31 @@ describe('useSubscription', () => {
       wrapper.update();
       expect(wrapper.find(SpyComponent).prop('meta')).toEqual(expect.objectContaining({ error: undefined, valid: true, invalid: false }));
     });
+
+    it('should set form level error key on sync validation', async () => {
+      const managerApi = createManagerApi({});
+      const subscriberProps = {
+        name: 'sync-validate',
+        validate: fooValidator
+      };
+      const wrapper = mount(<DummyComponent managerApi={managerApi} subscriberProps={subscriberProps} />);
+      const input = wrapper.find('input');
+      expect(managerApi().errors).toEqual({});
+
+      await act(async () => {
+        input.simulate('change', { target: { value: 'foo' } });
+      });
+      expect(managerApi().errors).toEqual({
+        'sync-validate': 'error'
+      });
+
+      await act(async () => {
+        input.simulate('change', { target: { value: 'bar' } });
+      });
+      expect(managerApi().errors).toEqual({
+        'sync-validate': undefined
+      });
+    });
   });
 
   describe('clearedValue', () => {

--- a/packages/form-state-manager/src/types/form-state-manager.d.ts
+++ b/packages/form-state-manager/src/types/form-state-manager.d.ts
@@ -1,5 +1,6 @@
 import AnyObject from './any-object';
 import { Subscription } from './use-subscription';
+import { FormValidator } from './validate';
 
 export interface FormStateManagerProps {
   onSubmit: (values: AnyObject) => void;
@@ -9,6 +10,7 @@ export interface FormStateManagerProps {
   clearedValue?: any;
   initialValues?: AnyObject;
   initializeOnMount?: boolean;
+  validate?: FormValidator;
 }
 
 export default FormStateManagerProps;

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -42,6 +42,7 @@ export interface ManagerState {
   getFieldValue: GetFieldValue;
   getFieldState: GetFieldState;
   registerAsyncValidator: (validator: Promise<unknown>) => void;
+  updateError: (name: string, error: string | undefined) => void;
   updateValid: UpdateValid;
   rerender: Rerender;
   registeredFields: Array<string>;

--- a/packages/form-state-manager/src/types/validate.d.ts
+++ b/packages/form-state-manager/src/types/validate.d.ts
@@ -1,9 +1,13 @@
 import AnyObject from './any-object';
 import { ManagerApi } from './manager-api';
 
+export interface FormLevelError {
+  [key: string]: string;
+}
+
 export type Validator = (value: any, allValues: AnyObject) => undefined | string | Promise<string | undefined>;
 
-export type FormValidator = (allValues: AnyObject) => undefined | string | Promise<string | undefined>;
+export type FormValidator = (allValues: AnyObject) => FormLevelError | Promise<FormLevelError>;
 
 export type FieldLevelValidator = (
   validator: Validator,
@@ -12,8 +16,4 @@ export type FieldLevelValidator = (
   managerApi: ManagerApi
 ) => string | undefined | Promise<string | undefined>;
 
-export type FormLevelValidator = (
-  validator: FormValidator,
-  allValues: AnyObject,
-  managerApi: ManagerApi
-) => string | undefined | Promise<string | undefined>;
+export type FormLevelValidator = (validator: FormValidator, allValues: AnyObject, managerApi: ManagerApi) => FormLevelError | Promise<FormLevelError>;

--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -4,7 +4,7 @@ import set from 'lodash/set';
 import CreateManagerApi, { ManagerState, ManagerApi, AsyncWatcher, AsyncWatcherRecord, Rerender } from '../types/manager-api';
 import AnyObject from '../types/any-object';
 import FieldConfig from '../types/field-config';
-import { formLevelValidator } from './validate';
+import { formLevelValidator, isPromise } from './validate';
 
 const isLast = (fieldListeners: AnyObject, name: string) => fieldListeners?.[name]?.count === 1;
 
@@ -55,6 +55,7 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
     getFieldValue,
     getFieldState,
     registerAsyncValidator,
+    updateError,
     updateValid,
     rerender,
     registeredFields: [],
@@ -184,6 +185,10 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
 
   function updateSubmitting(submitting: boolean) {
     state.submitting = submitting;
+  }
+
+  function updateError(name: string, error: string | undefined = undefined): void {
+    state.errors[name] = error;
   }
 
   function registerAsyncValidator(validator: Promise<unknown>) {

--- a/packages/form-state-manager/src/utils/use-subscription.ts
+++ b/packages/form-state-manager/src/utils/use-subscription.ts
@@ -132,6 +132,7 @@ const useSubscription = ({
         validating: false
       }
     }));
+    formOptions().updateError(name, isValid ? undefined : error);
   };
 
   const finalClearedValue = Object.prototype.hasOwnProperty.call(props, 'clearedValue') ? props.clearedValue : rest.clearedValue;

--- a/packages/form-state-manager/src/utils/validate.ts
+++ b/packages/form-state-manager/src/utils/validate.ts
@@ -1,5 +1,5 @@
 import AnyObject from '../types/any-object';
-import { FieldLevelValidator, FormLevelValidator } from '../types/validate';
+import { FieldLevelValidator, FormLevelValidator, FormLevelError } from '../types/validate';
 
 export const isPromise = (obj: AnyObject | PromiseLike<unknown> | string | undefined): boolean =>
   !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
@@ -19,7 +19,7 @@ export const fieldLevelValidator: FieldLevelValidator = (validator, value, allVa
 export const formLevelValidator: FormLevelValidator = (validator, allValues, managerApi) => {
   const result = validator(allValues);
   if (isPromise(result)) {
-    const asyncResult = result as Promise<string | undefined>;
+    const asyncResult = result as Promise<FormLevelError>;
     managerApi().registerAsyncValidator(asyncResult);
     asyncResult.then(() => undefined).catch((error) => error);
     return result;


### PR DESCRIPTION
part of #687

Only handles field-level validation

To enable it for form-level validation, we will need to register all validation functions and run them again after the form level validation passes. We need a way to clear form level validation errors, but do not remove field-level validation results at the same time. The only safe way I can think of is re-run all field-level validators, update the state, and possibly trigger the field render.

We will have also trigger the field render after we run form level validation for invalid fields.