### PR TITLE
Form level validation state mutation

### DIFF
--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -791,4 +791,194 @@ describe('managerApi', () => {
       expect(managerApi().fieldListeners).toEqual({});
     });
   });
+
+  describe('Form level validation', () => {
+    const validate = (values) => (values.foo === 'foo' ? { foo: 'error' } : undefined);
+    const asyncValidate = (values) =>
+      new Promise((res, rej) =>
+        setTimeout(() => {
+          if (values?.foo === 'foo') {
+            rej({ foo: 'error' });
+          }
+
+          return res();
+        }, 10)
+      );
+
+    it('should pass sync level validation', () => {
+      const render = jest.fn();
+      const managerApi = createManagerApi({ validate });
+      const { registerField, change } = managerApi();
+
+      registerField({ name: 'foo', render });
+      registerField({ name: 'bar', render });
+
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(false);
+
+      change('foo', 'ok');
+      change('bar', 'baz');
+
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(false);
+    });
+
+    it('should fail sync level validation', () => {
+      const render = jest.fn();
+      const managerApi = createManagerApi({ validate });
+      const { registerField, change } = managerApi();
+
+      registerField({ name: 'foo', render });
+      registerField({ name: 'bar', render });
+
+      change('foo', 'foo');
+      change('bar', 'baz');
+
+      expect(managerApi().getState().errors).toEqual({ foo: 'error' });
+      expect(managerApi().getState().valid).toEqual(false);
+      expect(managerApi().getState().invalid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(false);
+    });
+
+    it('should pass async level validation', () => {
+      jest.useFakeTimers();
+      const render = jest.fn();
+      const managerApi = createManagerApi({ validate: asyncValidate });
+      const { registerField, change } = managerApi();
+
+      registerField({ name: 'foo', render });
+      registerField({ name: 'bar', render });
+
+      change('foo', 'ok');
+      change('bar', 'baz');
+
+      /**
+       * before validation starts
+       */
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(true);
+
+      jest.advanceTimersByTime(5);
+
+      /**
+       * While validation in progress
+       */
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(true);
+
+      jest.advanceTimersByTime(5);
+
+      /**
+       * After validation finishes
+       */
+      jest.advanceTimersByTime(6);
+      setImmediate(() => {
+        expect(managerApi().getState().errors).toEqual({});
+        expect(managerApi().getState().valid).toEqual(true);
+        expect(managerApi().getState().validating).toEqual(false);
+      });
+    });
+
+    it('should fail async level validation', () => {
+      jest.useFakeTimers();
+      const render = jest.fn();
+      const managerApi = createManagerApi({ validate: asyncValidate });
+      const { registerField, change } = managerApi();
+
+      registerField({ name: 'foo', render });
+      registerField({ name: 'bar', render });
+
+      change('foo', 'foo');
+      change('bar', 'baz');
+
+      /**
+       * before validation starts
+       */
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(true);
+
+      jest.advanceTimersByTime(5);
+
+      /**
+       * While validation in progress
+       */
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(true);
+
+      jest.advanceTimersByTime(5);
+
+      /**
+       * After validation finishes
+       */
+      jest.advanceTimersByTime(6);
+      setImmediate(() => {
+        expect(managerApi().getState().errors).toEqual({
+          foo: 'error'
+        });
+        expect(managerApi().getState().valid).toEqual(false);
+        expect(managerApi().getState().invalid).toEqual(true);
+        expect(managerApi().getState().validating).toEqual(false);
+      });
+    });
+
+    it('should fail and then pass sync validation', () => {
+      const render = jest.fn();
+      const managerApi = createManagerApi({ validate });
+      const { registerField, change } = managerApi();
+
+      registerField({ name: 'foo', render });
+
+      change('foo', 'foo');
+
+      expect(managerApi().getState().errors).toEqual({
+        foo: 'error'
+      });
+      expect(managerApi().getState().valid).toEqual(false);
+      expect(managerApi().getState().invalid).toEqual(true);
+      expect(managerApi().getState().validating).toEqual(false);
+
+      change('foo', 'ok');
+
+      expect(managerApi().getState().errors).toEqual({});
+      expect(managerApi().getState().valid).toEqual(true);
+      expect(managerApi().getState().invalid).toEqual(false);
+      expect(managerApi().getState().validating).toEqual(false);
+    });
+
+    it('should fail and then pass async validation', () => {
+      jest.useFakeTimers();
+      const render = jest.fn();
+      const managerApi = createManagerApi({ validate: asyncValidate });
+      const { registerField, change } = managerApi();
+
+      registerField({ name: 'foo', render });
+
+      change('foo', 'foo');
+
+      jest.advanceTimersByTime(10);
+      setImmediate(() => {
+        expect(managerApi().getState().errors).toEqual({
+          foo: 'error'
+        });
+        expect(managerApi().getState().valid).toEqual(false);
+        expect(managerApi().getState().invalid).toEqual(true);
+        expect(managerApi().getState().validating).toEqual(false);
+
+        change('foo', 'ok');
+        jest.advanceTimersByTime(10);
+        setImmediate(() => {
+          expect(managerApi().getState().errors).toEqual({});
+          expect(managerApi().getState().valid).toEqual(true);
+          expect(managerApi().getState().invalid).toEqual(false);
+          expect(managerApi().getState().validating).toEqual(false);
+        });
+      });
+    });
+  });
 });

--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -981,4 +981,149 @@ describe('managerApi', () => {
       });
     });
   });
+
+  describe('Combine form and field level validation', () => {
+    const formLevelValidate = (values) => (values.foo === 'foo' ? { foo: 'form-error' } : undefined);
+    const fieldLevelValidate = (value) => (value === 'bar' ? 'field-error' : undefined);
+
+    it('should fail sync form level, but pass sync field level validation', () => {
+      const managerApi = createManagerApi({ validate: formLevelValidate });
+      const { change, registerField, getFieldState } = managerApi();
+      const getErrorState = () => {
+        let { valid, invalid, validating, errors } = managerApi();
+        let {
+          meta: { error: fieldError, valid: fieldValid, validating: fieldValidating, invalid: fieldInvalid }
+        } = getFieldState('foo');
+
+        return { valid, invalid, validating, errors, fieldError, fieldValid, fieldValidating, fieldInvalid };
+      };
+
+      registerField({ name: 'foo', validate: fieldLevelValidate, render: jest.fn() });
+
+      change('foo', 'foo');
+      let expectedResult = getErrorState();
+      expect(expectedResult).toEqual({
+        valid: false,
+        invalid: true,
+        validating: false,
+        errors: { foo: 'form-error' },
+        fieldError: 'form-error',
+        fieldValid: false,
+        fieldInvalid: true,
+        fieldValidating: false
+      });
+    });
+
+    it('should initialy fail sync form level, but pass on second run validation', () => {
+      const managerApi = createManagerApi({ validate: formLevelValidate });
+      const { change, registerField, getFieldState } = managerApi();
+      const getErrorState = () => {
+        let { valid, invalid, validating, errors } = managerApi();
+        let {
+          meta: { error: fieldError, valid: fieldValid, validating: fieldValidating, invalid: fieldInvalid }
+        } = getFieldState('foo');
+
+        return { valid, invalid, validating, errors, fieldError, fieldValid, fieldValidating, fieldInvalid };
+      };
+
+      registerField({ name: 'foo', validate: fieldLevelValidate, render: jest.fn() });
+
+      change('foo', 'foo');
+
+      let expectedResult = getErrorState();
+      expect(expectedResult).toEqual({
+        valid: false,
+        invalid: true,
+        validating: false,
+        errors: { foo: 'form-error' },
+        fieldError: 'form-error',
+        fieldValid: false,
+        fieldInvalid: true,
+        fieldValidating: false
+      });
+
+      change('foo', 'ok');
+
+      expectedResult = getErrorState();
+      expect(expectedResult).toEqual({
+        valid: true,
+        invalid: false,
+        validating: false,
+        errors: {},
+        fieldError: undefined,
+        fieldValid: true,
+        fieldInvalid: false,
+        fieldValidating: false
+      });
+    });
+
+    it('should pass sync form level, but fail sync field level validation', () => {
+      const managerApi = createManagerApi({ validate: formLevelValidate });
+      const { change, registerField, getFieldState } = managerApi();
+      const getErrorState = () => {
+        let { valid, invalid, validating, errors } = managerApi();
+        let {
+          meta: { error: fieldError, valid: fieldValid, validating: fieldValidating, invalid: fieldInvalid }
+        } = getFieldState('foo');
+
+        return { valid, invalid, validating, errors, fieldError, fieldValid, fieldValidating, fieldInvalid };
+      };
+
+      registerField({ name: 'foo', validate: fieldLevelValidate, render: jest.fn() });
+
+      change('foo', 'bar');
+      let expectedResult = getErrorState();
+      expect(expectedResult).toEqual({
+        valid: false,
+        invalid: true,
+        validating: false,
+        errors: { foo: 'field-error' },
+        fieldError: 'field-error',
+        fieldValid: false,
+        fieldInvalid: true,
+        fieldValidating: false
+      });
+    });
+
+    it('should fail first sync field level validation, but pass on second round', () => {
+      const managerApi = createManagerApi({ validate: formLevelValidate });
+      const { change, registerField, getFieldState } = managerApi();
+      const getErrorState = () => {
+        let { valid, invalid, validating, errors } = managerApi();
+        let {
+          meta: { error: fieldError, valid: fieldValid, validating: fieldValidating, invalid: fieldInvalid }
+        } = getFieldState('foo');
+
+        return { valid, invalid, validating, errors, fieldError, fieldValid, fieldValidating, fieldInvalid };
+      };
+
+      registerField({ name: 'foo', validate: fieldLevelValidate, render: jest.fn() });
+
+      change('foo', 'bar');
+      let expectedResult = getErrorState();
+      expect(expectedResult).toEqual({
+        valid: false,
+        invalid: true,
+        validating: false,
+        errors: { foo: 'field-error' },
+        fieldError: 'field-error',
+        fieldValid: false,
+        fieldInvalid: true,
+        fieldValidating: false
+      });
+
+      change('foo', 'ok');
+      expectedResult = getErrorState();
+      expect(expectedResult).toEqual({
+        valid: true,
+        invalid: false,
+        validating: false,
+        errors: {},
+        fieldError: undefined,
+        fieldValid: true,
+        fieldInvalid: false,
+        fieldValidating: false
+      });
+    });
+  });
 });

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -10,6 +10,12 @@ export interface FieldState {
   name: string;
 }
 
+export interface ExtendedFieldState extends FieldState {
+  change: (value: any) => any;
+  blur: () => void;
+  focus: () => void;
+}
+
 export type UpdateFieldState = (name: string, mutateState: (prevState: FieldState) => FieldState) => void;
 
 export type Callback = () => void;
@@ -20,7 +26,7 @@ export type UnregisterField = (field: Omit<FieldConfig, 'render'>) => void;
 export type GetState = () => ManagerState;
 export type OnSubmit = (values: AnyObject) => void;
 export type GetFieldValue = (name: string) => any;
-export type GetFieldState = (name: string) => AnyObject | undefined;
+export type GetFieldState = (name: string) => ExtendedFieldState | undefined;
 export type Focus = (name: string) => void;
 export type Blur = (name: string) => void;
 export type UpdateValid = (valid: boolean) => void;

--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -9,7 +9,8 @@ import CreateManagerApi, {
   FieldState,
   Callback,
   SubscriberConfig,
-  ManagerApiFunctions
+  ManagerApiFunctions,
+  ExtendedFieldState
 } from '../types/manager-api';
 import AnyObject from '../types/any-object';
 import FieldConfig from '../types/field-config';
@@ -233,6 +234,7 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
 
   function validateForm(validate: FormValidator) {
     const result = formLevelValidator(validate, state.values, managerApi);
+    const currentInvalidFields = Object.keys(state.errors);
     if (isPromise(result)) {
       const asyncResult = result as Promise<FormLevelError>;
       return asyncResult
@@ -242,6 +244,7 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
             state.valid = true;
             state.invalid = false;
             state.error = undefined;
+            revalidateFields(currentInvalidFields);
           }
         })
         .catch((errors) => {
@@ -253,6 +256,9 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
 
     const syncError = result as FormLevelError | undefined;
     if (syncError) {
+      Object.keys(syncError).forEach((name) => {
+        handleFieldError(name, false, syncError[name]);
+      });
       state.errors = syncError;
       state.valid = false;
       state.invalid = true;
@@ -261,7 +267,17 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
       state.valid = true;
       state.invalid = false;
       state.error = undefined;
+      /**
+       * Fields have to be revalidated on field level to synchronize the form and field errors
+       */
+      revalidateFields(currentInvalidFields);
     }
+  }
+
+  function revalidateFields(fields: string[]) {
+    fields.forEach((name) => {
+      validateField(name, state.values[name]);
+    });
   }
 
   function change(name: string, value?: any): void {
@@ -349,7 +365,7 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
     return state.values[name];
   }
 
-  function getFieldState(name: string): AnyObject | undefined {
+  function getFieldState(name: string): ExtendedFieldState | undefined {
     if (state.fieldListeners[name]) {
       return {
         ...state.fieldListeners[name].state,
@@ -377,7 +393,18 @@ const createManagerApi: CreateManagerApi = ({ onSubmit, clearOnUnmount, initiali
   }
 
   function updateError(name: string, error: string | undefined = undefined): void {
-    state.errors[name] = error;
+    if (error) {
+      state.errors[name] = error;
+      state.valid = false;
+      state.invalid = true;
+    } else {
+      delete state.errors[name];
+    }
+
+    if (Object.keys(state.errors).length === 0) {
+      state.valid = true;
+      state.invalid = false;
+    }
   }
 
   function registerAsyncValidator(validator: Promise<unknown>) {

--- a/packages/form-state-manager/src/utils/use-subscription.ts
+++ b/packages/form-state-manager/src/utils/use-subscription.ts
@@ -110,7 +110,7 @@ const useSubscription = ({
     }
   };
 
-  return [formOptions().getFieldValue(name), onChange, () => focus(name), () => blur(name), state?.meta];
+  return [formOptions().getFieldValue(name), onChange, () => focus(name), () => blur(name), state!.meta];
 };
 
 export default useSubscription;


### PR DESCRIPTION
part of https://github.com/data-driven-forms/react-forms/issues/687

### Changes
- add state mutation after form level validation
- synchronizes form-level and field-level validation errors and state flags