### PR TITLE
fix(manager): fix rendering issues by rerendering forms on mount

### DIFF
--- a/packages/form-state-manager/src/files/use-field.ts
+++ b/packages/form-state-manager/src/files/use-field.ts
@@ -66,7 +66,6 @@ const useField = ({
   beforeSubmit,
   afterSubmit,
   allowNull,
-  silent,
   ...props
 }: UseField): UseFieldData => {
   const { registerField, unregisterField, change, getFieldValue, blur, focus, formOptions, ...rest } = useContext(FormManagerContext);
@@ -85,7 +84,7 @@ const useField = ({
       defaultValue: dataType ? convertValue(defaultValue, dataType) : defaultValue,
       beforeSubmit,
       afterSubmit,
-      silent
+      silent: true
     });
 
     return internalId;
@@ -121,8 +120,12 @@ const useField = ({
   };
 
   useEffect(
-    () => () => {
-      unregisterField({ name, clearOnUnmount, internalId: id, value: finalClearedValue });
+    () => {
+      formOptions().afterSilentRegistration({ name, internalId: id });
+
+      return () => {
+        unregisterField({ name, clearOnUnmount, internalId: id, value: finalClearedValue });
+      };
     },
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );

--- a/packages/form-state-manager/src/tests/files/use-field-array.test.js
+++ b/packages/form-state-manager/src/tests/files/use-field-array.test.js
@@ -6,13 +6,13 @@ import useFieldArray from '../../files/use-field-array';
 import FormStateManager from '../../files/form-state-manager';
 
 const DummyInput = (props) => {
-  const { input, meta } = useField({ ...props, silent: true });
+  const { input, meta } = useField({ ...props });
   return <input {...input} />;
 };
 
 const CompositeDummyInput = ({ name, ...props }) => {
-  const firstField = useField({ ...props, name: `${name}.first-field`, silent: true });
-  const secondField = useField({ ...props, name: `${name}.second-field`, silent: true });
+  const firstField = useField({ ...props, name: `${name}.first-field` });
+  const secondField = useField({ ...props, name: `${name}.second-field` });
   return (
     <Fragment>
       <input {...firstField.input} />

--- a/packages/form-state-manager/src/tests/files/use-field.test.js
+++ b/packages/form-state-manager/src/tests/files/use-field.test.js
@@ -58,7 +58,8 @@ describe('useField', () => {
       name: 'spy',
       initialValue: 'foo',
       render: expect.any(Function),
-      internalId: expect.any(Number)
+      internalId: expect.any(Number),
+      silent: true
     };
     const unregisterArguments = {
       name: 'spy',

--- a/packages/form-state-manager/src/types/manager-api.d.ts
+++ b/packages/form-state-manager/src/types/manager-api.d.ts
@@ -44,6 +44,7 @@ export type IsValidationPaused = () => boolean;
 export type PauseValidation = () => void;
 export type ResumeValidation = () => void;
 export type SetConfig = (attribute: keyof CreateManagerApiConfig, value: any) => void;
+export type AfterSilentRegistration = (field: Omit<FieldConfig, 'render'>) => void;
 
 export interface AsyncWatcherRecord {
   [key: number]: Promise<unknown>;
@@ -110,7 +111,8 @@ export type ManagerApiFunctions =
   | 'isValidationPaused'
   | 'pauseValidation'
   | 'resumeValidation'
-  | 'setConfig';
+  | 'setConfig'
+  | 'afterSilentRegistration';
 
 export interface ManagerState {
   values: AnyObject;
@@ -142,6 +144,7 @@ export interface ManagerState {
   pauseValidation: PauseValidation;
   resumeValidation: ResumeValidation;
   setConfig: SetConfig;
+  afterSilentRegistration: AfterSilentRegistration;
   registeredFields: Array<string>;
   fieldListeners: FieldListeners;
   active: string | undefined;


### PR DESCRIPTION
- to avoid rendering other fields during initialization of a field, this render is called in `useEffect` via `afterSilentRegistration` function. This function revalidates all fields and rerender all fields (except the one that has been just registered) based on changed form state attributes from the last field registration.