### PR TITLE
Make tables fixed on smaller screens

### DIFF
--- a/packages/react-renderer-demo/src/components/mdx/mdx-components.js
+++ b/packages/react-renderer-demo/src/components/mdx/mdx-components.js
@@ -59,6 +59,31 @@ export const Heading = ({ level, children, component }) => {
   );
 };
 
+const tableStyles = makeStyles((theme) => ({
+  table: {
+    [theme.breakpoints.down('sm')]: {
+      tableLayout: 'fixed'
+    }
+  },
+  cell: {
+    [theme.breakpoints.down('sm')]: {
+      overflow: 'overlay'
+    }
+  }
+}));
+
+const StyledCell = (props) => {
+  const { cell } = tableStyles();
+
+  return <TableCell {...props} className={cell} />;
+};
+
+const StyledTable = (props) => {
+  const { table } = tableStyles();
+
+  return <Table {...props} className={table} />;
+};
+
 const MdLink = ({ href, children }) => {
   const classes = useHeadingStyles();
   return href.startsWith('/') ? (
@@ -94,15 +119,15 @@ const MdxComponents = {
   ),
   table: ({ children }) => (
     <Paper style={{ marginBottom: 10, marginTop: 10 }} className="DocTable">
-      <Table>
+      <StyledTable>
         <TableHead>{children[0].props.children}</TableHead>
         <TableBody>{children[1].props.children}</TableBody>
-      </Table>
+      </StyledTable>
     </Paper>
   ),
   tr: ({ children }) => <TableRow>{children}</TableRow>,
-  td: ({ children }) => <TableCell>{children}</TableCell>,
-  th: ({ children }) => <TableCell>{children}</TableCell>,
+  td: ({ children }) => <StyledCell>{children}</StyledCell>,
+  th: ({ children }) => <StyledCell>{children}</StyledCell>,
   inlineCode: ({ children }) => (
     <code style={{ background: 'white', borderRadius: 3, fontFamily: 'courier, monospace', padding: '3px' }}>{children}</code>
   )


### PR DESCRIPTION
Material UI tables are not very responsive on smaller screens, so I fixed it (it messes with the menu width)

**Before**

![image](https://user-images.githubusercontent.com/32869456/92492258-71fd6400-f1f3-11ea-8f8b-5843915bae4a.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/92492237-6ca01980-f1f3-11ea-9c94-5281fe1c5066.png)
