### PR TITLE
feat(manager): lift field state to global state

### DIFF
--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -169,7 +169,7 @@ describe('managerApi', () => {
     it('should clear on form level', () => {
       const managerApi = createManagerApi({ clearOnUnmount: true });
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       managerApi().change('field', 'value');
 
       expect(managerApi().values).toEqual({ field: 'value' });
@@ -182,7 +182,7 @@ describe('managerApi', () => {
     it('should clear on field level', () => {
       const managerApi = createManagerApi({});
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       managerApi().change('field', 'value');
 
       expect(managerApi().values).toEqual({ field: 'value' });
@@ -195,7 +195,7 @@ describe('managerApi', () => {
     it('should override form level by field', () => {
       const managerApi = createManagerApi({ clearOnUnmount: true });
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       managerApi().change('field', 'value');
 
       expect(managerApi().values).toEqual({ field: 'value' });
@@ -208,7 +208,7 @@ describe('managerApi', () => {
     it('should clear on field level with cleared value', () => {
       const managerApi = createManagerApi({});
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       managerApi().change('field', 'value');
 
       expect(managerApi().values).toEqual({ field: 'value' });
@@ -231,11 +231,11 @@ describe('managerApi', () => {
     const onSubmit = jest.fn();
     const managerApi = createManagerApi({ onSubmit });
     const { registerField, change } = managerApi();
-    registerField({ name: 'field' });
-    registerField({ name: 'nested.name' });
-    registerField({ name: 'nested.age' });
-    registerField({ name: 'array[0].name' });
-    registerField({ name: 'array[0].age' });
+    registerField({ name: 'field', render: jest.fn() });
+    registerField({ name: 'nested.name', render: jest.fn() });
+    registerField({ name: 'nested.age', render: jest.fn() });
+    registerField({ name: 'array[0].name', render: jest.fn() });
+    registerField({ name: 'array[0].age', render: jest.fn() });
 
     managerApi().registeredFields.forEach((key) => {
       change(key, key);
@@ -254,11 +254,11 @@ describe('managerApi', () => {
     const { registerField } = managerApi();
     registerField({
       name: 'field',
-      getFieldState: () => ({
+      state: {
         value: { foo: 'bar' },
         baz: 'quazz',
         meta: { pristine: true }
-      })
+      }
     });
     expect(managerApi().getFieldState('field')).toEqual(expectedValue);
   });
@@ -281,8 +281,8 @@ describe('managerApi', () => {
     it.skip('should initialize on form level using initialValues', () => {
       const managerApi = createManagerApi({ initializeOnMount: true, initialValues: { field: 'second' } });
 
-      managerApi().registerField({ name: 'field', value: 'first' });
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', value: 'first', render: jest.fn() });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
 
       expect(managerApi().values).toEqual({ field: 'second' });
     });
@@ -290,8 +290,8 @@ describe('managerApi', () => {
     it('should initialize on form level', () => {
       const managerApi = createManagerApi({ initializeOnMount: true });
 
-      managerApi().registerField({ name: 'field', value: 'first' });
-      managerApi().registerField({ name: 'field', value: 'second' });
+      managerApi().registerField({ name: 'field', value: 'first', render: jest.fn() });
+      managerApi().registerField({ name: 'field', value: 'second', render: jest.fn() });
 
       expect(managerApi().values).toEqual({ field: 'second' });
     });
@@ -299,8 +299,8 @@ describe('managerApi', () => {
     it('should initialize on field level', () => {
       const managerApi = createManagerApi({});
 
-      managerApi().registerField({ name: 'field', value: 'first' });
-      managerApi().registerField({ name: 'field', value: 'second', initializeOnMount: true });
+      managerApi().registerField({ name: 'field', value: 'first', render: jest.fn() });
+      managerApi().registerField({ name: 'field', value: 'second', initializeOnMount: true, render: jest.fn() });
 
       expect(managerApi().values).toEqual({ field: 'second' });
     });
@@ -308,8 +308,8 @@ describe('managerApi', () => {
     it('should override form level by field', () => {
       const managerApi = createManagerApi({ initializeOnMount: true });
 
-      managerApi().registerField({ name: 'field', value: 'first' });
-      managerApi().registerField({ name: 'field', value: 'second', initializeOnMount: false });
+      managerApi().registerField({ name: 'field', value: 'first', render: jest.fn() });
+      managerApi().registerField({ name: 'field', value: 'second', initializeOnMount: false, render: jest.fn() });
 
       expect(managerApi().values).toEqual({ field: 'first' });
     });

--- a/packages/form-state-manager/src/tests/utils/use-subscription.test.js
+++ b/packages/form-state-manager/src/tests/utils/use-subscription.test.js
@@ -54,9 +54,14 @@ describe('useSubscription', () => {
     const registerArguments = {
       name: 'spy',
       value: 'foo',
-      getFieldState: expect.any(Function),
       render: expect.any(Function),
-      internalId: expect.any(Number)
+      internalId: expect.any(Number),
+      state: {
+        internalId: expect.any(Number),
+        meta: expect.any(Object),
+        name: 'spy',
+        value: 'foo'
+      }
     };
     const unregisterArguments = {
       name: 'spy',

--- a/packages/form-state-manager/src/tests/utils/validate.test.js
+++ b/packages/form-state-manager/src/tests/utils/validate.test.js
@@ -74,7 +74,7 @@ describe('validate', () => {
 
       const managerApi = createManagerApi({ validate });
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       expect(validate).not.toHaveBeenCalled();
 
       managerApi().change('field', 'different');
@@ -88,7 +88,7 @@ describe('validate', () => {
 
       const managerApi = createManagerApi({ validate });
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       expect(validate).not.toHaveBeenCalled();
 
       managerApi().change('field', 'different');
@@ -107,7 +107,7 @@ describe('validate', () => {
 
       const managerApi = createManagerApi({ validate });
 
-      managerApi().registerField({ name: 'field' });
+      managerApi().registerField({ name: 'field', render: jest.fn() });
       expect(validate).not.toHaveBeenCalled();
 
       managerApi().change('field', 'different');

--- a/packages/form-state-manager/src/types/field-config.d.ts
+++ b/packages/form-state-manager/src/types/field-config.d.ts
@@ -1,5 +1,6 @@
 import AnyObject from './any-object';
 import { Subscription } from './use-subscription';
+import { FieldRender } from './manager-api';
 
 export interface FieldConfig extends AnyObject {
   name: string;
@@ -10,6 +11,7 @@ export interface FieldConfig extends AnyObject {
   initializeOnMount?: boolean;
   subscription?: Subscription;
   internalId: number;
+  render: FieldRender;
 }
 
 export default FieldConfig;

--- a/packages/form-state-manager/src/types/form-manager-context.d.ts
+++ b/packages/form-state-manager/src/types/form-manager-context.d.ts
@@ -10,7 +10,7 @@ export interface Action extends AnyObject {
 export interface ManagerContextValue {
   handleSubmit: (event: FormEvent) => void;
   registerField: (fieldState: FieldConfig) => void;
-  unregisterField: (fieldState: FieldConfig) => void;
+  unregisterField: (fieldState: Omit<FieldConfig, 'render'>) => void;
   change: Change;
   getState: GetState;
   formOptions: ManagerApi;

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -2,12 +2,21 @@ import AnyObject from './any-object';
 import { FormEvent } from 'react';
 import FieldConfig from './field-config';
 import { FormValidator } from './validate';
-import { Subscription } from './use-subscription';
+import { Subscription, Meta } from './use-subscription';
+
+export interface FieldState {
+  value: any;
+  meta: Meta;
+  name: string;
+  internalId: number;
+}
+
+export type UpdateFieldState = (name: string, mutateState: (prevState: FieldState) => FieldState) => void;
 
 export type Change = (name: string, value?: any) => void;
 export type HandleSubmit = (event: FormEvent) => void;
 export type RegisterField = (field: FieldConfig) => void;
-export type UnregisterField = (field: FieldConfig) => void;
+export type UnregisterField = (field: Omit<FieldConfig, 'render'>) => void;
 export type GetState = () => AnyObject;
 export type OnSubmit = (values: AnyObject) => void;
 export type GetFieldValue = (name: string) => any;
@@ -29,6 +38,27 @@ export type AsyncWatcher = (updateValidating: (validating: boolean) => void, upd
 
 export type Rerender = (subscribeTo?: Array<string>) => void;
 
+export type FieldRender = () => void;
+
+export interface ListenerField {
+  render: FieldRender;
+  subscription?: Subscription;
+}
+
+export interface FieldListenerFields {
+  [key: number]: ListenerField;
+}
+
+export interface FieldListener {
+  count: number;
+  state: FieldState;
+  fields: FieldListenerFields;
+}
+
+export interface FieldListeners {
+  [key: string]: FieldListener;
+}
+
 export interface ManagerState {
   values: AnyObject;
   errors: AnyObject;
@@ -42,12 +72,13 @@ export interface ManagerState {
   getState: GetState;
   getFieldValue: GetFieldValue;
   getFieldState: GetFieldState;
+  setFieldState: UpdateFieldState;
   registerAsyncValidator: (validator: Promise<unknown>) => void;
   updateError: UpdateError;
   updateValid: UpdateValid;
   rerender: Rerender;
   registeredFields: Array<string>;
-  fieldListeners: AnyObject;
+  fieldListeners: FieldListeners;
   active: string | undefined;
   dirty: boolean;
   dirtyFields: Array<string>;


### PR DESCRIPTION
closes #708 

### Changes
- fields no longer have local state
  - the state is now stored inside the `fieldListeners` state 
- field state is updated and after the update, all fields registered under the same name are re-rendered
  - we can now use global `change` and other methods to mutate registered fields all at once
  - using the `setFieldState` will update and trigger field render
- `render` is now required registration attribute (it should have been before)