### PR TITLE
fix(pf3): display placeholder for pre-selected lazy options.

### DIFF
--- a/packages/pf3-component-mapper/src/files/select/select.js
+++ b/packages/pf3-component-mapper/src/files/select/select.js
@@ -53,7 +53,12 @@ const getDropdownText = (value, placeholder, options) => {
     return [placeholder, true];
   }
 
-  return [options.find((option) => option.value === value).label, false];
+  const selectedOption = options.find((option) => option.value === value);
+  if (!selectedOption) {
+    return [placeholder, true];
+  }
+
+  return [selectedOption.label, false];
 };
 
 class SearchInput extends Component {


### PR DESCRIPTION
closes #866 

If there is an initial value for pf3 select component with lazy loaded options, the searchable dropdown tris to create the label from an option that does not exist yet. 

Now it will display the placeholder until options are resolved.