### PR TITLE
fix(ant,pf4): copy css to build folders

### DIFF
--- a/packages/ant-component-mapper/package.json
+++ b/packages/ant-component-mapper/package.json
@@ -8,13 +8,14 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "webpack-dev-server --env dev --config ./config/webpack.config.js --open --hot",
-    "build": "yarn build:cjs && yarn build:esm && yarn build:typings && yarn build:packages",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:typings && yarn build:packages && yarn build:css",
     "build:cjs": "BABEL_ENV=cjs babel src --out-dir ./ --ignore \"src/tests/*\"",
     "build:esm": "BABEL_ENV=esm babel src --out-dir ./esm --ignore \"src/tests/*\"",
     "build:typings": "node ../../scripts/generate-typings.js",
     "build:packages": "node ../../scripts/generate-packages.js",
     "vendor": "webpack --env vendor --config ./config/webpack.config.js",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "build:css": "node ../../scripts/copy-css.js"
   },
   "repository": "git@github.com:data-driven-forms/react-forms.git",
   "devDependencies": {

--- a/packages/pf4-component-mapper/package.json
+++ b/packages/pf4-component-mapper/package.json
@@ -8,11 +8,12 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "webpack-dev-server --env dev --config ./config/webpack.config.js --open --hot",
-    "build": "yarn build:cjs && yarn build:esm && yarn build:typings && yarn build:packages",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:typings && yarn build:packages && yarn build:css",
     "build:cjs": "BABEL_ENV=cjs babel src --out-dir ./ --ignore \"src/tests/*\"",
     "build:esm": "BABEL_ENV=esm babel src --out-dir ./esm --ignore \"src/tests/*\"",
     "build:typings": "node ../../scripts/generate-typings.js",
     "build:packages": "node ../../scripts/generate-packages.js",
+    "build:css": "node ../../scripts/copy-css.js",
     "release": "semantic-release"
   },
   "repository": "git@github.com:data-driven-forms/react-forms.git",

--- a/scripts/copy-css.js
+++ b/scripts/copy-css.js
@@ -1,0 +1,32 @@
+const glob = require('glob');
+const path = require('path');
+const { copyFileSync } = require('fs');
+
+const packagePath = process.cwd();
+const src = path.resolve(packagePath, './src');
+
+async function copyCss() {
+  const directories = glob.sync(`${src}/*/`).filter((name) => !name.includes('/tests/') && !name.includes('/common/'));
+
+  directories.forEach(async (dir) => {
+    const cssFiles = glob.sync(`${dir}/**/*.css`);
+
+    cssFiles.forEach(async (file) => {
+      const fileName = file.replace(/^.*src\//, '');
+
+      copyFileSync(file, `./${fileName}`);
+      copyFileSync(file, `./esm/${fileName}`);
+    });
+  });
+}
+
+async function run() {
+  try {
+    await copyCss();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/scripts/copy-css.js
+++ b/scripts/copy-css.js
@@ -5,13 +5,13 @@ const { copyFileSync } = require('fs');
 const packagePath = process.cwd();
 const src = path.resolve(packagePath, './src');
 
-async function copyCss() {
+function copyCss() {
   const directories = glob.sync(`${src}/*/`).filter((name) => !name.includes('/tests/') && !name.includes('/common/'));
 
-  directories.forEach(async (dir) => {
+  directories.forEach((dir) => {
     const cssFiles = glob.sync(`${dir}/**/*.css`);
 
-    cssFiles.forEach(async (file) => {
+    cssFiles.forEach((file) => {
       const fileName = file.replace(/^.*src\//, '');
 
       copyFileSync(file, `./${fileName}`);
@@ -20,9 +20,9 @@ async function copyCss() {
   });
 }
 
-async function run() {
+function run() {
   try {
-    await copyCss();
+    copyCss();
   } catch (err) {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
Fixes #931 

**Description**

CSS files are copied to their build folders.