### PR TITLE
fix(carbon): reorder the buttons according to the alignment guide

### DIFF
--- a/packages/carbon-component-mapper/src/files/form-template.js
+++ b/packages/carbon-component-mapper/src/files/form-template.js
@@ -62,7 +62,7 @@ const WrappedFormTemplate = (props) => (
     ButtonGroup={ButtonGroup}
     Title={Title}
     Description={Description}
-    buttonOrder={['cancel', 'reset', 'submit']}
+    buttonOrder={['submit', 'reset', 'cancel']}
     Header={Header}
     {...props}
   />


### PR DESCRIPTION
The [docs](https://www.carbondesignsystem.com/components/button/usage#Alignment) are saying that if the buttons are aligned to the left, the primary button should be on the left, so changing ...