### PR TITLE
Redirect on examples when no mapper

### DIFF
--- a/packages/react-renderer-demo/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/components/component-example.js
@@ -157,9 +157,14 @@ const mapperTab = {
 
 const ComponentExample = ({ variants, schema, activeMapper, component }) => {
   const activeTab = mapperTab[activeMapper];
-  const { pathname, push } = useRouter();
+  const { pathname, push, query, asPath } = useRouter();
   const classes = useStyles();
   useEffect(() => {
+    if (!query?.mapper) {
+      const [path, hash] = asPath.split('#');
+      push(`${path}?mapper=mui${hash ? `#${hash}` : ''}`);
+    }
+
     sdk.embedProject(
       'code-target',
       {


### PR DESCRIPTION
- this should prevent algolia to index MUI components twice in the search index