### PR TITLE
fix(renderer): fix wizard context export type

### DIFF
--- a/packages/react-form-renderer/src/files/wizard-context.d.ts
+++ b/packages/react-form-renderer/src/files/wizard-context.d.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { FormOptions } from './renderer-context';
 
 export interface WizardContextValue {
@@ -16,8 +17,6 @@ export interface WizardContextValue {
   prevSteps: string[];
 }
 
-interface WizardContext {
-  value: WizardContextValue;
-}
+declare const WizardContext: React.Context<WizardContextValue>;
 
 export default WizardContext;


### PR DESCRIPTION
closes https://github.com/data-driven-forms/react-forms/issues/786

Changed wizard context type to constant from an interface