### PR TITLE
Fixing prop-type for FormTemplate

### DIFF
--- a/packages/react-form-renderer/src/form-renderer/form-renderer.js
+++ b/packages/react-form-renderer/src/form-renderer/form-renderer.js
@@ -101,7 +101,7 @@ FormRenderer.propTypes = {
   subscription: PropTypes.shape({ [PropTypes.string]: PropTypes.bool }),
   clearedValue: PropTypes.any,
   componentMapper: PropTypes.shape({
-    [PropTypes.string]: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func])
+    [PropTypes.string]: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func, PropTypes.elementType])
   }).isRequired,
   FormTemplate: PropTypes.elementType.isRequired,
   validatorMapper: PropTypes.shape({

--- a/packages/react-form-renderer/src/form-renderer/form-renderer.js
+++ b/packages/react-form-renderer/src/form-renderer/form-renderer.js
@@ -103,7 +103,7 @@ FormRenderer.propTypes = {
   componentMapper: PropTypes.shape({
     [PropTypes.string]: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func])
   }).isRequired,
-  FormTemplate: PropTypes.func.isRequired,
+  FormTemplate: PropTypes.elementType.isRequired,
   validatorMapper: PropTypes.shape({
     [PropTypes.string]: PropTypes.func
   }),


### PR DESCRIPTION
**Description**

Fixes error
```
Warning: Failed prop type: Invalid prop `FormTemplate` of type `object` supplied to `FormRenderer`, expected `function`.
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [ ] `Yarn build` passes
- [ ] `Yarn lint` passes
- [ ] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [ ] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
