### PR TITLE
fix(renderer): make component option in use field api interface

### DIFF
--- a/packages/react-form-renderer/src/files/use-field-api.d.ts
+++ b/packages/react-form-renderer/src/files/use-field-api.d.ts
@@ -9,7 +9,6 @@ export interface ValidatorType extends Object {
 
 export interface UseFieldApiConfig extends AnyObject {
   name: string;
-  component: string;
   validate?: ValidatorType[];
 }
 export interface UseFieldApiComponentConfig extends UseFieldConfig<any>  {


### PR DESCRIPTION
The component attribute should not be inside the useFieldApi config. Only in the schema.