### PR TITLE
fix(carbon): make the subform title element larger

### DIFF
--- a/packages/carbon-component-mapper/src/files/sub-form.js
+++ b/packages/carbon-component-mapper/src/files/sub-form.js
@@ -35,7 +35,7 @@ SubForm.propTypes = {
 };
 
 SubForm.defaultProps = {
-  TitleElement: 'h5',
+  TitleElement: 'h3',
   DescriptionElement: 'p'
 };
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/sub-form.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/sub-form.md
@@ -2,7 +2,7 @@
 
 |Props|Description|default|
 |-----|-----------|-------|
-|TitleElement|Element wrapping title|h5|
+|TitleElement|Element wrapping title|h3|
 |TitleProps|Props passed to the element wrapping title|{}|
 |DescriptionElement|Element wrapping description|p|
 |DescriptionProps|Props passed to the element wrapping description|{}|


### PR DESCRIPTION
Replacing the `h5` with an `h3` element.

**Before:**
![Screenshot from 2021-01-21 15-30-34](https://user-images.githubusercontent.com/649130/105364640-acddc280-5bfd-11eb-872e-57d6bd82c0c0.png)

**After:**
![Screenshot from 2021-01-21 15-30-49](https://user-images.githubusercontent.com/649130/105364648-afd8b300-5bfd-11eb-9452-c9df39d5d183.png)

Fixes #946

