### PR TITLE
fix(renderer): serialize validate config to prevent infinite loop

### DIFF
--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -1,17 +1,27 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import FormRenderer from '../src';
+import FormRenderer, { useFieldApi, validatorTypes, componentTypes } from '../src';
 import componentMapper from './form-fields-mapper';
 import FormTemplate from './form-template';
+
+// eslint-disable-next-line react/prop-types
+const TextField = ({ name, label }) => {
+  const { input } = useFieldApi({ name, validate: [{ type: validatorTypes.REQUIRED }] });
+  return (
+    <div>
+      <label>{label}</label>
+      <input {...input} />
+    </div>
+  );
+};
 
 const fileSchema = {
   fields: [
     {
       component: 'text-field',
-      name: 'file-upload',
-      type: 'file',
-      label: 'file upload'
+      name: 'foo',
+      label: 'Foo'
     }
   ]
 };
@@ -21,7 +31,10 @@ const App = () => {
   return (
     <div style={{ padding: 20 }}>
       <FormRenderer
-        componentMapper={componentMapper}
+        componentMapper={{
+          ...componentMapper,
+          [componentTypes.TEXT_FIELD]: TextField
+        }}
         onSubmit={(values, ...args) => console.log(values, args)}
         FormTemplate={FormTemplate}
         schema={fileSchema}

--- a/packages/react-form-renderer/src/files/use-field-api.js
+++ b/packages/react-form-renderer/src/files/use-field-api.js
@@ -96,7 +96,13 @@ const useFieldApi = ({ name, initializeOnMount, component, render, validate, res
         arrayValidator: calculateArrayValidator(props, validate, component, validatorMapper)
       });
     }
-  }, [validate, component, props.dataType]);
+    /**
+     * We have to stringify the validate array in order to preven infinite looping when validate was passed directly to useFieldApi
+     * const x = useFieldApu({name: 'foo', validate: [{type: 'bar'}]}) will trigger infinite looping witouth the serialize.
+     * Using stringify is acceptable here since the array is usually very small.
+     * If we notice performance hit, we can implement custom hook with a deep equal functionality.
+     */
+  }, [validate ? JSON.stringify(validate) : false, component, props.dataType]);
 
   /** Re-convert initialValue when changed */
   useEffect(() => {


### PR DESCRIPTION
### Use a component like this in your form
```jsx
const TextField = ({ name, label }) => {
  const { input, meta } = useFieldApi({ name, validate: [{ type: validatorTypes.REQUIRED }] }); // the direct validate reference is the issue here
  return (
    <div>
      <label>{label}</label>
      <input {...input} />
    </div>
  );
};
```

Defining the `validate` constant directly inside the `useFieldApi` causes infinite looping. This is caused by `useEffect` which is resetting validators on `validate` change. Since in JS `[] !== []` and due to a fact that the `validate` array is a new instance in each render when used like in the example, we will be stuck in an infinite loop and crash the UI.

### Changes
- serialize validate config to prevent infinite loop