### PR TITLE
fix(carbon): adjusted combobox onchange invocation for singlevalues

### DIFF
--- a/packages/carbon-component-mapper/src/files/select.js
+++ b/packages/carbon-component-mapper/src/files/select.js
@@ -8,11 +8,11 @@ import fnToString from '@data-driven-forms/common/src/utils/fn-to-string';
 import { Select as CarbonSelect, MultiSelect, SelectItem, ComboBox } from 'carbon-components-react';
 import prepareProps from './prepare-props';
 
-export const multiOnChange = (input, simpleValue) => ({ selectedItems }) => {
+export const multiOnChange = (input, simpleValue) => ({ selectedItem, selectedItems }) => {
   if (simpleValue) {
-    return input.onChange(selectedItems.map(({ value }) => value));
+    return input.onChange(selectedItems.map(({ value }) => value) || selectedItem.value);
   } else {
-    return input.onChange(selectedItems);
+    return input.onChange(selectedItems || selectedItem);
   }
 };
 


### PR DESCRIPTION
The `onChange` of the combobox (single select with search + clear) has a `selectedItem` argument, unlike the `selectedItems` of any other (multi)select. So in order to make the field working, it is necessary to adjust the onChange to deal with this case as well.