### PR TITLE
feat(carbon): Implement searchable/clearable non-multi select

### DIFF
--- a/packages/carbon-component-mapper/src/files/select.js
+++ b/packages/carbon-component-mapper/src/files/select.js
@@ -5,7 +5,7 @@ import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 import DataDrivenSelect from '@data-driven-forms/common/src/select';
 import fnToString from '@data-driven-forms/common/src/utils/fn-to-string';
 
-import { Select as CarbonSelect, MultiSelect, SelectItem } from 'carbon-components-react';
+import { Select as CarbonSelect, MultiSelect, SelectItem, ComboBox } from 'carbon-components-react';
 import prepareProps from '../common/prepare-props';
 
 export const multiOnChange = (input, simpleValue) => ({ selectedItems }) => {
@@ -165,8 +165,63 @@ ClearedSelect.propTypes = {
   isClearable: PropTypes.bool
 };
 
+const ClearedSelectSearchable = ({
+  isSearchable,
+  isClearable,
+  isDisabled,
+  isMulti,
+  invalidText,
+  hideSelectedOptions,
+  noOptionsMessage,
+  onInputChange,
+  options,
+  isFetching,
+  invalid,
+  classNamePrefix,
+  closeMenuOnSelect,
+  originalOnChange,
+  placeholder,
+  labelText,
+  ...rest
+}) => (
+  <ComboBox
+    disabled={isFetching}
+    {...rest}
+    id={rest.name}
+    invalid={Boolean(invalidText)}
+    invalidText={invalidText}
+    initialSelectedItem={rest.value}
+    items={options}
+    placeholder={placeholder}
+    titleText={labelText}
+    onChange={originalOnChange}
+  />
+);
+
+ClearedSelectSearchable.propTypes = {
+  invalidText: PropTypes.node,
+  hideSelectedOptions: PropTypes.any,
+  noOptionsMessage: PropTypes.any,
+  onInputChange: PropTypes.func,
+  options: PropTypes.array,
+  isFetching: PropTypes.bool,
+  invalid: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
+  isMulti: PropTypes.bool,
+  classNamePrefix: PropTypes.any,
+  closeMenuOnSelect: PropTypes.any,
+  onChange: PropTypes.func,
+  originalOnChange: PropTypes.func,
+  carbonLabel: PropTypes.node,
+  placeholder: PropTypes.node,
+  isDisabled: PropTypes.bool,
+  isRequired: PropTypes.bool,
+  isSearchable: PropTypes.bool,
+  isClearable: PropTypes.bool,
+  labelText: PropTypes.string
+};
+
 const Select = (props) => {
-  const { isMulti, isSearchable, loadOptions, input, meta, validateOnMount, ...rest } = useFieldApi(prepareProps(props));
+  const { isMulti, isSearchable, isClearable, loadOptions, input, meta, validateOnMount, ...rest } = useFieldApi(prepareProps(props));
 
   const [loadOptionsChangeCounter, setCounter] = useState(0);
 
@@ -176,8 +231,10 @@ const Select = (props) => {
     setCounter(loadOptionsChangeCounter + 1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadOptionsStr]);
+  const isSearchClear = isSearchable || isClearable;
 
-  const Component = isMulti && isSearchable ? ClearedMultiSelectFilterable : isMulti ? ClearedMultiSelect : ClearedSelect;
+  const Component =
+    isMulti && isSearchClear ? ClearedMultiSelectFilterable : isMulti ? ClearedMultiSelect : isSearchClear ? ClearedSelectSearchable : ClearedSelect;
 
   const invalidText = ((meta.touched || validateOnMount) && meta.error) || '';
 

--- a/packages/carbon-component-mapper/src/tests/select.test.js
+++ b/packages/carbon-component-mapper/src/tests/select.test.js
@@ -5,7 +5,7 @@ import FormRenderer, { componentTypes } from '@data-driven-forms/react-form-rend
 
 import FormTemplate from '../files/form-template';
 import componentMapper from '../files/component-mapper';
-import { Select, MultiSelect } from 'carbon-components-react';
+import { Select, MultiSelect, ComboBox } from 'carbon-components-react';
 import { multiOnChange } from '../files/select';
 
 describe('<Select />', () => {
@@ -29,6 +29,31 @@ describe('<Select />', () => {
     );
 
     expect(wrapper.find(Select)).toHaveLength(1);
+  });
+
+  ['isSearchable', 'isClearable'].forEach((setting) => {
+    it(`renders select ${setting}`, () => {
+      const schema = {
+        fields: [
+          {
+            component: componentTypes.SELECT,
+            name: 'select',
+            label: 'select',
+            [setting]: true,
+            options: [
+              { label: 'option 1', value: 1 },
+              { label: 'option 2', value: 2 }
+            ]
+          }
+        ]
+      };
+
+      const wrapper = mount(
+        <FormRenderer onSubmit={jest.fn()} FormTemplate={(props) => <FormTemplate {...props} />} schema={schema} componentMapper={componentMapper} />
+      );
+
+      expect(wrapper.find(ComboBox)).toHaveLength(1);
+    });
   });
 
   it('renders multi select', () => {
@@ -55,29 +80,31 @@ describe('<Select />', () => {
     expect(wrapper.find(MultiSelect)).toHaveLength(1);
   });
 
-  it('renders multi select - searchable', () => {
-    const schema = {
-      fields: [
-        {
-          component: componentTypes.SELECT,
-          name: 'select',
-          label: 'select',
-          initialValue: [1],
-          isMulti: true,
-          isSearchable: true,
-          options: [
-            { label: 'option 1', value: 1 },
-            { label: 'option 2', value: 2 }
-          ]
-        }
-      ]
-    };
+  ['isSearchable', 'isClearable'].forEach((setting) => {
+    it(`renders multi select - ${setting}`, () => {
+      const schema = {
+        fields: [
+          {
+            component: componentTypes.SELECT,
+            name: 'select',
+            label: 'select',
+            initialValue: [1],
+            isMulti: true,
+            [setting]: true,
+            options: [
+              { label: 'option 1', value: 1 },
+              { label: 'option 2', value: 2 }
+            ]
+          }
+        ]
+      };
 
-    const wrapper = mount(
-      <FormRenderer onSubmit={jest.fn()} FormTemplate={(props) => <FormTemplate {...props} />} schema={schema} componentMapper={componentMapper} />
-    );
+      const wrapper = mount(
+        <FormRenderer onSubmit={jest.fn()} FormTemplate={(props) => <FormTemplate {...props} />} schema={schema} componentMapper={componentMapper} />
+      );
 
-    expect(wrapper.find(MultiSelect.Filterable)).toHaveLength(1);
+      expect(wrapper.find(MultiSelect.Filterable)).toHaveLength(1);
+    });
   });
 
   describe('multichange', () => {

--- a/packages/react-renderer-demo/src/pages/mappers/carbon-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/mappers/carbon-component-mapper.md
@@ -38,41 +38,10 @@ This field will show the error immediately.
 
 ## Select
 
-### No isClearable
+### isClearable and isSearchable turn on each other
 
-Carbon select does not support `isClearable` option, instead of it use an option with null.
+Carbon doesn't provide a component that is searchable but not clearable and vice versa. Therefore, if one of these two options is turned on, it automatically triggers the other.
 
-🛑
-
-```jsx
-{
-   component: 'select',
-   label: 'select',
-   isClearable: true,
-   options: [
-        {value: 'option 1', label: 'first option'},
-        {value: 'option 2', label: 'second option'}
-    ]
-}
-```
-
-🆗
-
-```jsx
-{
-   component: 'select',
-   label: 'select',
-   options: [
-         {label: 'none', value: null},
-         {value: 'option 1', label: 'first option'},
-         {value: 'option 2', label: 'second option'}
-    ]
-}
-```
-
-### Single select cannot be isSearchable
-
-No known workaround.
 
 ### No async filtering options in multiselect
 


### PR DESCRIPTION
I found a way to implement the `isSearchable` and `isClearable` functionalities for non-multi selects in carbon usin the [`ComboBox`](https://react.carbondesignsystem.com/?path=/docs/combobox--combobox) component. Unfortunately, these two features come hand in hand, it's not possible to turn off one just of them without turning off the other one as well. Therefore, I adjusted the logic to turn on both features if at least one of them is enabled, i.e. `isClearable || isSearchable` for both the single and the multiselect.

![Screenshot from 2020-10-22 10-20-04](https://user-images.githubusercontent.com/649130/96844767-2e338680-1450-11eb-8a6b-39b189341115.png)

I guess I'll need some help with tests :pray: :see_no_evil: 