### PR TITLE
feat(renderer): introduce FieldProps

### DIFF
--- a/packages/common/src/dual-list-select/dual-list-select.js
+++ b/packages/common/src/dual-list-select/dual-list-select.js
@@ -33,7 +33,9 @@ const DualListSelectCommon = (props) => {
 
   const { DualListSelect, ...rest } = useFieldApi({
     ...props,
-    isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort())
+    FieldProps: {
+      isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort())
+    }
   });
 
   const leftValues = rest.options

--- a/packages/mui-component-mapper/demo/index.js
+++ b/packages/mui-component-mapper/demo/index.js
@@ -12,7 +12,7 @@ import fieldArraySchema from './demo-schemas/field-array-schema';
 
 import Button from '@material-ui/core/Button';
 import wizardSchema from './demo-schemas/wizard-schema';
-import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
+import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 
 const theme = createMuiTheme({
   typography: {

--- a/packages/pf4-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/pf4-component-mapper/src/dual-list-select/dual-list-select.js
@@ -26,7 +26,9 @@ const DualList = (props) => {
     ...rest
   } = useFieldApi({
     ...props,
-    isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort())
+    FieldProps: {
+      isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort())
+    }
   });
 
   const [sortConfig, setSortConfig] = useState(() => ({ left: isSortable && 'asc', right: isSortable && 'asc' }));

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -1650,7 +1650,7 @@ describe('renderForm function', () => {
 
     expect(wrapper.find('label').text()).toEqual(label);
     expect(resolveProps).toHaveBeenCalledWith(
-      { label: 'standard label' },
+      { label: 'standard label', component: 'custom-component' },
       expect.objectContaining({ meta: expect.any(Object), input: expect.any(Object) }),
       expect.any(Object)
     );

--- a/packages/react-form-renderer/src/tests/form-renderer/use-field-api.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/use-field-api.test.js
@@ -215,4 +215,19 @@ describe('useFieldApi', () => {
     wrapper.update();
     expect(wrapper.find('input')).toHaveLength(1);
   });
+
+  it('omits FieldProps', () => {
+    const parse = jest.fn().mockImplementation((value) => value);
+    initialProps = {...initialProps, FieldProps: { parse }};
+
+    const wrapper = mount(<WrapperComponent {...initialProps} />);
+
+    expect(wrapper.find(Catcher).props().FieldProps).toEqual(undefined);
+    expect(parse.mock.calls).toHaveLength(0);
+
+    wrapper.find('input').simulate('change', { target: { value: 'ABC' } });
+    wrapper.update();
+
+    expect(parse.mock.calls).toHaveLength(1);
+  });
 });

--- a/packages/react-form-renderer/src/use-field-api/use-field-api.js
+++ b/packages/react-form-renderer/src/use-field-api/use-field-api.js
@@ -121,7 +121,11 @@ const useFieldApi = ({
     dataType,
     type: combinedProps.type,
     ...(Object.prototype.hasOwnProperty.call(combinedProps, 'initialValue')
-      ? {initialValue: combinedProps.initialValue}
+      ? { initialValue: combinedProps.initialValue }
+      : {}
+    ),
+    ...(Object.prototype.hasOwnProperty.call(combinedProps, 'value')
+      ? { value: combinedProps.value }
       : {}
     ),
     ...FieldProps,

--- a/packages/react-renderer-demo/src/pages/migration-guide-v3.md
+++ b/packages/react-renderer-demo/src/pages/migration-guide-v3.md
@@ -66,4 +66,19 @@ FormRenderer component is no longer a default export of the `react-form-renderer
 
 All the mappers except Ant Design and PatternFly 4 were migrated to use JSS (CSS in JS), so you don't have to use any css-loader. (However, you still need to setup the loader in case you are using ant-component-mapper of pf4-component-mapper. If you are using PF4, you are probably using the loader right now, as you need it also for the core package.)
 
+## FieldProps introduction
+
+A new [FieldProps](/schema/introduction#fieldprops) props is introduced. This object serves to pass values to Final Form [useField configuration](https://final-form.org/docs/react-final-form/types/FieldProps). Do not use for natively supported props (`initialValue`, `validate`, ...).
+
+```diff
+{
+    name: 'component-with-complex-isEqual',
+    component: 'dual-list-selector',
+-   isEqual: (a, b) => isEqual(a, b),
++   FieldProps: {
++     isEqual: (a, b) => isEqual(a, b),
++   }
+}
+```
+
 </DocPage>

--- a/packages/react-renderer-demo/src/pages/schema/introduction.md
+++ b/packages/react-renderer-demo/src/pages/schema/introduction.md
@@ -29,6 +29,7 @@ Other attribues, such as title or description, can be used in [form templates](/
     clearOnUnmount: true,
     condition: { ... },
     dataType: 'string',
+    FieldProps: { ... },
     hideField: true,
     initializeOnMount: true,
     initialValue: 'default-login',
@@ -129,6 +130,14 @@ There are also two actions that can be binded to conditions: [set](/schema/condi
 one of strings: *integer | float | number | boolean | string*
 
 Data type sets the type the value will be converted to. Read more [here](/schema/data-types).
+
+---
+
+### FieldProps
+
+*object*
+
+You can pass additional [Final Form FieldProps](https://final-form.org/docs/react-final-form/types/FieldProps) via FieldProps object. This prop is made to avoid conflicts between Final Form props and component props.
 
 ---
 


### PR DESCRIPTION
Fixes #986 

**Description**

🚨  **BREAKING** 🚨 

## FieldProps introduction

A new [FieldProps](/schema/introduction#fieldprops) props is introduced. This object serves to pass values to Final Form [useField configuration](https://final-form.org/docs/react-final-form/types/FieldProps). Do not use for natively supported props (`initialValue`, `validate`, ...).

```diff
{
    name: 'component-with-complex-isEqual',
    component: 'dual-list-selector',
-   isEqual: (a, b) => isEqual(a, b),
+   FieldProps: {
+     isEqual: (a, b) => isEqual(a, b),
+   }
}
```


**Schema**

```jsx
{
  component: 'text-field',
  name: 'texttonumber',
  FieldProps: {
     parse: value => Number(Value)
  }
}
```