### PR TITLE
fix(carbon): pass the label for numeric text-field correctly

### DIFF
--- a/packages/carbon-component-mapper/src/files/text-field.js
+++ b/packages/carbon-component-mapper/src/files/text-field.js
@@ -7,7 +7,7 @@ import { TextInput, NumberInput } from 'carbon-components-react';
 import prepareProps from './prepare-props';
 
 const TextField = (props) => {
-  const { input, meta, validateOnMount, ...rest } = useFieldApi(prepareProps(props));
+  const { input, meta, validateOnMount, labelText, ...rest } = useFieldApi(prepareProps(props));
 
   const Component = input.type === 'number' ? NumberInput : TextInput;
 
@@ -23,6 +23,7 @@ const TextField = (props) => {
       invalidText={invalid || ''}
       warn={Boolean(warn)}
       warnText={warn || ''}
+      {...(input.type === 'number' ? { label: labelText } : { labelText })}
       {...rest}
     />
   );

--- a/packages/carbon-component-mapper/src/tests/components.test.js
+++ b/packages/carbon-component-mapper/src/tests/components.test.js
@@ -14,7 +14,13 @@ describe('component tests', () => {
       onSubmit={jest.fn()}
       FormTemplate={(props) => <FormTemplate {...props} />}
       schema={schema}
-      componentMapper={componentMapper}
+      componentMapper={{
+        ...componentMapper,
+        'text-field-number': {
+          component: componentMapper[componentTypes.TEXT_FIELD],
+          type: 'number'
+        }
+      }}
       {...props}
     />
   );
@@ -47,7 +53,8 @@ describe('component tests', () => {
       componentTypes.TIME_PICKER,
       componentTypes.SWITCH,
       componentTypes.SELECT,
-      componentTypes.SLIDER
+      componentTypes.SLIDER,
+      'text-field-number'
     ].forEach((component) => {
       describe(`Component type: ${component}`, () => {
         beforeEach(() => {
@@ -70,6 +77,8 @@ describe('component tests', () => {
 
           if (component === componentTypes.RADIO) {
             expect(wrapper.find('.bx--radio-button-wrapper')).toHaveLength(options.length);
+          } else if (component === 'text-field-number') {
+            expect(wrapper.find('NumberInput')).toHaveLength(1);
           } else {
             expect(wrapper.find(componentMapper[component])).toHaveLength(1);
             expect(
@@ -99,48 +108,90 @@ describe('component tests', () => {
           }
         });
 
-        it('renders with warning', async () => {
-          const errorField = {
-            ...field,
-            validate: [{ type: validatorTypes.REQUIRED, warning: true }],
-            useWarnings: true,
-            validateOnMount: true
-          };
-          let wrapper;
+        if (component !== 'text-field-number') {
+          it('renders with warning', async () => {
+            const errorField = {
+              ...field,
+              validate: [{ type: validatorTypes.REQUIRED, warning: true }],
+              useWarnings: true,
+              validateOnMount: true
+            };
+            let wrapper;
 
-          await act(async () => {
-            wrapper = mount(<RendererWrapper schema={{ fields: [errorField] }} />);
+            await act(async () => {
+              wrapper = mount(<RendererWrapper schema={{ fields: [errorField] }} />);
+            });
+            wrapper.update();
+            wrapper.update();
+
+            const helperText = wrapper.find('.bx--form__helper-text');
+
+            if (helperText.length) {
+              expect(helperText.text()).toEqual(errorText);
+            } else {
+              expect(
+                wrapper
+                  .find('.bx--form-requirement')
+                  .last()
+                  .text()
+              ).toEqual(errorText);
+            }
           });
-          wrapper.update();
 
-          const helperText = wrapper.find('.bx--form__helper-text');
+          it('renders with helperText', () => {
+            const helpertextField = {
+              ...field,
+              helperText
+            };
+            const wrapper = mount(<RendererWrapper schema={{ fields: [helpertextField] }} />);
 
-          if (helperText.length) {
-            expect(helperText.text()).toEqual(errorText);
-          } else {
             expect(
               wrapper
-                .find('.bx--form-requirement')
+                .find('.bx--form__helper-text')
                 .last()
                 .text()
-            ).toEqual(errorText);
-          }
-        });
+            ).toEqual(helperText);
+          });
 
-        it('renders with helperText', () => {
-          const helpertextField = {
-            ...field,
-            helperText
-          };
-          const wrapper = mount(<RendererWrapper schema={{ fields: [helpertextField] }} />);
+          it('renders with description and helperText', () => {
+            const descriptionField = {
+              ...field,
+              description,
+              helperText
+            };
+            const wrapper = mount(<RendererWrapper schema={{ fields: [descriptionField] }} />);
 
-          expect(
-            wrapper
-              .find('.bx--form__helper-text')
-              .last()
-              .text()
-          ).toEqual(helperText);
-        });
+            expect(wrapper.find(WithDescription)).toHaveLength(1);
+
+            expect(
+              wrapper
+                .find('.bx--form__helper-text')
+                .last()
+                .text()
+            ).toEqual(helperText);
+          });
+
+          it('renders with error and helperText', () => {
+            const errorFields = {
+              ...field,
+              helperText,
+              validate: [{ type: validatorTypes.REQUIRED }]
+            };
+            const wrapper = mount(<RendererWrapper schema={{ fields: [errorFields] }} />);
+            wrapper.find('form').simulate('submit');
+
+            if (wrapper.find('#field-name-error-msg').length) {
+              expect(wrapper.find('#field-name-error-msg').text()).toEqual(errorText);
+              expect(wrapper.find('[invalid=true]').length).toBeGreaterThanOrEqual(1);
+            }
+
+            if (wrapper.find('.ddorg__carbon-error-helper-text').length) {
+              expect(wrapper.find('.ddorg__carbon-error-helper-text').text()).toEqual(errorText);
+            }
+
+            expect(wrapper.find('.bx--form__helper-text')).toHaveLength(0);
+          });
+        }
 
         it('renders with description', () => {
           const descriptionField = {
@@ -150,45 +201,6 @@ describe('component tests', () => {
           const wrapper = mount(<RendererWrapper schema={{ fields: [descriptionField] }} />);
 
           expect(wrapper.find(WithDescription)).toHaveLength(1);
-        });
-
-        it('renders with description and helperText', () => {
-          const descriptionField = {
-            ...field,
-            description,
-            helperText
-          };
-          const wrapper = mount(<RendererWrapper schema={{ fields: [descriptionField] }} />);
-
-          expect(wrapper.find(WithDescription)).toHaveLength(1);
-
-          expect(
-            wrapper
-              .find('.bx--form__helper-text')
-              .last()
-              .text()
-          ).toEqual(helperText);
-        });
-
-        it('renders with error and helperText', () => {
-          const errorFields = {
-            ...field,
-            helperText,
-            validate: [{ type: validatorTypes.REQUIRED }]
-          };
-          const wrapper = mount(<RendererWrapper schema={{ fields: [errorFields] }} />);
-          wrapper.find('form').simulate('submit');
-
-          if (wrapper.find('#field-name-error-msg').length) {
-            expect(wrapper.find('#field-name-error-msg').text()).toEqual(errorText);
-            expect(wrapper.find('[invalid=true]').length).toBeGreaterThanOrEqual(1);
-          }
-
-          if (wrapper.find('.ddorg__carbon-error-helper-text').length) {
-            expect(wrapper.find('.ddorg__carbon-error-helper-text').text()).toEqual(errorText);
-          }
-
-          expect(wrapper.find('.bx--form__helper-text')).toHaveLength(0);
         });
 
         it('renders isDisabled', () => {


### PR DESCRIPTION
The `TextInput` component takes a `labelText` prop, while the `NumberInput` needs a `label` :confused: :disappointed: 

**Before:**
![Screenshot from 2021-01-21 16-37-23](https://user-images.githubusercontent.com/649130/105373537-11514f80-5c07-11eb-8dd9-9b75bcbcd342.png)

**After:**
![Screenshot from 2021-01-21 16-37-17](https://user-images.githubusercontent.com/649130/105373548-144c4000-5c07-11eb-8d72-006515b023ef.png)
