### PR TITLE
[V2] fix(renderer): fix numbers conversions

### DIFF
--- a/packages/react-form-renderer/package.json
+++ b/packages/react-form-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-driven-forms/react-form-renderer",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "React form renderer for data-driven-forms.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-form-renderer/src/common/convert-type.js
+++ b/packages/react-form-renderer/src/common/convert-type.js
@@ -13,16 +13,29 @@ const castToBoolean = (value) => {
 };
 
 /**
+ * Check if the value can be converted to number
+ * @param {Any} value value to be checked
+ */
+const canBeConvertedToNumber = (value) => !isNaN(Number(value)) && value !== '';
+
+/**
  * Changes the value type
  * @param {FieldDataTypes} dataType type for value conversion
  * @param {Any} value value to be converted
  */
-const convertType = (dataType, value) =>
-  ({
-    [dataTypes.INTEGER]: !isNaN(Number(value)) && parseInt(value),
-    [dataTypes.FLOAT]: !isNaN(Number(value)) && parseFloat(value),
-    [dataTypes.NUMBER]: Number(value),
-    [dataTypes.BOOLEAN]: castToBoolean(value)
-  }[dataType] || value);
+const convertType = (dataType, value) => {
+  switch (dataType) {
+    case dataTypes.INTEGER:
+      return canBeConvertedToNumber(value) ? parseInt(value) : value;
+    case dataTypes.FLOAT:
+      return canBeConvertedToNumber(value) ? parseFloat(value) : value;
+    case dataTypes.NUMBER:
+      return canBeConvertedToNumber(value) ? Number(value) : value;
+    case dataTypes.BOOLEAN:
+      return castToBoolean(value);
+    default:
+      return value;
+  }
+};
 
 export default convertType;

--- a/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
@@ -4,6 +4,8 @@ import FormRenderer from '../../files/form-renderer';
 import FormTemplate from '../../../../../__mocks__/mock-form-template';
 import componentTypes from '../../files/component-types';
 import useFieldApi from '../../files/use-field-api';
+import convertType from '../../common/convert-type';
+import dataTypes from '../../files/data-types';
 
 const DataTypeInput = (props) => {
   const { input, type, label } = useFieldApi(props);
@@ -68,5 +70,29 @@ describe('data types', () => {
       expect.anything(),
       expect.anything()
     );
+  });
+
+  describe('converTypes', () => {
+    describe('integer', () => {
+      it('converts empty string', () => {
+        expect(convertType(dataTypes.INTEGER, '')).toEqual('');
+      });
+
+      it('converts zero', () => {
+        expect(convertType(dataTypes.INTEGER, '0')).toEqual(0);
+      });
+
+      it('converts an integer', () => {
+        expect(convertType(dataTypes.INTEGER, '12132')).toEqual(12132);
+      });
+
+      it('converts a string', () => {
+        expect(convertType(dataTypes.INTEGER, 'abcd')).toEqual('abcd');
+      });
+
+      it('converts a negative integer', () => {
+        expect(convertType(dataTypes.INTEGER, '-12132')).toEqual(-12132);
+      });
+    });
   });
 });


### PR DESCRIPTION
**BACKPORT OF https://github.com/data-driven-forms/react-forms/pull/982**

Part of https://github.com/data-driven-forms/react-forms/issues/980

**Description**

```
}[dataType] || value);
```

This OR operator skips `0` values because it's falsy. 🤕 

Added a seperate check to check if the value is convertable to number values.

Also, JS is funny because

```jsx
parseInt() => NaN
```

```jsx
Number() => 0
``` 

**Schema**

```jsx
{
   component: 'text-field';
   name: 'number',
   dataType: 'integer'
}
```