### PR TITLE
Add missing dual list select into the carbon demo schema

### DIFF
--- a/packages/carbon-component-mapper/demo/demo-schemas/sandbox.js
+++ b/packages/carbon-component-mapper/demo/demo-schemas/sandbox.js
@@ -551,6 +551,33 @@ const output = {
                   label: 'Timepicker',
                   title: 'Timepicker',
                   component: components.TIME_PICKER
+                },
+                {
+                  component: components.DUAL_LIST_SELECT,
+                  name: 'dual_list_select',
+                  label: 'Dual List Select',
+                  options: [
+                    {
+                      label: 'Cat',
+                      value: 'cat'
+                    },
+                    {
+                      label: 'Dog',
+                      value: 'dog'
+                    },
+                    {
+                      label: 'Duck',
+                      value: 'duck'
+                    },
+                    {
+                      label: 'Lion',
+                      value: 'lion'
+                    },
+                    {
+                      label: 'Monster',
+                      value: 'monster'
+                    }
+                  ]
                 }
               ],
               component: components.SUB_FORM


### PR DESCRIPTION
There was no demo for the dual-list-select component for the Carbon mapper, so I'm adding one.