### PR TITLE
 feat(renderer): add useWarnings functionality

### DIFF
--- a/packages/react-form-renderer/src/files/compose-validators.js
+++ b/packages/react-form-renderer/src/files/compose-validators.js
@@ -1,17 +1,20 @@
 const composeValidators = (validators = []) => (value, allValues, meta) => {
   const [initialValidator, ...sequenceValidators] = validators;
-  const resolveValidator = (error, validator) => error || (typeof validator === 'function' ? validator(value, allValues, meta) : undefined);
-  if (initialValidator && typeof initialValidator === 'function') {
-    const result = initialValidator(value, allValues, meta);
-    if (result && result.then) {
-      return result.then(() => sequenceValidators.reduce(resolveValidator, undefined)).catch((error) => error);
+  const resolveValidator = (error, validator) => {
+    if (error) {
+      return error;
     }
+
+    return validator(value, allValues, meta);
+  };
+
+  const result = resolveValidator(undefined, initialValidator);
+
+  if (result?.then) {
+    return result.then(() => sequenceValidators.reduce(resolveValidator, undefined)).catch((error) => error);
   }
 
-  return validators.reduce(
-    (error, validator) => error || (typeof validator === 'function' ? validator(value, allValues, meta) : undefined),
-    undefined
-  );
+  return sequenceValidators.reduce(resolveValidator, result);
 };
 
 export default composeValidators;

--- a/packages/react-form-renderer/src/files/compose-validators.js
+++ b/packages/react-form-renderer/src/files/compose-validators.js
@@ -5,6 +5,10 @@ const composeValidators = (validators = []) => (value, allValues, meta) => {
       return error;
     }
 
+    if (typeof validator !== 'function') {
+      return undefined;
+    }
+
     return validator(value, allValues, meta);
   };
 

--- a/packages/react-form-renderer/src/files/field.d.ts
+++ b/packages/react-form-renderer/src/files/field.d.ts
@@ -4,6 +4,7 @@ import { DataType } from "./data-types";
 import { AnyObject } from "./common";
 import { FieldMetaState, FieldInputProps } from "react-final-form";
 import { FormOptions } from "./renderer-context";
+import { Meta } from "./use-field-api";
 
 export type FieldAction = [string, ...any[]];
 
@@ -12,7 +13,7 @@ export interface FieldActions {
 }
 
 export interface FieldApi<FieldValue, T extends HTMLElement = HTMLElement> {
-  meta: FieldMetaState<FieldValue>;
+  meta: Meta<FieldValue>;
   input: FieldInputProps<FieldValue, T>;
 }
 

--- a/packages/react-form-renderer/src/files/use-field-api.d.ts
+++ b/packages/react-form-renderer/src/files/use-field-api.d.ts
@@ -11,7 +11,6 @@ export interface UseFieldApiConfig extends AnyObject {
   name: string;
   validate?: ValidatorType[];
   useWarnings?: boolean;
-  convertWarningToError?: boolean;
 }
 export interface UseFieldApiComponentConfig extends UseFieldConfig<any>  {
   name: string;

--- a/packages/react-form-renderer/src/files/use-field-api.d.ts
+++ b/packages/react-form-renderer/src/files/use-field-api.d.ts
@@ -17,11 +17,15 @@ export interface UseFieldApiComponentConfig extends UseFieldConfig<any>  {
   name: string;
 }
 
+export interface Meta<FieldValue> extends FieldMetaState<FieldValue> {
+  warning?: any;
+}
+
 export interface UseFieldApiProps<
  FieldValue,
 T extends HTMLElement = HTMLElement> extends AnyObject {
   input: FieldInputProps<FieldValue, T>;
-  meta: FieldMetaState<FieldValue>;
+  meta: Meta<FieldValue>;
 }
 
 export default function<T = any>(options: UseFieldApiConfig): UseFieldApiProps<T>;

--- a/packages/react-form-renderer/src/files/use-field-api.d.ts
+++ b/packages/react-form-renderer/src/files/use-field-api.d.ts
@@ -10,6 +10,8 @@ export interface ValidatorType extends Object {
 export interface UseFieldApiConfig extends AnyObject {
   name: string;
   validate?: ValidatorType[];
+  useWarnings?: boolean;
+  convertWarningToError?: boolean;
 }
 export interface UseFieldApiComponentConfig extends UseFieldConfig<any>  {
   name: string;

--- a/packages/react-form-renderer/src/files/use-field-api.js
+++ b/packages/react-form-renderer/src/files/use-field-api.js
@@ -66,7 +66,7 @@ const createFieldProps = (name, formOptions) => {
   };
 };
 
-const useFieldApi = ({ name, initializeOnMount, component, render, validate, resolveProps, useWarnings, ...props }) => {
+const useFieldApi = ({ name, initializeOnMount, component, render, validate, resolveProps, useWarnings, convertWarningToError, ...props }) => {
   const { validatorMapper, formOptions } = useContext(RendererContext);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -219,7 +219,8 @@ const useFieldApi = ({ name, initializeOnMount, component, render, validate, res
     ...(useWarnings && {
       meta: {
         ...fieldProps.meta,
-        warning
+        warning,
+        ...(convertWarningToError && { error: warning })
       }
     }),
     input: {

--- a/packages/react-form-renderer/src/files/use-field-api.js
+++ b/packages/react-form-renderer/src/files/use-field-api.js
@@ -84,7 +84,7 @@ const createFieldProps = (name, formOptions) => {
   };
 };
 
-const useFieldApi = ({ name, initializeOnMount, component, render, validate, resolveProps, useWarnings, convertWarningToError, ...props }) => {
+const useFieldApi = ({ name, initializeOnMount, component, render, validate, resolveProps, useWarnings, ...props }) => {
   const { validatorMapper, formOptions } = useContext(RendererContext);
   const [warning, setWarning] = useState();
 
@@ -216,8 +216,7 @@ const useFieldApi = ({ name, initializeOnMount, component, render, validate, res
     ...(useWarnings && {
       meta: {
         ...fieldProps.meta,
-        warning,
-        ...(convertWarningToError && { error: warning })
+        warning
       }
     }),
     input: {

--- a/packages/react-form-renderer/src/files/validator-mapper.d.ts
+++ b/packages/react-form-renderer/src/files/validator-mapper.d.ts
@@ -1,5 +1,7 @@
+import { ValidatorFunction } from "./validators";
+
 export interface ValidatorMapper {
-  [key: string]: (options?: object) => (value: any, allValues: object) => string | undefined;
+  [key: string]: (options?: object) => ValidatorFunction;
 }
 
 declare const validatorMapper: ValidatorMapper;

--- a/packages/react-form-renderer/src/files/validators.d.ts
+++ b/packages/react-form-renderer/src/files/validators.d.ts
@@ -9,6 +9,7 @@ export interface ValidatorConfiguration extends AnyObject {
   type: string;
   message?: string;
   msg?: string;
+  warning?: boolean;
 }
 
 export type Validator = ValidatorConfiguration | ValidatorFunction;

--- a/packages/react-form-renderer/src/form-renderer/validator-helpers.d.ts
+++ b/packages/react-form-renderer/src/form-renderer/validator-helpers.d.ts
@@ -5,6 +5,8 @@ import { DataType } from "../files/data-types";
 
 export type ValidatorFunction = (value: any, allValues: object) => ReactNode | undefined;
 
+export type convertToWarning = (validator: ValidatorType) => ValidatorFunction;
+
 export function prepareValidator(
   validator: ValidatorFunction | ValidatorType,
   mapper: ValidatorMapper): ValidatorFunction;

--- a/packages/react-form-renderer/src/form-renderer/validator-helpers.d.ts
+++ b/packages/react-form-renderer/src/form-renderer/validator-helpers.d.ts
@@ -2,8 +2,7 @@ import { ValidatorType } from "../files/use-field-api";
 import { ReactNode } from "react";
 import { ValidatorMapper } from "../files/validator-mapper";
 import { DataType } from "../files/data-types";
-
-export type ValidatorFunction = (value: any, allValues: object) => ReactNode | undefined;
+import { ValidatorFunction } from "../files/validators";
 
 export type convertToWarning = (validator: ValidatorType) => ValidatorFunction;
 

--- a/packages/react-form-renderer/src/form-renderer/validator-helpers.js
+++ b/packages/react-form-renderer/src/form-renderer/validator-helpers.js
@@ -2,8 +2,22 @@ import { memoize } from '../validators/helpers';
 import { dataTypeValidator } from '../validators';
 import composeValidators from '../files/compose-validators';
 
-export const prepareValidator = (validator, mapper) =>
-  typeof validator === 'function' ? memoize(validator) : mapper[validator.type]({ ...validator });
+export const convertToWarning = (validator) => (...args) => ({
+  type: 'warning',
+  error: validator(...args)
+});
+
+export const prepareValidator = (validator, mapper) => {
+  if (typeof validator === 'function') {
+    return memoize(validator);
+  }
+
+  if (validator.warning) {
+    return convertToWarning(mapper[validator.type]({ ...validator }));
+  }
+
+  return mapper[validator.type]({ ...validator });
+};
 
 export const getValidate = (validate, dataType, mapper = {}) => [
   ...(validate ? validate.map((validator) => prepareValidator(validator, mapper)) : []),

--- a/packages/react-form-renderer/src/tests/form-renderer/validator.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/validator.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
 import FormRenderer from '../../files/form-renderer';
 import componentTypes from '../../files/component-types';
 import FormTemplate from '../../../../../__mocks__/mock-form-template';
 import useFieldApi from '../../files/use-field-api';
-import { act } from 'react-dom/test-utils';
 
 describe('FormRenderer validator', () => {
   const TextField = (props) => {
@@ -18,11 +18,12 @@ describe('FormRenderer validator', () => {
     );
   };
 
+  const VALUE = 'some-value';
+  const NAME = 'field1';
+
   it('pass value, allvalues, meta to custom validator func', async () => {
     expect.assertions(3);
 
-    const VALUE = 'some-value';
-    const NAME = 'field1';
     const META = expect.any(Object);
 
     const validator = (value, allValues, meta) => {
@@ -53,6 +54,108 @@ describe('FormRenderer validator', () => {
 
     await act(async () => {
       wrapper.find('input').simulate('change', { target: { value: VALUE } });
+    });
+  });
+
+  describe('warning validators', () => {
+    const TextFieldWarning = (props) => {
+      const { input, meta, ...rest } = useFieldApi(props);
+      return (
+        <div>
+          <input {...input} {...rest} />
+          {meta.warning && <div id="warning">{meta.warning}</div>}
+        </div>
+      );
+    };
+
+    let wrapper;
+
+    it('should not convert object validator to warning when warnings are not used', async () => {
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            FormTemplate={FormTemplate}
+            componentMapper={{
+              [componentTypes.TEXT_FIELD]: TextFieldWarning
+            }}
+            schema={{
+              fields: [{ component: 'text-field', name: NAME, validate: [{ type: 'required', warning: true }] }]
+            }}
+            onSubmit={jest.fn()}
+          />
+        );
+      });
+      wrapper.update();
+
+      expect(wrapper.find('#warning')).toHaveLength(0);
+    });
+
+    it('should convert object validator to warning', async () => {
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            FormTemplate={FormTemplate}
+            componentMapper={{
+              [componentTypes.TEXT_FIELD]: TextFieldWarning
+            }}
+            schema={{
+              fields: [{ useWarnings: true, component: 'text-field', name: NAME, validate: [{ type: 'required', warning: true }] }]
+            }}
+            onSubmit={jest.fn()}
+          />
+        );
+      });
+      wrapper.update();
+
+      expect(wrapper.find('#warning').text()).toEqual('Required');
+    });
+
+    it('should convert function validator to warning', async () => {
+      const ERROR = 'SOME-ERROR';
+
+      const customValidator = () => ({ type: 'warning', error: ERROR });
+
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            FormTemplate={FormTemplate}
+            componentMapper={{
+              [componentTypes.TEXT_FIELD]: TextFieldWarning
+            }}
+            schema={{
+              fields: [{ useWarnings: true, component: 'text-field', name: NAME, validate: [customValidator] }]
+            }}
+            onSubmit={jest.fn()}
+          />
+        );
+      });
+      wrapper.update();
+
+      expect(wrapper.find('#warning').text()).toEqual(ERROR);
+    });
+
+    it('should convert async function validator to warning', async () => {
+      const ERROR = 'SOME-ERROR';
+
+      const customValidator = () => new Promise((res, rej) => setTimeout(() => rej({ type: 'warning', error: ERROR })));
+
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            FormTemplate={FormTemplate}
+            componentMapper={{
+              [componentTypes.TEXT_FIELD]: TextFieldWarning
+            }}
+            schema={{
+              fields: [{ useWarnings: true, component: 'text-field', name: NAME, validate: [customValidator] }]
+            }}
+            onSubmit={jest.fn()}
+          />
+        );
+      });
+      wrapper.update();
+
+      expect(wrapper.find('#warning').text()).toEqual(ERROR);
     });
   });
 });

--- a/packages/react-form-renderer/src/tests/form-renderer/validator.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/validator.test.js
@@ -110,6 +110,34 @@ describe('FormRenderer validator', () => {
       expect(wrapper.find('#warning').text()).toEqual('Required');
     });
 
+    it('should convert warning to error', async () => {
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            FormTemplate={FormTemplate}
+            componentMapper={{
+              [componentTypes.TEXT_FIELD]: TextField
+            }}
+            schema={{
+              fields: [
+                {
+                  useWarnings: true,
+                  convertWarningToError: true,
+                  component: 'text-field',
+                  name: NAME,
+                  validate: [{ type: 'required', warning: true }]
+                }
+              ]
+            }}
+            onSubmit={jest.fn()}
+          />
+        );
+      });
+      wrapper.update();
+
+      expect(wrapper.find('#error').text()).toEqual('Required');
+    });
+
     it('should convert function validator to warning', async () => {
       const ERROR = 'SOME-ERROR';
 

--- a/packages/react-form-renderer/src/tests/form-renderer/validator.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/validator.test.js
@@ -110,34 +110,6 @@ describe('FormRenderer validator', () => {
       expect(wrapper.find('#warning').text()).toEqual('Required');
     });
 
-    it('should convert warning to error', async () => {
-      await act(async () => {
-        wrapper = mount(
-          <FormRenderer
-            FormTemplate={FormTemplate}
-            componentMapper={{
-              [componentTypes.TEXT_FIELD]: TextField
-            }}
-            schema={{
-              fields: [
-                {
-                  useWarnings: true,
-                  convertWarningToError: true,
-                  component: 'text-field',
-                  name: NAME,
-                  validate: [{ type: 'required', warning: true }]
-                }
-              ]
-            }}
-            onSubmit={jest.fn()}
-          />
-        );
-      });
-      wrapper.update();
-
-      expect(wrapper.find('#error').text()).toEqual('Required');
-    });
-
     it('should convert function validator to warning', async () => {
       const ERROR = 'SOME-ERROR';
 

--- a/packages/react-renderer-demo/src/components/navigation/schemas/schema.schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/schema.schema.js
@@ -78,6 +78,10 @@ const schemaNav = [
     linkText: 'Validator mapper'
   },
   {
+    component: 'validator-warnings',
+    linkText: 'Warnings'
+  },
+  {
     subHeader: true,
     title: 'Condition',
     noRoute: true

--- a/packages/react-renderer-demo/src/pages/schema/validator-warnings.md
+++ b/packages/react-renderer-demo/src/pages/schema/validator-warnings.md
@@ -58,18 +58,4 @@ const TextFieldWarning = (props) => {
 };
 ```
 
-### Convert to error
-
-By default, Data Driven Forms mappers are not supporting showing warnings. However you can convert the warning into an error - set `convertWarningToError` to `true`. This will replace `meta.error` with `meta.warning`, but `valid` etc. will be unchanged.
-
-```jsx
-{
-    name: 'warning-as-error',
-    component: 'text-field',
-    useWarnings: true,
-    convertWarningToError: true,
-    validate: [{type: 'required', warning: true}]
-}
-```
-
 </DocPage>

--- a/packages/react-renderer-demo/src/pages/schema/validator-warnings.md
+++ b/packages/react-renderer-demo/src/pages/schema/validator-warnings.md
@@ -8,7 +8,7 @@ If you don't want to block the form from submitting when a validator fails, you 
 
 ## 1. Enable warnings
 
-In the field, set `useWarnings` to `true`. This feature can impact performace, so it was made to be opt-in. Please, do not change this value run-time as it could introduce bugs because of React hooks ordering.
+In the field, set `useWarnings` to `true`.
 
 ```jsx
 {

--- a/packages/react-renderer-demo/src/pages/schema/validator-warnings.md
+++ b/packages/react-renderer-demo/src/pages/schema/validator-warnings.md
@@ -1,0 +1,75 @@
+import DocPage from '@docs/doc-page';
+
+<DocPage>
+
+# Validator warnings
+
+If you don't want to block the form from submitting when a validator fails, you can convert the validator into a warning validator.
+
+## 1. Enable warnings
+
+In the field, set `useWarnings` to `true`. This feature can impact performace, so it was made to be opt-in. Please, do not change this value run-time as it could introduce bugs because of React hooks ordering.
+
+```jsx
+{
+    component: 'text-field',
+    useWarnings: true,
+    ...
+}
+```
+
+## 2. Return warning
+
+### Object validator
+
+When you want to return an object validator as a function, just add `warning: true` to its configuration.
+
+```jsx
+{
+    ...,
+    validate: [{ type: 'required', warning: true }]
+}
+```
+
+### Function validator
+
+When using a function as the validator, the function has to return an object with the following format:
+
+```
+{
+    warning: true,
+    error: 'some message'
+}
+```
+
+## 3. Get warning
+
+A warning is stored in `meta.warning`. This value is specific for each field and fields with the same name do not share this. Also, this value is not reachable via `resolveProps` as it's computed just after the `resolveProps` function.
+
+```jsx
+const TextFieldWarning = (props) => {
+  const { input, meta, ...rest } = useFieldApi(props);
+  return (
+    <div>
+      <input {...input} {...rest} />
+      {meta.warning && <div id="warning">{meta.warning}</div>}
+    </div>
+  );
+};
+```
+
+### Convert to error
+
+By default, Data Driven Forms mappers are not supporting showing warnings. However you can convert the warning into an error - set `convertWarningToError` to `true`. This will replace `meta.error` with `meta.warning`, but `valid` etc. will be unchanged.
+
+```jsx
+{
+    name: 'warning-as-error',
+    component: 'text-field',
+    useWarnings: true,
+    convertWarningToError: true,
+    validate: [{type: 'required', warning: true}]
+}
+```
+
+</DocPage>


### PR DESCRIPTION
closes #835 

I have tried several ways how to store warnings and not to use state (`useRef`, `meta.data` via mutator), however I have encounter several issues with the initial validation, where both solutions didn't triggered a re-rerender and who knows how it would handle async functions.

So I implemented it using `useState` and to prevent performance issues, I created a `useWarnings` prop, that turn this functionality on. However, this prop **cannot be changed at runtime** because of hooks ordering. That's one possible issue.

# Validator warnings

If you don't want to block the form from submitting when a validator fails, you can convert the validator into a warning validator.

## 1. Enable warnings

In the field, set `useWarnings` to `true`. This feature can impact performace, so it was made to be opt-in. Please, do not change this value run-time as it could introduce bugs because of React hooks ordering.

```jsx
{
    component: 'text-field',
    useWarnings: true,
    ...
}
```

## 2. Return warning

### Object validator

When you want to return an object validator as a function, just add `warning: true` to its configuration.

```jsx
{
    ...,
    validate: [{ type: 'required', warning: true }]
}
```

### Function validator

When using a function as the validator, the function has to return an object with the following format:

```
{
    warning: true,
    error: 'some message'
}
```

## 3. Get warning

A warning is stored in `meta.warning`. This value is specific for each field and fields with the same name do not share this. Also, this value is not reachable via `resolveProps` as it's computed just after the `resolveProps` function.

```jsx
const TextFieldWarning = (props) => {
  const { input, meta, ...rest } = useFieldApi(props);
  return (
    <div>
      <input {...input} {...rest} />
      {meta.warning && <div id="warning">{meta.warning}</div>}
    </div>
  );
};
```

### Convert to error

By default, Data Driven Forms mappers are not supporting showing warnings. However you can convert the warning into an error - set `convertWarningToError` to `true`. This will replace `meta.error` with `meta.warning`, but `valid` etc. will be unchanged.

```jsx
{
    name: 'warning-as-error',
    component: 'text-field',
    useWarnings: true,
    convertWarningToError: true,
    validate: [{type: 'required', warning: true}]
}
```


TODO: 
- [x] variant for type validators
- [x] tests
- [x] docs