### PR TITLE
fix(manager): reset errors when revalidated

### DIFF
--- a/packages/form-state-manager/src/utils/manager-api.ts
+++ b/packages/form-state-manager/src/utils/manager-api.ts
@@ -291,7 +291,7 @@ const createManagerApi: CreateManagerApi = ({
     runFormValidation = false;
   }
 
-  function handleFieldError(name: string, isValid: boolean, error: string | undefined = undefined) {
+  function handleFieldError(name: string, isValid: boolean, error: string | undefined = undefined, validating = false) {
     setFieldState(name, (prev: FieldState) => ({
       ...prev,
       meta: {
@@ -299,7 +299,8 @@ const createManagerApi: CreateManagerApi = ({
         error,
         valid: isValid,
         invalid: !isValid,
-        validating: false
+        validating,
+        warning: undefined
       }
     }));
 
@@ -322,7 +323,7 @@ const createManagerApi: CreateManagerApi = ({
       if (validators.length > 0) {
         const result = composeValidators(validators as Validator[])(value, state.values);
         if (isPromise(result)) {
-          handleFieldError(name, true);
+          handleFieldError(name, true, undefined, true);
           (result as Promise<string | undefined>)
             .then(() => handleFieldError(name, true))
             .catch((response) => {
@@ -331,7 +332,11 @@ const createManagerApi: CreateManagerApi = ({
                   ...prev,
                   meta: {
                     ...prev.meta,
-                    warning: response.error
+                    warning: response.error,
+                    error: undefined,
+                    valid: true,
+                    invalid: false,
+                    validating: false
                   }
                 }));
               } else {
@@ -345,7 +350,11 @@ const createManagerApi: CreateManagerApi = ({
               ...prev,
               meta: {
                 ...prev.meta,
-                warning: (result as WarningObject)?.error
+                warning: (result as WarningObject)?.error,
+                error: undefined,
+                valid: true,
+                invalid: false,
+                validating: false
               }
             }));
           } else {


### PR DESCRIPTION
part of https://github.com/data-driven-forms/react-forms/issues/860

todo:
- [x] clear errors on warnings/warnings on errors