### PR TITLE
feat(manager): rerender form on basic functions

### DIFF
--- a/packages/form-state-manager/src/files/use-field.ts
+++ b/packages/form-state-manager/src/files/use-field.ts
@@ -66,6 +66,7 @@ const useField = ({
   beforeSubmit,
   afterSubmit,
   allowNull,
+  silent,
   ...props
 }: UseField): UseFieldData => {
   const { registerField, unregisterField, change, getFieldValue, blur, focus, formOptions, ...rest } = useContext(FormManagerContext);
@@ -83,7 +84,8 @@ const useField = ({
       internalId,
       defaultValue: dataType ? convertValue(defaultValue, dataType) : defaultValue,
       beforeSubmit,
-      afterSubmit
+      afterSubmit,
+      silent
     });
 
     return internalId;

--- a/packages/form-state-manager/src/tests/files/use-field-array.test.js
+++ b/packages/form-state-manager/src/tests/files/use-field-array.test.js
@@ -6,13 +6,13 @@ import useFieldArray from '../../files/use-field-array';
 import FormStateManager from '../../files/form-state-manager';
 
 const DummyInput = (props) => {
-  const { input, meta } = useField(props);
+  const { input, meta } = useField({ ...props, silent: true });
   return <input {...input} />;
 };
 
 const CompositeDummyInput = ({ name, ...props }) => {
-  const firstField = useField({ ...props, name: `${name}.first-field` });
-  const secondField = useField({ ...props, name: `${name}.second-field` });
+  const firstField = useField({ ...props, name: `${name}.first-field`, silent: true });
+  const secondField = useField({ ...props, name: `${name}.second-field`, silent: true });
   return (
     <Fragment>
       <input {...firstField.input} />

--- a/packages/form-state-manager/src/tests/utils/manager-api.test.js
+++ b/packages/form-state-manager/src/tests/utils/manager-api.test.js
@@ -692,8 +692,10 @@ describe('managerApi', () => {
       managerApi().registerField({ ...field1 });
       managerApi().registerField({ ...field2 });
 
-      expect(renderField1).not.toHaveBeenCalled();
+      expect(renderField1).toHaveBeenCalled(); // registeredFields was changed
       expect(renderField2).not.toHaveBeenCalled();
+
+      renderField1.mockReset();
 
       managerApi().rerender(['values']);
 
@@ -727,8 +729,10 @@ describe('managerApi', () => {
       managerApi().registerField({ ...field1 });
       managerApi().registerField({ ...field2, subscription: { valid: true } });
 
-      expect(renderField1).not.toHaveBeenCalled();
+      expect(renderField1).toHaveBeenCalled(); // registeredFields was changed
       expect(renderField2).not.toHaveBeenCalled();
+
+      renderField1.mockReset();
 
       managerApi().rerender(['values']);
 

--- a/packages/form-state-manager/src/types/field-config.d.ts
+++ b/packages/form-state-manager/src/types/field-config.d.ts
@@ -1,5 +1,5 @@
 import AnyObject from './any-object';
-import { Subscription } from './use-subscription';
+import { Subscription } from './use-field';
 import { FieldRender } from './manager-api';
 import { Validator } from './validate';
 
@@ -25,6 +25,7 @@ export interface FieldConfig extends AnyObject {
   data?: AnyObject;
   afterSubmit?: AfterSubmit;
   beforeSubmit?: BeforeSubmit;
+  silent?: boolean;
 }
 
 export default FieldConfig;

--- a/packages/form-state-manager/src/types/use-field.d.ts
+++ b/packages/form-state-manager/src/types/use-field.d.ts
@@ -81,6 +81,7 @@ export interface UseField extends AnyObject {
   afterSubmit?: AfterSubmit;
   beforeSubmit?: BeforeSubmit;
   allowNull?: boolean;
+  silent?: boolean;
 }
 
 export default UseField;


### PR DESCRIPTION
This PR rerenders form on these events:
- register field
- unregister field
- initialize
- reset
- resetFieldState
- blur
- focus
- change

not tested yet but should work:
- submitting (submit is not properly implemented now)
- validating
- error
- valid

also implements silent from https://github.com/data-driven-forms/react-forms/issues/726 because we have encountered the same issue as all other libraries. React does not like rendering from the first render..  we should probably brainstorm a solution of registering field in useEffect..(edit: I have an idea, will try it after this PR is merged)