### PR TITLE
fix(pf4): fix wizard navigation buttons to not submit forms

### DIFF
--- a/packages/pf4-component-mapper/src/files/wizard/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/files/wizard/wizard-nav.js
@@ -36,11 +36,13 @@ const WizardNavigationInternal = React.memo(
             isDisabled={isValid ? maxStepIndex < step.index : step.index > activeStepIndex}
             onNavItemClick={(ind) => jumpToStep(ind, isValid)}
             step={step.index}
+            type="button"
           >
             {substeps && (
               <WizardNav returnList>
                 {substeps.map((substep) => (
                   <WizardNavItem
+                    type="button"
                     key={substep.name}
                     content={substep.title}
                     isCurrent={activeStepIndex === substep.index}

--- a/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
+++ b/packages/pf4-component-mapper/src/tests/wizard/__snapshots__/wizard.test.js.snap
@@ -643,6 +643,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 key="1"
                                                 onNavItemClick={[Function]}
                                                 step={0}
+                                                type="button"
                                               >
                                                 <li
                                                   className="pf-c-wizard__nav-item"
@@ -653,6 +654,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                     className="pf-c-wizard__nav-link pf-m-current"
                                                     disabled={false}
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
                                                     foo-step
                                                   </button>
@@ -665,6 +667,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                 key="2"
                                                 onNavItemClick={[Function]}
                                                 step={1}
+                                                type="button"
                                               >
                                                 <li
                                                   className="pf-c-wizard__nav-item"
@@ -675,6 +678,7 @@ exports[`<Wizard /> should render correctly and unmount 1`] = `
                                                     className="pf-c-wizard__nav-link pf-m-disabled"
                                                     disabled={true}
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
                                                     bar-step
                                                   </button>
@@ -1723,6 +1727,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                   <button
                                                     aria-current="page"
                                                     class="pf-c-wizard__nav-link pf-m-current"
+                                                    type="button"
                                                   >
                                                     foo-step
                                                   </button>
@@ -1735,6 +1740,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                     aria-disabled="true"
                                                     class="pf-c-wizard__nav-link pf-m-disabled"
                                                     disabled=""
+                                                    type="button"
                                                   >
                                                     bar-step
                                                   </button>
@@ -1890,6 +1896,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                     <button
                                                       aria-current="page"
                                                       class="pf-c-wizard__nav-link pf-m-current"
+                                                      type="button"
                                                     >
                                                       foo-step
                                                     </button>
@@ -1902,6 +1909,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                       aria-disabled="true"
                                                       class="pf-c-wizard__nav-link pf-m-disabled"
                                                       disabled=""
+                                                      type="button"
                                                     >
                                                       bar-step
                                                     </button>
@@ -2179,6 +2187,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                             key="1"
                                                             onNavItemClick={[Function]}
                                                             step={0}
+                                                            type="button"
                                                           >
                                                             <li
                                                               className="pf-c-wizard__nav-item"
@@ -2189,6 +2198,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                 className="pf-c-wizard__nav-link pf-m-current"
                                                                 disabled={false}
                                                                 onClick={[Function]}
+                                                                type="button"
                                                               >
                                                                 foo-step
                                                               </button>
@@ -2201,6 +2211,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                             key="2"
                                                             onNavItemClick={[Function]}
                                                             step={1}
+                                                            type="button"
                                                           >
                                                             <li
                                                               className="pf-c-wizard__nav-item"
@@ -2211,6 +2222,7 @@ exports[`<Wizard /> should render correctly in modal and unmount 1`] = `
                                                                 className="pf-c-wizard__nav-link pf-m-disabled"
                                                                 disabled={true}
                                                                 onClick={[Function]}
+                                                                type="button"
                                                               >
                                                                 bar-step
                                                               </button>


### PR DESCRIPTION
**Description**

Buttons in PF4 Wizard Nav were missing `type=button` so in non-modal version, they triggered the submit action. :fairy: 