### PR TITLE
fix(pf3): fix incorrect invalid prop type in select component

### DIFF
--- a/packages/pf3-component-mapper/src/files/select.js
+++ b/packages/pf3-component-mapper/src/files/select.js
@@ -20,7 +20,7 @@ const Select = (props) => {
       inputAddon={inputAddon}
     >
       <div>
-        <DataDrivenSelect classNamePrefix="ddorg__pf3-component-mapper__select" invalid={validationError(meta, validateOnMount)} {...rest} />
+        <DataDrivenSelect classNamePrefix="ddorg__pf3-component-mapper__select" invalid={!!validationError(meta, validateOnMount)} {...rest} />
       </div>
     </FormGroup>
   );


### PR DESCRIPTION
The power of a two-character fix!

Fixed console prop types warning.