### PR TITLE
fix(dual-list): set value to empty array when undefined

### DIFF
--- a/packages/blueprint-component-mapper/src/tests/dual-list-select.test.js
+++ b/packages/blueprint-component-mapper/src/tests/dual-list-select.test.js
@@ -254,7 +254,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-Menu': [] });
   });
 
   it('switch all to right', async () => {
@@ -288,7 +288,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-Menu': [] });
   });
 
   it('filters options', async () => {

--- a/packages/carbon-component-mapper/src/tests/dual-list-select.test.js
+++ b/packages/carbon-component-mapper/src/tests/dual-list-select.test.js
@@ -249,7 +249,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-StructuredListWrapper': [] });
   });
 
   it('switch all to right', async () => {
@@ -283,7 +283,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-StructuredListWrapper': [] });
   });
 
   it('filters options', async () => {

--- a/packages/common/src/dual-list-select/index.js
+++ b/packages/common/src/dual-list-select/index.js
@@ -33,7 +33,9 @@ const DualListSelectCommon = (props) => {
 
   const { DualListSelect, ...rest } = useFieldApi({
     ...props,
-    isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort())
+    isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort()),
+    parse: (value) => (value === undefined ? [] : value),
+    format: (value) => (value === undefined ? [] : value)
   });
 
   const leftValues = rest.options

--- a/packages/mui-component-mapper/src/tests/dual-list-select.test.js
+++ b/packages/mui-component-mapper/src/tests/dual-list-select.test.js
@@ -257,7 +257,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-list': [] });
   });
 
   it('switch all to right', async () => {
@@ -291,7 +291,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-list': [] });
   });
 
   it('filters options', async () => {

--- a/packages/pf4-component-mapper/src/tests/dual-list-select.test.js
+++ b/packages/pf4-component-mapper/src/tests/dual-list-select.test.js
@@ -264,7 +264,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-list': [] });
   });
 
   it('switch all to right', async () => {
@@ -298,7 +298,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-list': [] });
   });
 
   it('filters options', async () => {

--- a/packages/suir-component-mapper/src/tests/dual-list-select.test.js
+++ b/packages/suir-component-mapper/src/tests/dual-list-select.test.js
@@ -238,7 +238,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-list': [] });
   });
 
   it('switch all to right', async () => {
@@ -270,7 +270,7 @@ describe('DualListSelect', () => {
       wrapper.find('form').simulate('submit');
     });
 
-    expect(onSubmit).toHaveBeenCalledWith({});
+    expect(onSubmit).toHaveBeenCalledWith({ 'dual-list': [] });
   });
 
   it('filters options', async () => {


### PR DESCRIPTION
In dual list selector when the right side is empty, the value is set to undefined which causes that component to be discarded in the `values` object that is passed to `onSubmit`.

For example, I have three dual list selectors here:
![image](https://user-images.githubusercontent.com/2453279/99250616-a48b9480-2814-11eb-8f19-d298bdd6e1de.png)

If I click on "Submit", it will send an empty object {} as `values`.
With this patch it will send the following object:
```
{
 tags: {
  aws: { enabled: [] },
  azure: { enabled: [] },
  openshift: { enabled: [] }
 }
}
```