### PR TITLE
Add validateOnMount option

### DIFF
--- a/packages/pf4-component-mapper/README.md
+++ b/packages/pf4-component-mapper/README.md
@@ -96,6 +96,23 @@ Data Driven Forms supports all kinds of component, basic set is consisted of:
 - [Plain text](https://data-driven-forms.org/mappers/plain-text?mapper=pf4)
 - [Wizard](https://data-driven-forms.org/mappers/wizard?mapper=pf4)
 
+
+### ValidateOnMount
+
+PF4 mapper provides an option to validate a field when the component is mounted. Just set `validateOnMount` to `true`.
+
+```jsx
+{
+    component: 'text-field',
+    name: 'required-field',
+    validate: [{type: 'required'}],
+    validateOnMount: true
+}
+```
+
+This field will show the error immediately.
+
+
 ### Useful links
 
 - [Data Driven Forms documentation](https://data-driven-forms.org/)

--- a/packages/pf4-component-mapper/src/common/form-group.js
+++ b/packages/pf4-component-mapper/src/common/form-group.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 
 import showError from './show-error';
 
-const FormGroup = ({ label, isRequired, helperText, meta, description, hideLabel, children, id, FormGroupProps }) => (
+const FormGroup = ({ label, isRequired, helperText, meta, validateOnMount, description, hideLabel, children, id, FormGroupProps }) => (
   <Pf4FormGroup
     isRequired={isRequired}
     label={!hideLabel && label}
     fieldId={id}
     helperText={(meta.touched && meta.warning) || helperText}
     helperTextInvalid={meta.error || meta.submitError}
-    {...showError(meta)}
+    {...showError(meta, validateOnMount)}
     {...FormGroupProps}
   >
     {description && (
@@ -30,6 +30,7 @@ FormGroup.propTypes = {
   meta: PropTypes.object.isRequired,
   description: PropTypes.node,
   hideLabel: PropTypes.bool,
+  validateOnMount: PropTypes.bool,
   id: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
   FormGroupProps: PropTypes.object

--- a/packages/pf4-component-mapper/src/common/show-error.js
+++ b/packages/pf4-component-mapper/src/common/show-error.js
@@ -1,13 +1,13 @@
-const showError = ({ error, touched, warning, submitError }) => {
-  if (touched && error) {
+const showError = ({ error, touched, warning, submitError }, validateOnMount) => {
+  if ((touched || validateOnMount) && error) {
     return { validated: 'error' };
   }
 
-  if (touched && submitError) {
+  if ((touched || validateOnMount) && submitError) {
     return { validated: 'error' };
   }
 
-  if (touched && warning) {
+  if ((touched || validateOnMount) && warning) {
     return { validated: 'warning' };
   }
 

--- a/packages/pf4-component-mapper/src/files/checkbox.js
+++ b/packages/pf4-component-mapper/src/files/checkbox.js
@@ -7,12 +7,26 @@ import { Checkbox as Pf4Checkbox } from '@patternfly/react-core';
 import IsRequired from '../common/is-required';
 
 const SingleCheckbox = (props) => {
-  const { label, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(props);
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel
       id={id || input.name}
@@ -33,6 +47,7 @@ const SingleCheckbox = (props) => {
 
 SingleCheckbox.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/date-picker.js
+++ b/packages/pf4-component-mapper/src/files/date-picker.js
@@ -6,27 +6,49 @@ import FormGroup from '../common/form-group';
 import showError from '../common/show-error';
 
 const DatePicker = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
-    props
-  );
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       label={label}
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
       FormGroupProps={FormGroupProps}
     >
-      <TextInput {...input} {...showError(meta)} {...rest} type="date" id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
+      <TextInput
+        {...input}
+        {...showError(meta, validateOnMount)}
+        {...rest}
+        type="date"
+        id={id || input.name}
+        isReadOnly={isReadOnly}
+        isDisabled={isDisabled}
+      />
     </FormGroup>
   );
 };
 
 DatePicker.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/dual-list-select.js
+++ b/packages/pf4-component-mapper/src/files/dual-list-select.js
@@ -13,6 +13,7 @@ const DualList = (props) => {
     isRequired,
     helperText,
     meta,
+    validateOnMount,
     description,
     hideLabel,
     id,
@@ -81,6 +82,7 @@ const DualList = (props) => {
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
@@ -109,6 +111,7 @@ const DualList = (props) => {
 
 DualList.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,
   description: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/radio.js
+++ b/packages/pf4-component-mapper/src/files/radio.js
@@ -35,7 +35,20 @@ const Radio = ({ name, options, type, ...props }) => {
    * You cannot assign type radio to PF4 radio buttons input. It will break and will not set input value, only checked property
    * It has to be reqular input and we have change the radio value manully to the option value
    */
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps } = useFieldApi({
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps
+  } = useFieldApi({
     name,
     ...props
   });
@@ -45,6 +58,7 @@ const Radio = ({ name, options, type, ...props }) => {
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
@@ -59,6 +73,7 @@ const Radio = ({ name, options, type, ...props }) => {
 
 Radio.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/select.js
+++ b/packages/pf4-component-mapper/src/files/select.js
@@ -5,15 +5,28 @@ import FormGroup from '../common/form-group';
 import DataDrivenSelect from '../common/select/select';
 
 const Select = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
-    props
-  );
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       label={label}
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
@@ -26,6 +39,7 @@ const Select = (props) => {
 
 Select.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/slider.js
+++ b/packages/pf4-component-mapper/src/files/slider.js
@@ -5,7 +5,20 @@ import FormGroup from '../common/form-group';
 import { Slider as PF4Slider } from '@patternfly/react-core';
 
 const Slider = (props) => {
-  const { label, isRequired, helperText, meta, description, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(props);
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
 
   return (
     <FormGroup
@@ -13,6 +26,7 @@ const Slider = (props) => {
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       id={id || input.name}
       FormGroupProps={FormGroupProps}
@@ -24,6 +38,7 @@ const Slider = (props) => {
 
 Slider.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/switch.js
+++ b/packages/pf4-component-mapper/src/files/switch.js
@@ -13,6 +13,7 @@ const Switch = (props) => {
     isRequired,
     helperText,
     meta,
+    validateOnMount,
     description,
     input,
     isReadOnly,
@@ -29,6 +30,7 @@ const Switch = (props) => {
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel
       id={id || input.name}
@@ -48,6 +50,7 @@ const Switch = (props) => {
 
 Switch.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/text-field.js
+++ b/packages/pf4-component-mapper/src/files/text-field.js
@@ -6,27 +6,41 @@ import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 import showError from '../common/show-error';
 
 const TextField = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
-    props
-  );
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       label={label}
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
       FormGroupProps={FormGroupProps}
     >
-      <TextInput {...input} {...showError(meta)} {...rest} id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
+      <TextInput {...input} {...showError(meta, validateOnMount)} {...rest} id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
     </FormGroup>
   );
 };
 
 TextField.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/textarea.js
+++ b/packages/pf4-component-mapper/src/files/textarea.js
@@ -6,27 +6,41 @@ import FormGroup from '../common/form-group';
 import showError from '../common/show-error';
 
 const Textarea = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
-    props
-  );
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       label={label}
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
       FormGroupProps={FormGroupProps}
     >
-      <Pf4TextArea {...showError(meta)} disabled={isDisabled || isReadOnly} {...input} id={id || input.name} {...rest} />
+      <Pf4TextArea {...showError(meta, validateOnMount)} disabled={isDisabled || isReadOnly} {...input} id={id || input.name} {...rest} />
     </FormGroup>
   );
 };
 
 Textarea.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/files/time-picker.js
+++ b/packages/pf4-component-mapper/src/files/time-picker.js
@@ -6,27 +6,49 @@ import PropTypes from 'prop-types';
 import showError from '../common/show-error';
 
 const TimePicker = (props) => {
-  const { label, isRequired, helperText, meta, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } = useFieldApi(
-    props
-  );
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       label={label}
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
+      validateOnMount={validateOnMount}
       description={description}
       hideLabel={hideLabel}
       id={id || input.name}
       FormGroupProps={FormGroupProps}
     >
-      <TextInput {...showError(meta)} {...input} {...rest} type="time" id={id || input.name} isReadOnly={isReadOnly} isDisabled={isDisabled} />
+      <TextInput
+        {...showError(meta, validateOnMount)}
+        {...input}
+        {...rest}
+        type="time"
+        id={id || input.name}
+        isReadOnly={isReadOnly}
+        isDisabled={isDisabled}
+      />
     </FormGroup>
   );
 };
 
 TimePicker.propTypes = {
   label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,
   helperText: PropTypes.node,

--- a/packages/pf4-component-mapper/src/tests/form-fields.test.js
+++ b/packages/pf4-component-mapper/src/tests/form-fields.test.js
@@ -321,6 +321,25 @@ describe('FormFields', () => {
             ).toEqual(errorText);
           });
 
+          it('renders with error and validateOnMount', async () => {
+            const errorField = {
+              ...field,
+              validate: [{ type: validatorTypes.REQUIRED }],
+              validateOnMount: true
+            };
+            let wrapper;
+            await act(async () => {
+              wrapper = mount(<RendererWrapper schema={{ fields: [errorField] }} />);
+            });
+            wrapper.update();
+            expect(
+              wrapper
+                .find('.pf-m-error')
+                .last()
+                .text()
+            ).toEqual(errorText);
+          });
+
           it('renders with helperText', () => {
             const helpertextField = {
               ...field,

--- a/packages/pf4-component-mapper/src/tests/show-error.test.js
+++ b/packages/pf4-component-mapper/src/tests/show-error.test.js
@@ -1,0 +1,21 @@
+import showError from '../common/show-error';
+
+describe('Show error on validation', () => {
+  describe('show error', () => {
+    it('should return default ', () => {
+      expect(showError({}, false)).toEqual({ validated: 'default' });
+    });
+
+    it('should return validation error if not touched but validating on mount', () => {
+      expect(showError({ error: 'Foo' }, true)).toEqual({ validated: 'error' });
+    });
+
+    it('should return default if not touched', () => {
+      expect(showError({ error: 'Foo', touched: false }, false)).toEqual({ validated: 'default' });
+    });
+
+    it('should return error if touched and has error', () => {
+      expect(showError({ error: 'Foo', touched: true }, false)).toEqual({ validated: 'error' });
+    });
+  });
+});


### PR DESCRIPTION
**Description**

Adds validateOnMount option to PF4 mapper.

**Schema** 

```
          schema={{
              fields: [
                {
                  name: 'textarea_box_1',
                  label: 'Text Area',
                  title: 'Text Area',
                  validate: [
                    {
                      type: validators.PATTERN,
                      pattern: '[0-9]'
                    }
                  ],
                  validateOnMount: true,
                  component: components.TEXTAREA
                }
              ]
          }}

```
@Hyperkid123 