### PR TITLE
feat(carbon): use NumberInput for text-field if type=number

### DIFF
--- a/packages/carbon-component-mapper/src/files/text-field.js
+++ b/packages/carbon-component-mapper/src/files/text-field.js
@@ -2,18 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 
-import { TextInput } from 'carbon-components-react';
+import { TextInput, NumberInput } from 'carbon-components-react';
 
 import prepareProps from './prepare-props';
 
 const TextField = (props) => {
   const { input, meta, validateOnMount, ...rest } = useFieldApi(prepareProps(props));
 
+  const Component = input.type === 'number' ? NumberInput : TextInput;
+
   const invalid = (meta.touched || validateOnMount) && (meta.error || meta.submitError);
   const warn = (meta.touched || validateOnMount) && meta.warning;
 
   return (
-    <TextInput
+    <Component
       {...input}
       key={input.name}
       id={input.name}


### PR DESCRIPTION
Carbon has a [`NumberInput`](https://www.carbondesignsystem.com/components/number-input/usage) component that is more suitable for numeric values in text fields.

**Before:**
![Screenshot from 2021-01-21 13-49-06](https://user-images.githubusercontent.com/649130/105353373-726d2900-5bef-11eb-8e21-c94db1f4327f.png)

**After:**
![Screenshot from 2021-01-21 13-48-38](https://user-images.githubusercontent.com/649130/105353349-68e3c100-5bef-11eb-942d-76a488457ba0.png)

Resolves https://github.com/data-driven-forms/react-forms/issues/945