### PR TITLE
Changed validator mapper type to export object

### DIFF
--- a/packages/react-form-renderer/src/files/form-renderer.d.ts
+++ b/packages/react-form-renderer/src/files/form-renderer.d.ts
@@ -3,7 +3,7 @@ import { FormApi, SubmissionErrors } from 'final-form';
 import { FormProps } from 'react-final-form';
 import Schema from './schema';
 import ComponentMapper from './component-mapper';
-import ValidatorMapper from './validator-mapper';
+import { ValidatorMapper} from './validator-mapper';
 import ActionMapper from './action-mapper';
 import SchemaValidatorMapper from './schema-validator-mapper';
 import { FormTemplateRenderProps } from './form-template-render-props';

--- a/packages/react-form-renderer/src/files/renderer-context.d.ts
+++ b/packages/react-form-renderer/src/files/renderer-context.d.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { FormApi } from 'final-form';
 import ComponentMapper from './component-mapper';
-import ValidatorMapper from './validator-mapper';
+import { ValidatorMapper } from './validator-mapper';
 import ActionMapper from './action-mapper';
 import Field from './field';
 import { AnyObject } from './common';

--- a/packages/react-form-renderer/src/files/validator-mapper.d.ts
+++ b/packages/react-form-renderer/src/files/validator-mapper.d.ts
@@ -1,5 +1,6 @@
-interface ValidatorMapper {
-  [key: string]: (options: object) => (value: any, allValues: object) => string;
+export interface ValidatorMapper {
+  [key: string]: (options?: object) => (value: any, allValues: object) => string | undefined;
 }
 
-export default ValidatorMapper;
+declare const validatorMapper: ValidatorMapper;
+export default validatorMapper;

--- a/packages/react-form-renderer/src/form-renderer/validator-helpers.d.ts
+++ b/packages/react-form-renderer/src/form-renderer/validator-helpers.d.ts
@@ -1,6 +1,6 @@
 import { ValidatorType } from "../files/use-field-api";
 import { ReactNode } from "react";
-import ValidatorMapper from "../files/validator-mapper";
+import { ValidatorMapper } from "../files/validator-mapper";
 import { DataType } from "../files/data-types";
 
 export type ValidatorFunction = (value: any, allValues: object) => ReactNode | undefined;


### PR DESCRIPTION
When implementing the solution in https://github.com/data-driven-forms/react-forms/issues/764#issuecomment-680849795 I noticed that Typescript will throw an error `'validatorMapper' only refers to a type, but is being used as a value here.ts(2693).` when trying to import `validatorMapper`.

I realized that it should export a variable of this type by default since that is what is going on in https://github.com/data-driven-forms/react-forms/blob/862db36f2155cec9a6027464e9b158b4966048db/packages/react-form-renderer/src/files/validator-mapper.js#L6-L18