### PR TITLE
feat(manager): Revalidate all fields

### DIFF
--- a/packages/form-state-manager/.eslintrc
+++ b/packages/form-state-manager/.eslintrc
@@ -1,4 +1,4 @@
-{ 
+{
   "parser": "@typescript-eslint/parser",
   "plugins": [
     "@typescript-eslint"
@@ -10,6 +10,7 @@
   ],
   "rules": {
     "react/prop-types": "off",
-    "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".jsx", ".js"] }]
+    "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".jsx", ".js"] }],
+    "@typescript-eslint/no-unused-vars": 2
   }
 }

--- a/packages/form-state-manager/src/files/use-field.ts
+++ b/packages/form-state-manager/src/files/use-field.ts
@@ -44,9 +44,7 @@ export const checkEmpty = (value: any) => {
 };
 
 const useField = ({ name, initialValue, clearOnUnmount, initializeOnMount, validate, subscription, dataType, ...props }: UseField): UseFieldData => {
-  const { registerField, unregisterField, change, getFieldValue, blur, focus, formOptions, initialValues = {}, ...rest } = useContext(
-    FormManagerContext
-  );
+  const { registerField, unregisterField, change, getFieldValue, blur, focus, formOptions, ...rest } = useContext(FormManagerContext);
   const [, render] = useReducer((count) => count + 1, 0);
   const [id] = useState(() => {
     const internalId = generateId();

--- a/packages/form-state-manager/src/tests/.eslintrc
+++ b/packages/form-state-manager/src/tests/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": 0
+  }
+}

--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -92,6 +92,37 @@ describe('managerApi', () => {
 
       expect(validate1).toHaveBeenCalled();
       expect(validate2).not.toHaveBeenCalled();
+
+      validate1.mockReset();
+
+      managerApi().change('field2', 'cosi');
+
+      expect(validate1).toHaveBeenCalled();
+      expect(validate2).toHaveBeenCalled();
+    });
+
+    it('empty validateFields', () => {
+      const managerApi = createManagerApi({});
+
+      const render = jest.fn();
+
+      const validate1 = jest.fn();
+      const validate2 = jest.fn();
+
+      managerApi().registerField({ name: 'field1', render, validate: validate1, validateFields: [] });
+      managerApi().registerField({ name: 'field2', render, validate: validate2 });
+
+      managerApi().change('field1', 'cosi');
+
+      expect(validate1).toHaveBeenCalled();
+      expect(validate2).not.toHaveBeenCalled();
+
+      validate1.mockReset();
+
+      managerApi().change('field2', 'cosi');
+
+      expect(validate1).toHaveBeenCalled();
+      expect(validate2).toHaveBeenCalled();
     });
 
     it('should compute value using isEqual', () => {
@@ -1312,7 +1343,7 @@ describe('managerApi', () => {
 
       managerApi().pauseValidation();
 
-      managerApi().registerField({ name: '123', validate: fieldValidate, render: jest.fn() });
+      managerApi().registerField({ name: '123', validate: fieldValidate, validateFields: [], render: jest.fn() });
       managerApi().registerField({ name: 'noRun', validate: fieldValidateNoRun, render: jest.fn() });
 
       managerApi().change('123', 'value');

--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -441,10 +441,8 @@ const createManagerApi: CreateManagerApi = ({
       }));
       state.pristine = false;
       state.dirty = true;
-      validateField(name, value);
 
-      const validateFields = state.fieldListeners[name]?.validateFields;
-      validateFields && revalidateFields(validateFields);
+      revalidateFields([name, ...(state.fieldListeners[name]?.validateFields || state.registeredFields.filter((n) => n !== name))]);
 
       if (config.validate) {
         validateForm(config.validate);

--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -45,7 +45,7 @@ const traverseObject = (object: AnyObject, callback: objectMapFunction) => Objec
 const asyncWatcher: AsyncWatcher = (updateValidating, updateSubmitting) => {
   let nextKey = 0;
   const asyncValidators: AsyncWatcherRecord = {};
-  const asyncSubmissions: AsyncWatcherRecord = {};
+  // const asyncSubmissions: AsyncWatcherRecord = {};
 
   const resolveValidator = (resolveKey: number): void => {
     delete asyncValidators[resolveKey];


### PR DESCRIPTION
part of https://github.com/data-driven-forms/react-forms/issues/726

- all fields are being revalidated on change
- validateFields shares the same behavior
- tslint won't allow unused vars