### PR TITLE
Revert "Redirect on examples when no mapper" 

### DIFF
--- a/packages/react-renderer-demo/src/components/component-example.js
+++ b/packages/react-renderer-demo/src/components/component-example.js
@@ -157,14 +157,9 @@ const mapperTab = {
 
 const ComponentExample = ({ variants, schema, activeMapper, component }) => {
   const activeTab = mapperTab[activeMapper];
-  const { pathname, push, query, asPath } = useRouter();
+  const { pathname, push } = useRouter();
   const classes = useStyles();
   useEffect(() => {
-    if (!query?.mapper) {
-      const [path, hash] = asPath.split('#');
-      push(`${path}?mapper=mui${hash ? `#${hash}` : ''}`);
-    }
-
     sdk.embedProject(
       'code-target',
       {

--- a/packages/react-renderer-demo/src/pages/404.js
+++ b/packages/react-renderer-demo/src/pages/404.js
@@ -64,7 +64,16 @@ const Custom404 = () => {
 
     if (asPath.includes('/component-example/')) {
       setLoading(true);
-      push(asPath.replace('/component-example/', '/mappers/'));
+
+      let newPath = asPath.replace('/component-example/', '/mappers/');
+
+      if (!newPath.match(/\?mapper=/) && !newPath.match(/#/)) {
+        newPath = `${newPath}?mapper=mui`;
+      } else if (!newPath.match(/\?mapper=/)) {
+        newPath = newPath.replace(/#/, '?mapper=mui#');
+      }
+
+      push(newPath);
     } else if (asPath.startsWith('/renderer/condition#') && conditionHashMapper[hash]) {
       setLoading(true);
       push(`/schema/${conditionHashMapper[hash]}`);


### PR DESCRIPTION
- so the previous PR actually made impossible to crawl these results so I reverted it :sob: :sob: :skull: 
- I also added the query param when users are redirected from the old route.