### PR TITLE
Fix MUI templates in demo

### DIFF
--- a/packages/react-renderer-demo/src/stackblitz-templates/mui-templates.js
+++ b/packages/react-renderer-demo/src/stackblitz-templates/mui-templates.js
@@ -62,8 +62,8 @@ class App extends Component {
 render(<App />, document.getElementById('root'));`;
 
 export const dependencies = {
-  react: '^16.12.0',
-  'react-dom': '^16.12.0',
+  react: 'latest',
+  'react-dom': 'latest',
   '@babel/runtime': '^7.12.1',
   '@data-driven-forms/react-form-renderer': 'latest',
   '@data-driven-forms/mui-component-mapper': 'latest',


### PR DESCRIPTION
Fixes #911

**Description**

By updating React to latest, the demo is working again.