### PR TITLE
fix(manager): allow multiple field listener validators

### DIFF
--- a/packages/form-state-manager/src/files/compose-validators.ts
+++ b/packages/form-state-manager/src/files/compose-validators.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-sequences */
+import AnyObject from '../types/any-object';
+import { isPromise } from '../utils/validate';
+import ComposeValidators from '../types/compose-validators';
+
+type SyncValidator = (value: any, allValues: AnyObject) => string | undefined;
+
+/**
+ * Function that allows running mulple validation functions on a single field.
+ * Pass an array of validators as an argument.
+ * New validation will be returned, that runs all validation until first one fails, or every validator is sucessfull.
+ * @param validators Array of Validators. Only first validator in array can be asynchronous. Rest of validators must return either string or undefined
+ * @returns {Function} New validation function
+ */
+const composeValidators: ComposeValidators = (validators = []) => (value: any, allValues: AnyObject) => {
+  const [initialValidator, ...sequenceValidators] = validators;
+  const resolveValidator = (error: string | undefined, validator: SyncValidator) =>
+    error || (typeof validator === 'function' ? validator(value, allValues) : undefined);
+  if (initialValidator && typeof initialValidator === 'function') {
+    const result = initialValidator(value, allValues);
+    if (result && isPromise(result)) {
+      const asyncResult = result as Promise<string | undefined>;
+      return asyncResult.then(() => sequenceValidators.reduce(resolveValidator as SyncValidator, undefined)).catch((error) => error);
+    }
+  }
+
+  let error: string | undefined;
+  let index = 0;
+  while (!error || index < validators.length) {
+    error = (validators[index] as SyncValidator)(value, allValues);
+    index = index + 1;
+  }
+
+  return error;
+};
+
+// TODO tests
+export default composeValidators;

--- a/packages/form-state-manager/src/files/compose-validators.ts
+++ b/packages/form-state-manager/src/files/compose-validators.ts
@@ -1,38 +1,24 @@
-/* eslint-disable no-sequences */
-import AnyObject from '../types/any-object';
 import { isPromise } from '../utils/validate';
 import ComposeValidators from '../types/compose-validators';
-
-type SyncValidator = (value: any, allValues: AnyObject) => string | undefined;
 
 /**
  * Function that allows running mulple validation functions on a single field.
  * Pass an array of validators as an argument.
  * New validation will be returned, that runs all validation until first one fails, or every validator is sucessfull.
- * @param validators Array of Validators. Only first validator in array can be asynchronous. Rest of validators must return either string or undefined
+ * @param validators Array of Validators. All validators are asynchrounsly resolved. First rejected validator error message will be returned as validation error.
+ * Synchronous validators are also run in async mode.
  * @returns {Function} New validation function
  */
-const composeValidators: ComposeValidators = (validators = []) => (value: any, allValues: AnyObject) => {
-  const [initialValidator, ...sequenceValidators] = validators;
-  const resolveValidator = (error: string | undefined, validator: SyncValidator) =>
-    error || (typeof validator === 'function' ? validator(value, allValues) : undefined);
-  if (initialValidator && typeof initialValidator === 'function') {
-    const result = initialValidator(value, allValues);
-    if (result && isPromise(result)) {
-      const asyncResult = result as Promise<string | undefined>;
-      return asyncResult.then(() => sequenceValidators.reduce(resolveValidator as SyncValidator, undefined)).catch((error) => error);
-    }
-  }
+const composeValidators: ComposeValidators = (validators = []) => (value, allValues) =>
+  Promise.all(
+    validators.map((validator) => {
+      const result = validator(value, allValues);
+      if (isPromise(result)) {
+        return result;
+      }
 
-  let error: string | undefined;
-  let index = 0;
-  while (!error || index < validators.length) {
-    error = (validators[index] as SyncValidator)(value, allValues);
-    index = index + 1;
-  }
+      return result ? Promise.reject(result) : Promise.resolve(undefined);
+    })
+  ).then(() => undefined);
 
-  return error;
-};
-
-// TODO tests
 export default composeValidators;

--- a/packages/form-state-manager/src/files/compose-validators.ts
+++ b/packages/form-state-manager/src/files/compose-validators.ts
@@ -5,20 +5,44 @@ import ComposeValidators from '../types/compose-validators';
  * Function that allows running mulple validation functions on a single field.
  * Pass an array of validators as an argument.
  * New validation will be returned, that runs all validation until first one fails, or every validator is sucessfull.
- * @param validators Array of Validators. All validators are asynchrounsly resolved. First rejected validator error message will be returned as validation error.
- * Synchronous validators are also run in async mode.
+ * @param validators Array of Validators. First rejected validator error message will be returned as validation error.
+ * Synchronous validators are run in synchrounously and sync error is prioritized over async errors.
  * @returns {Function} New validation function
  */
-const composeValidators: ComposeValidators = (validators = []) => (value, allValues) =>
-  Promise.all(
-    validators.map((validator) => {
-      const result = validator(value, allValues);
-      if (isPromise(result)) {
-        return result;
-      }
+const composeValidators: ComposeValidators = (validators = []) => (value, allValues) => {
+  const promises: Promise<string | undefined>[] = [];
+  let index = 0;
+  let error: string | undefined;
+  while (validators.length > 0 && !error && index < validators.length) {
+    const result = validators[index](value, allValues);
+    if (isPromise(result)) {
+      promises.push(result as Promise<string | undefined>);
+    } else {
+      error = result as string | undefined;
+    }
 
-      return result ? Promise.reject(result) : Promise.resolve(undefined);
-    })
-  ).then(() => undefined);
+    index = index + 1;
+  }
+
+  if (error) {
+    return error;
+  }
+
+  if (promises.length > 0) {
+    return Promise.all(promises)
+      .catch((asyncError) => {
+        throw error || asyncError;
+      })
+      .then(() => {
+        if (error) {
+          throw error;
+        }
+
+        return undefined;
+      });
+  }
+
+  return undefined;
+};
 
 export default composeValidators;

--- a/packages/form-state-manager/src/tests/files/compose-validators.test.js
+++ b/packages/form-state-manager/src/tests/files/compose-validators.test.js
@@ -1,4 +1,5 @@
 import composeValidators from '../../files/compose-validators';
+import { isPromise } from '../../utils/validate';
 
 describe('composeValidators', () => {
   const one = (value) => new Promise((res, rej) => setTimeout(() => (value === 'one' ? rej('error-one') : res()), 200));
@@ -6,66 +7,70 @@ describe('composeValidators', () => {
   const three = (value) => (value === 'three' ? 'error-three' : undefined);
   const threeCopy = (value) => (value === 'three' ? 'error-three-copy' : undefined);
 
-  it('should fail last sync validator', (done) => {
-    expect.assertions(1);
+  it('should fail last sync validator', () => {
+    expect.assertions(2);
     const validator = composeValidators([one, two, three]);
-    validator('three').catch((result) => {
-      expect(result).toEqual('error-three');
-      done();
-    });
+    const result = validator('three');
+    expect(isPromise(validator)).toBe(false);
+    expect(result).toEqual('error-three');
   });
 
   it('should fail second async validator', (done) => {
-    expect.assertions(1);
+    expect.assertions(2);
     const validator = composeValidators([one, two, three]);
-    validator('two').catch((result) => {
+    const result = validator('two');
+    expect(isPromise(result)).toEqual(true);
+    return result.catch((result) => {
       expect(result).toEqual('error-two');
       done();
     });
   });
 
   it('should fail first async validator', (done) => {
-    expect.assertions(1);
+    expect.assertions(2);
     const validator = composeValidators([one, two, three]);
-    validator('one').catch((result) => {
+    const result = validator('one');
+    expect(isPromise(result)).toBe(true);
+    return result.catch((result) => {
       expect(result).toEqual('error-one');
       done();
     });
   });
 
   it('should pass all validators', (done) => {
-    expect.assertions(1);
+    expect.assertions(2);
     const validator = composeValidators([one, two, three]);
-    validator('ok').then((result) => {
+    const result = validator('ok');
+    expect(isPromise(result)).toEqual(true);
+    return result.then((result) => {
       expect(result).toBeUndefined();
       done();
     });
   });
 
   it('should pass all async validators', (done) => {
-    expect.assertions(1);
+    expect.assertions(2);
     const validator = composeValidators([one, two]);
-    validator('ok').then((result) => {
+    const result = validator('ok');
+    expect(isPromise(result)).toEqual(true);
+    return result.then((result) => {
       expect(result).toBeUndefined();
       done();
     });
   });
 
-  it('should return error message of sync validators in order all validators', (done) => {
-    expect.assertions(1);
+  it('should return error message of sync validators in order of validators', () => {
+    expect.assertions(2);
     const validator = composeValidators([three, threeCopy]);
-    return validator('three').catch((result) => {
-      expect(result).toEqual('error-three');
-      done();
-    });
+    const result = validator('three');
+    expect(isPromise(result)).toEqual(false);
+    expect(result).toEqual('error-three');
   });
 
-  it('should pass when no argument is passed to the function', (done) => {
+  it('should pass when no argument is passed to the function', () => {
     expect.assertions(1);
     const validator = composeValidators();
-    return validator().then(() => {
-      expect(true).toEqual(true);
-      done();
-    });
+    const result = validator();
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/form-state-manager/src/tests/files/compose-validators.test.js
+++ b/packages/form-state-manager/src/tests/files/compose-validators.test.js
@@ -1,0 +1,71 @@
+import composeValidators from '../../files/compose-validators';
+
+describe('composeValidators', () => {
+  const one = (value) => new Promise((res, rej) => setTimeout(() => (value === 'one' ? rej('error-one') : res()), 200));
+  const two = (value) => new Promise((res, rej) => setTimeout(() => (value === 'two' ? rej('error-two') : res()), 200));
+  const three = (value) => (value === 'three' ? 'error-three' : undefined);
+  const threeCopy = (value) => (value === 'three' ? 'error-three-copy' : undefined);
+
+  it('should fail last sync validator', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators([one, two, three]);
+    validator('three').catch((result) => {
+      expect(result).toEqual('error-three');
+      done();
+    });
+  });
+
+  it('should fail second async validator', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators([one, two, three]);
+    validator('two').catch((result) => {
+      expect(result).toEqual('error-two');
+      done();
+    });
+  });
+
+  it('should fail first async validator', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators([one, two, three]);
+    validator('one').catch((result) => {
+      expect(result).toEqual('error-one');
+      done();
+    });
+  });
+
+  it('should pass all validators', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators([one, two, three]);
+    validator('ok').then((result) => {
+      expect(result).toBeUndefined();
+      done();
+    });
+  });
+
+  it('should pass all async validators', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators([one, two]);
+    validator('ok').then((result) => {
+      expect(result).toBeUndefined();
+      done();
+    });
+  });
+
+  it('should return error message of sync validators in order all validators', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators([three, threeCopy]);
+    return validator('three').catch((result) => {
+      expect(result).toEqual('error-three');
+      done();
+    });
+  });
+
+  it('should pass when no argument is passed to the function', (done) => {
+    expect.assertions(1);
+    const validator = composeValidators();
+    return validator().then(() => {
+      expect(true).toEqual(true);
+      done();
+    });
+  });
+});

--- a/packages/form-state-manager/src/tests/files/use-field.test.js
+++ b/packages/form-state-manager/src/tests/files/use-field.test.js
@@ -32,7 +32,7 @@ const DummyComponent = ({ subscriberProps, managerApi }) => (
   </FormManagerContext.Provider>
 );
 
-describe('useField', () => {
+describe.only('useField', () => {
   let managerApi;
   beforeEach(() => {
     managerApi = createManagerApi(jest.fn());
@@ -70,37 +70,45 @@ describe('useField', () => {
     expect(unregisterSpy).toHaveBeenCalledWith(unregisterArguments);
   });
 
-  it('should set correct value on input type text', () => {
+  it('should set correct value on input type text', async () => {
     const wrapper = mount(<DummyComponent subscriberProps={{ name: 'spy' }} managerApi={managerApi} />);
     const input = wrapper.find('input');
-    input.simulate('change', { target: { value: 'foo' } });
+    await act(async () => {
+      input.simulate('change', { target: { value: 'foo' } });
+    });
     wrapper.update();
     expect(wrapper.find(SpyComponent).prop('value')).toEqual('foo');
   });
 
-  it('should set correct value on input type checkbox', () => {
+  it('should set correct value on input type checkbox', async () => {
     const wrapper = mount(<DummyComponent subscriberProps={{ name: 'spy', type: 'checkbox' }} managerApi={managerApi} />);
     const input = wrapper.find('input');
-    input.simulate('change', { target: { checked: true, type: 'checkbox' } });
+    await act(async () => {
+      input.simulate('change', { target: { checked: true, type: 'checkbox' } });
+    });
     wrapper.update();
     expect(wrapper.find(SpyComponent).prop('checked')).toEqual(true);
   });
 
-  it('should set correct array value', () => {
+  it('should set correct array value', async () => {
     const wrapper = mount(<DummyComponent subscriberProps={{ fakeComponent: true, name: 'spy', changeValue: [] }} managerApi={managerApi} />);
     const input = wrapper.find('button#fake-change');
-    input.simulate('click');
+    await act(async () => {
+      input.simulate('click');
+    });
     wrapper.update();
     expect(wrapper.find(NonInputSpyComponent).prop('value')).toEqual([]);
   });
 
-  it('should set correct on non event object value', () => {
+  it('should set correct on non event object value', async () => {
     const nonEventObject = { value: 1, label: 'bar' };
     const wrapper = mount(
       <DummyComponent subscriberProps={{ fakeComponent: true, name: 'spy', changeValue: nonEventObject }} managerApi={managerApi} />
     );
     const input = wrapper.find('button#fake-change');
-    input.simulate('click');
+    await act(async () => {
+      input.simulate('click');
+    });
     wrapper.update();
     expect(wrapper.find(NonInputSpyComponent).prop('value')).toEqual(nonEventObject);
   });
@@ -431,24 +439,28 @@ describe('useField', () => {
         name: 'async-validate',
         validate: asyncValidator
       };
+
       const wrapper = mount(<DummyComponent managerApi={managerApi} subscriberProps={subscriberProps} />);
-      const spy = wrapper.find(SpyComponent);
       const input = wrapper.find('input');
-      expect(spy.prop('meta')).toEqual(expect.objectContaining({ validating: true, valid: true }));
+      expect(wrapper.find(SpyComponent).prop('meta')).toEqual(expect.objectContaining({ validating: true, valid: true }));
 
       await act(async () => {
         jest.runAllTimers(); // skip initial validation
       });
+      wrapper.update();
 
-      expect(spy.prop('meta')).toEqual(expect.objectContaining({ validating: false, valid: true }));
+      expect(wrapper.find(SpyComponent).prop('meta')).toEqual(expect.objectContaining({ validating: false, valid: true }));
 
-      input.simulate('change', { target: { value: 'foo' } });
+      await act(() => {
+        input.simulate('change', { target: { value: 'foo' } });
+      });
       /**
        * All validations are pending
        */
       await act(async () => {
         jest.advanceTimersByTime(10);
       });
+      wrapper.update();
       expect(wrapper.find(SpyComponent).prop('meta')).toEqual(expect.objectContaining({ validating: true, valid: true }));
       /**
        * Second faster async validation has finished
@@ -456,6 +468,7 @@ describe('useField', () => {
       await act(async () => {
         jest.advanceTimersByTime(290);
       });
+      wrapper.update();
       expect(wrapper.find(SpyComponent).prop('meta')).toEqual(expect.objectContaining({ validating: true, valid: true }));
       /**
        * First slow async validation has finished
@@ -463,6 +476,7 @@ describe('useField', () => {
       await act(async () => {
         jest.advanceTimersByTime(200);
       });
+      wrapper.update();
       expect(wrapper.find(SpyComponent).prop('meta')).toEqual(expect.objectContaining({ validating: false, valid: true }));
     });
   });

--- a/packages/form-state-manager/src/tests/files/use-field.test.js
+++ b/packages/form-state-manager/src/tests/files/use-field.test.js
@@ -32,7 +32,7 @@ const DummyComponent = ({ subscriberProps, managerApi }) => (
   </FormManagerContext.Provider>
 );
 
-describe.only('useField', () => {
+describe('useField', () => {
   let managerApi;
   beforeEach(() => {
     managerApi = createManagerApi(jest.fn());

--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -1134,11 +1134,11 @@ describe('managerApi', () => {
       });
     });
 
-    it('should initialy fail sync form level, but pass on second run validation', () => {
+    it('should initialy fail sync form level, but pass on second run validation', (done) => {
       const managerApi = createManagerApi({ validate: formLevelValidate });
-      const { change, registerField, getFieldState } = managerApi();
-      const getErrorState = () => {
-        let { valid, invalid, validating, errors } = managerApi();
+      const { change, registerField } = managerApi();
+      const getErrorState = (api) => {
+        let { valid, invalid, validating, errors, getFieldState } = api();
         let {
           meta: { error: fieldError, valid: fieldValid, validating: fieldValidating, invalid: fieldInvalid }
         } = getFieldState('foo');
@@ -1150,7 +1150,7 @@ describe('managerApi', () => {
 
       change('foo', 'foo');
 
-      let expectedResult = getErrorState();
+      let expectedResult = getErrorState(managerApi);
       expect(expectedResult).toEqual({
         valid: false,
         invalid: true,
@@ -1164,20 +1164,23 @@ describe('managerApi', () => {
 
       change('foo', 'ok');
 
-      expectedResult = getErrorState();
-      expect(expectedResult).toEqual({
-        valid: true,
-        invalid: false,
-        validating: false,
-        errors: {},
-        fieldError: undefined,
-        fieldValid: true,
-        fieldInvalid: false,
-        fieldValidating: false
+      setImmediate(() => {
+        expectedResult = getErrorState(managerApi);
+        expect(expectedResult).toEqual({
+          valid: true,
+          invalid: false,
+          validating: false,
+          errors: {},
+          fieldError: undefined,
+          fieldValid: true,
+          fieldInvalid: false,
+          fieldValidating: false
+        });
+        done();
       });
     });
 
-    it('should pass sync form level, but fail sync field level validation', () => {
+    it('should pass sync form level, but fail sync field level validation', (done) => {
       const managerApi = createManagerApi({ validate: formLevelValidate });
       const { change, registerField, getFieldState } = managerApi();
       const getErrorState = () => {
@@ -1192,20 +1195,23 @@ describe('managerApi', () => {
       registerField({ name: 'foo', validate: fieldLevelValidate, render: jest.fn() });
 
       change('foo', 'bar');
-      let expectedResult = getErrorState();
-      expect(expectedResult).toEqual({
-        valid: false,
-        invalid: true,
-        validating: false,
-        errors: { foo: 'field-error' },
-        fieldError: 'field-error',
-        fieldValid: false,
-        fieldInvalid: true,
-        fieldValidating: false
+      setImmediate(() => {
+        let expectedResult = getErrorState();
+        expect(expectedResult).toEqual({
+          valid: false,
+          invalid: true,
+          validating: false,
+          errors: { foo: 'field-error' },
+          fieldError: 'field-error',
+          fieldValid: false,
+          fieldInvalid: true,
+          fieldValidating: false
+        });
+        done();
       });
     });
 
-    it('should fail first sync field level validation, but pass on second round', () => {
+    it('should fail first sync field level validation, but pass on second round', (done) => {
       const managerApi = createManagerApi({ validate: formLevelValidate });
       const { change, registerField, getFieldState } = managerApi();
       const getErrorState = () => {
@@ -1220,29 +1226,157 @@ describe('managerApi', () => {
       registerField({ name: 'foo', validate: fieldLevelValidate, render: jest.fn() });
 
       change('foo', 'bar');
-      let expectedResult = getErrorState();
-      expect(expectedResult).toEqual({
-        valid: false,
-        invalid: true,
-        validating: false,
-        errors: { foo: 'field-error' },
-        fieldError: 'field-error',
-        fieldValid: false,
-        fieldInvalid: true,
-        fieldValidating: false
-      });
+      setImmediate(() => {
+        let expectedResult = getErrorState();
+        expect(expectedResult).toEqual({
+          valid: false,
+          invalid: true,
+          validating: false,
+          errors: { foo: 'field-error' },
+          fieldError: 'field-error',
+          fieldValid: false,
+          fieldInvalid: true,
+          fieldValidating: false
+        });
 
-      change('foo', 'ok');
-      expectedResult = getErrorState();
-      expect(expectedResult).toEqual({
-        valid: true,
-        invalid: false,
-        validating: false,
-        errors: {},
-        fieldError: undefined,
-        fieldValid: true,
-        fieldInvalid: false,
-        fieldValidating: false
+        change('foo', 'ok');
+        setImmediate(() => {
+          expectedResult = getErrorState();
+          expect(expectedResult).toEqual({
+            valid: true,
+            invalid: false,
+            validating: false,
+            errors: {},
+            fieldError: undefined,
+            fieldValid: true,
+            fieldInvalid: false,
+            fieldValidating: false
+          });
+          done();
+        });
+      });
+    });
+  });
+
+  describe('validation of a field with multiple listeners', () => {
+    const syncValidate1 = jest.fn().mockImplementation((value) => (value === 'one' ? 'error-one' : undefined));
+    const syncValidate2 = jest.fn().mockImplementation((value) => (value === 'two' ? 'error-two' : undefined));
+    const asyncValidate1 = jest
+      .fn()
+      .mockImplementation((value) => new Promise((res, rej) => setTimeout(() => (value === 'one' ? rej('error-one') : res()), 200)));
+    const asyncValidate2 = jest
+      .fn()
+      .mockImplementation((value) => new Promise((res, rej) => setTimeout(() => (value === 'two' ? rej('error-two') : res()), 200)));
+
+    it('should pass first sync validation but fail second sync validation', (done) => {
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: syncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: syncValidate2, render, internalId: 2 });
+
+      managerApi().change('field', 'two');
+      setImmediate(() => {
+        expect(managerApi().errors).toEqual({ field: 'error-two' });
+        done();
+      });
+    });
+
+    it('should fail first sync validation but pass second sync validation', (done) => {
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: syncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: syncValidate2, render, internalId: 2 });
+
+      managerApi().change('field', 'one');
+
+      setImmediate(() => {
+        expect(managerApi().errors).toEqual({ field: 'error-one' });
+        done();
+      });
+    });
+
+    it('should pass both sync validation', () => {
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: syncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: syncValidate2, render, internalId: 2 });
+
+      managerApi().change('field', 'ok');
+
+      expect(managerApi().errors).toEqual({});
+    });
+
+    it('should pass first async validation but fail second async validation', (done) => {
+      jest.useFakeTimers();
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: asyncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: asyncValidate2, render, internalId: 2 });
+      jest.advanceTimersByTime(200);
+
+      managerApi().change('field', 'two');
+      jest.advanceTimersByTime(200);
+
+      setImmediate(() => {
+        expect(managerApi().errors).toEqual({ field: 'error-two' });
+        done();
+      });
+    });
+
+    it('should pass both async validation', (done) => {
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: asyncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: asyncValidate2, render, internalId: 2 });
+      jest.advanceTimersByTime(200);
+
+      managerApi().change('field', 'ok');
+      jest.advanceTimersByTime(200);
+
+      setImmediate(() => {
+        expect(managerApi().errors).toEqual({});
+        done();
+      });
+    });
+
+    it('should pass first sync validation but fail second async validation', (done) => {
+      jest.useFakeTimers();
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: syncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: asyncValidate2, render, internalId: 2 });
+      jest.advanceTimersByTime(200);
+
+      managerApi().change('field', 'two');
+      jest.advanceTimersByTime(200);
+
+      setImmediate(() => {
+        expect(managerApi().errors).toEqual({ field: 'error-two' });
+        done();
+      });
+    });
+
+    it('should fail sync validation but pass second async validation', (done) => {
+      jest.useFakeTimers();
+      const render = jest.fn();
+
+      const managerApi = createManagerApi({});
+      managerApi().registerField({ name: 'field', validate: syncValidate1, render, internalId: 1 });
+      managerApi().registerField({ name: 'field', validate: asyncValidate2, render, internalId: 2 });
+      jest.advanceTimersByTime(200);
+
+      managerApi().change('field', 'one');
+      jest.advanceTimersByTime(200);
+
+      setImmediate(() => {
+        expect(managerApi().errors).toEqual({ field: 'error-one' });
+        done();
       });
     });
   });

--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -1370,13 +1370,14 @@ describe('managerApi', () => {
       managerApi().registerField({ name: 'field', validate: syncValidate1, render, internalId: 1 });
       managerApi().registerField({ name: 'field', validate: asyncValidate2, render, internalId: 2 });
       jest.advanceTimersByTime(200);
-
-      managerApi().change('field', 'one');
-      jest.advanceTimersByTime(200);
-
       setImmediate(() => {
-        expect(managerApi().errors).toEqual({ field: 'error-one' });
-        done();
+        managerApi().change('field', 'one');
+        jest.advanceTimersByTime(200);
+
+        setImmediate(() => {
+          expect(managerApi().errors).toEqual({ field: 'error-one' });
+          done();
+        });
       });
     });
   });

--- a/packages/form-state-manager/src/types/compose-validators.d.ts
+++ b/packages/form-state-manager/src/types/compose-validators.d.ts
@@ -1,0 +1,6 @@
+import { Validator } from './validate';
+import AnyObject from './any-object';
+
+export type ComposeValidators = (validators: Validator[]) => (value: any, allValues: AnyObject) => string | undefined | Promise<string | undefined>;
+
+export default ComposeValidators;

--- a/packages/form-state-manager/src/types/compose-validators.d.ts
+++ b/packages/form-state-manager/src/types/compose-validators.d.ts
@@ -1,6 +1,6 @@
 import { Validator } from './validate';
 import AnyObject from './any-object';
 
-export type ComposeValidators = (validators: Validator[]) => (value: any, allValues: AnyObject) => Promise<string | undefined>;
+export type ComposeValidators = (validators: Validator[]) => (value: any, allValues: AnyObject) => Promise<string | undefined> | string | undefined;
 
 export default ComposeValidators;

--- a/packages/form-state-manager/src/types/compose-validators.d.ts
+++ b/packages/form-state-manager/src/types/compose-validators.d.ts
@@ -1,6 +1,6 @@
 import { Validator } from './validate';
 import AnyObject from './any-object';
 
-export type ComposeValidators = (validators: Validator[]) => (value: any, allValues: AnyObject) => string | undefined | Promise<string | undefined>;
+export type ComposeValidators = (validators: Validator[]) => (value: any, allValues: AnyObject) => Promise<string | undefined>;
 
 export default ComposeValidators;

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -64,6 +64,7 @@ export interface ListenerField {
   subscription?: Subscription;
   afterSubmit?: AfterSubmit;
   beforeSubmit?: BeforeSubmit;
+  validate?: Validator;
 }
 
 export interface FieldListenerFields {
@@ -73,7 +74,6 @@ export interface FieldListenerFields {
 export interface FieldListener {
   count: number;
   state: FieldState;
-  validate?: Validator;
   isEqual?: IsEqual;
   asyncWatcher: AsyncWatcherApi;
   fields: FieldListenerFields;

--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -297,11 +297,15 @@ const createManagerApi: CreateManagerApi = ({
         .filter((validator) => validator !== undefined);
 
       if (validators.length > 0) {
-        const result = composeValidators(validators as Validator[])(value, state.values)
-          .then(() => handleFieldError(name, true))
-          .catch((response) => handleFieldError(name, false, response as string | undefined));
-
-        listener.registerValidator(result);
+        const result = composeValidators(validators as Validator[])(value, state.values);
+        if (isPromise(result)) {
+          (result as Promise<string | undefined>)
+            .then(() => handleFieldError(name, true))
+            .catch((response) => handleFieldError(name, false, response as string | undefined));
+          listener.registerValidator(result as Promise<string | undefined>);
+        } else {
+          handleFieldError(name, !result, result as string | undefined);
+        }
       }
     }
   }


### PR DESCRIPTION
part of https://github.com/data-driven-forms/react-forms/issues/739

I have added `composeValidators` but then I have realized, it's not usable for this feature. I have not added test but we will need this function later anyway.