### PR TITLE
feat(manager): introduce destroyOnUnregister

### DIFF
--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -363,6 +363,19 @@ describe('managerApi', () => {
       expect(managerApi().values).toEqual({ field: undefined });
     });
 
+    it('should clear on form level using destroyOnUnregister', () => {
+      const managerApi = createManagerApi({ destroyOnUnregister: true });
+
+      managerApi().registerField({ name: 'field', render: jest.fn() });
+      managerApi().change('field', 'value');
+
+      expect(managerApi().values).toEqual({ field: 'value' });
+
+      managerApi().unregisterField({ name: 'field' });
+
+      expect(managerApi().values).toEqual({ field: undefined });
+    });
+
     it('should clear on field level', () => {
       const managerApi = createManagerApi({});
 

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -147,6 +147,7 @@ export interface ManagerState {
   valid: boolean;
   validating: boolean;
   visited: AnyBooleanObject;
+  destroyOnUnregister: boolean | undefined;
 }
 
 export type ManagerApi = () => ManagerState;
@@ -170,6 +171,7 @@ export interface CreateManagerApiConfig {
   initialValues?: AnyObject;
   debug?: Debug;
   keepDirtyOnReinitialize?: boolean;
+  destroyOnUnregister?: boolean;
 }
 
 declare type CreateManagerApi = (CreateManagerApiConfig: CreateManagerApiConfig) => ManagerApi;

--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -128,7 +128,7 @@ export const createField = (name: string, value: any): FieldState => ({
   meta: initialMeta(value)
 });
 
-export const initialFormState = (initialValues?: AnyObject): Omit<ManagerState, ManagerApiFunctions> => ({
+export const initialFormState = (initialValues?: AnyObject): Omit<ManagerState, ManagerApiFunctions | 'destroyOnUnregister'> => ({
   values: initialValues ? flatObject(initialValues) : {},
   errors: {},
   pristine: true,
@@ -165,7 +165,8 @@ const createManagerApi: CreateManagerApi = ({
   subscription,
   initialValues,
   debug,
-  keepDirtyOnReinitialize
+  keepDirtyOnReinitialize,
+  destroyOnUnregister
 }) => {
   let state: ManagerState = {
     change,
@@ -189,6 +190,7 @@ const createManagerApi: CreateManagerApi = ({
     restart: () => reset(),
     resetFieldState,
     initialize,
+    destroyOnUnregister,
     ...initialFormState(initialValues)
   };
   let inBatch = 0;
@@ -410,7 +412,7 @@ const createManagerApi: CreateManagerApi = ({
 
     if (isLast(state.fieldListeners, field.name)) {
       state.registeredFields = state.registeredFields.filter((fieldName: string) => fieldName !== field.name);
-      if (shouldExecute(clearOnUnmount, field.clearOnUnmount)) {
+      if (shouldExecute(clearOnUnmount || destroyOnUnregister, field.clearOnUnmount)) {
         state.values[field.name] = field.value;
       }
     }


### PR DESCRIPTION
part of https://github.com/data-driven-forms/react-forms/issues/705

destroyOnUnregister is the same as clearOnUnmount