### PR TITLE
Optimize condition and field array performance

### DIFF
--- a/__mocks__/with-provider.js
+++ b/__mocks__/with-provider.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { RendererContext } from '@data-driven-forms/react-form-renderer';
 import Form from '@data-driven-forms/react-form-renderer/form';
 
-const RenderWithProvider = ({ value = { formOptions: {} }, children, onSubmit = () => {} }) => {
+const RenderWithProvider = ({ value = { formOptions: {internalRegisterField: jest.fn(), internalUnRegisterField: jest.fn()} }, children, onSubmit = () => {} }) => {
   return (
     <Form onSubmit={onSubmit}>
       {() => (

--- a/packages/ant-component-mapper/package.json
+++ b/packages/ant-component-mapper/package.json
@@ -69,7 +69,8 @@
     "react-dom": ">=16.13.0"
   },
   "dependencies": {
-    "@data-driven-forms/common": "*"
+    "@data-driven-forms/common": "*",
+    "lodash": "^4.17.21"
   },
   "postpublish": "export RELEASE_DEMO=true"
 }

--- a/packages/ant-component-mapper/src/field-array/field-array.js
+++ b/packages/ant-component-mapper/src/field-array/field-array.js
@@ -1,4 +1,5 @@
-import React, { useReducer } from 'react';
+import React, { memo, useReducer } from 'react';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import { useFieldApi, useFormApi, FieldArray } from '@data-driven-forms/react-form-renderer';
 import { Row, Col, Button, Typography, Space } from 'antd';
@@ -6,7 +7,7 @@ import { UndoOutlined, RedoOutlined } from '@ant-design/icons';
 
 import FormGroup from '../form-group';
 
-const ArrayItem = ({
+const ArrayItem = memo(({
   fields,
   fieldIndex,
   name,
@@ -38,7 +39,7 @@ const ArrayItem = ({
       </Col>
     </Row>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   name: PropTypes.string,

--- a/packages/ant-component-mapper/src/tests/slider.test.js
+++ b/packages/ant-component-mapper/src/tests/slider.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form as DDFForm } from '@data-driven-forms/react-form-renderer';
+import { Form as DDFForm, RendererContext } from '@data-driven-forms/react-form-renderer';
 import { mount } from 'enzyme';
 import { Slider as AntSlider, Form as OriginalForm } from 'antd';
 import Slider from '../slider';
@@ -7,7 +7,9 @@ import FormGroup from '../form-group';
 
 const Form = (props) => (
   <OriginalForm>
-    <DDFForm onSubmit={jest.fn()} {...props} />
+    <RendererContext.Provider value={{ formOptions: { internalRegisterField: jest.fn(), internalUnRegisterField: jest.fn() } }}>
+      <DDFForm onSubmit={jest.fn()} {...props} />
+    </RendererContext.Provider>
   </OriginalForm>
 );
 

--- a/packages/blueprint-component-mapper/package.json
+++ b/packages/blueprint-component-mapper/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@data-driven-forms/common": "*",
     "clsx": "^1.1.0",
+    "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react-jss": "^10.5.0"
   }

--- a/packages/blueprint-component-mapper/src/field-array/field-array.js
+++ b/packages/blueprint-component-mapper/src/field-array/field-array.js
@@ -1,5 +1,6 @@
-import React, { useContext } from 'react';
+import React, { memo, useContext } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 import clsx from 'clsx';
 import { useFieldApi, useFormApi, FieldArray as FieldArrayFF } from '@data-driven-forms/react-form-renderer';
 import { createUseStyles } from 'react-jss';
@@ -19,7 +20,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const ArrayItem = ({ remove, fields, name, removeLabel, ArrayItemProps, RemoveButtonProps, disabledRemove }) => {
+const ArrayItem = memo(({ remove, fields, name, removeLabel, ArrayItemProps, RemoveButtonProps, disabledRemove }) => {
   const formOptions = useFormApi();
   const { remove: removeCss } = useStyles();
 
@@ -42,7 +43,7 @@ const ArrayItem = ({ remove, fields, name, removeLabel, ArrayItemProps, RemoveBu
       </Button>
     </div>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   remove: PropTypes.func,

--- a/packages/carbon-component-mapper/package.json
+++ b/packages/carbon-component-mapper/package.json
@@ -64,6 +64,7 @@
   "peerDependencies": {},
   "dependencies": {
     "@data-driven-forms/common": "*",
+    "lodash": "^4.17.21",
     "prop-types": ">=15.7.2",
     "react-jss": "^10.5.0"
   }

--- a/packages/carbon-component-mapper/src/field-array/field-array.js
+++ b/packages/carbon-component-mapper/src/field-array/field-array.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 import clsx from 'clsx';
 import { createUseStyles } from 'react-jss';
 
@@ -30,7 +31,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const ArrayItem = ({ remove, fields, name, removeText, buttonDisabled, RemoveButtonProps, ArrayItemProps }) => {
+const ArrayItem = memo(({ remove, fields, name, removeText, buttonDisabled, RemoveButtonProps, ArrayItemProps }) => {
   const formOptions = useFormApi();
   const { remove: removeStyle } = useStyles();
 
@@ -55,7 +56,7 @@ const ArrayItem = ({ remove, fields, name, removeText, buttonDisabled, RemoveBut
       </Button>
     </div>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   remove: PropTypes.func,

--- a/packages/mui-component-mapper/package.json
+++ b/packages/mui-component-mapper/package.json
@@ -70,6 +70,7 @@
     "@material-ui/pickers": "^3.2.10",
     "clsx": "^1.0.4",
     "date-fns": "^1.30.1",
+    "lodash": "^4.17.21",
     "moment": "^2.23.0",
     "@material-ui/lab": "^4.0.0-alpha.53"
   },

--- a/packages/mui-component-mapper/src/field-array/field-array.js
+++ b/packages/mui-component-mapper/src/field-array/field-array.js
@@ -1,6 +1,7 @@
-import React, { useReducer } from 'react';
+import React, { memo, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { useFormApi, FieldArray } from '@data-driven-forms/react-form-renderer';
+import isEqual from 'lodash/isEqual';
 
 import { Grid, Button, Typography, FormControl, FormHelperText, IconButton } from '@material-ui/core';
 
@@ -36,7 +37,7 @@ const useFielArrayStyles = makeStyles({
   }
 });
 
-const ArrayItem = ({
+const ArrayItem = memo(({
   fields,
   fieldIndex,
   name,
@@ -71,7 +72,7 @@ const ArrayItem = ({
       </Grid>
     </Grid>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   name: PropTypes.string,

--- a/packages/pf4-component-mapper/package.json
+++ b/packages/pf4-component-mapper/package.json
@@ -66,7 +66,8 @@
   "dependencies": {
     "@data-driven-forms/common": "*",
     "prop-types": "^15.7.2",
-    "downshift": "^5.4.3"
+    "downshift": "^5.4.3",
+    "lodash": "^4.17.21"
   },
   "postpublish": "export RELEASE_DEMO=true"
 }

--- a/packages/pf4-component-mapper/src/field-array/field-array.js
+++ b/packages/pf4-component-mapper/src/field-array/field-array.js
@@ -1,4 +1,5 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, memo } from 'react';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import { useFormApi, FieldArray } from '@data-driven-forms/react-form-renderer';
 
@@ -9,7 +10,7 @@ import { AddCircleOIcon, CloseIcon } from '@patternfly/react-icons';
 import './final-form-array.css';
 import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 
-const ArrayItem = ({ fields, fieldIndex, name, remove, length, minItems }) => {
+const ArrayItem = memo(({ fields, fieldIndex, name, remove, length, minItems }) => {
   const { renderForm } = useFormApi();
 
   const widths = {
@@ -60,7 +61,7 @@ const ArrayItem = ({ fields, fieldIndex, name, remove, length, minItems }) => {
       </Grid>
     </React.Fragment>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   name: PropTypes.string,

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -1,56 +1,131 @@
 /* eslint-disable camelcase */
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { FormRenderer, useFieldApi, componentTypes, validatorTypes } from '../src';
-import componentMapper from './form-fields-mapper';
-import FormTemplate from './form-template';
+import { FormRenderer, useFieldApi, componentTypes } from '../src';
+import MuiTextField from '@material-ui/core/TextField';
+import Grid from '@material-ui/core/Grid';
 
-// eslint-disable-next-line react/prop-types
-const TextField = (props) => {
-  const { input, label, isRequired } = useFieldApi(props);
+import { Button as MUIButton, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+import FormTemplate from '@data-driven-forms/common/form-template';
+
+const useStyles = makeStyles(() => ({
+  buttonGroup: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    '&>button:not(last-child)': {
+      marginLeft: 8
+    }
+  }
+}));
+
+const Form = ({ children, GridContainerProps, GridProps, ...props }) => (
+  <Grid item xs={12} {...GridProps}>
+    <form noValidate {...props}>
+      <Grid container item spacing={2} xs={12} {...GridContainerProps}>
+        {children}
+      </Grid>
+    </form>
+  </Grid>
+);
+
+Form.propTypes = {
+  children: PropTypes.node,
+  GridProps: PropTypes.object,
+  GridContainerProps: PropTypes.object
+};
+
+const Description = ({ children, GridProps, ...props }) => (
+  <Grid item xs={12} {...GridProps}>
+    <Typography variant="body1" gutterBottom {...props}>
+      {children}
+    </Typography>
+  </Grid>
+);
+
+Description.propTypes = {
+  children: PropTypes.node,
+  GridProps: PropTypes.object
+};
+
+const Title = ({ children, GridProps, ...props }) => (
+  <Grid item xs={12} {...GridProps}>
+    <Typography variant="h3" gutterBottom {...props}>
+      {children}
+    </Typography>
+  </Grid>
+);
+
+Title.propTypes = {
+  children: PropTypes.node,
+  GridProps: PropTypes.object
+};
+
+const ButtonGroup = ({ children, GridProps, ...props }) => {
+  const classes = useStyles();
   return (
-    <div>
-      <label>
-        {label}
-        {isRequired && '*'}
-      </label>
-      <input {...input} />
-    </div>
+    <Grid item xs={12} {...GridProps}>
+      <div className={classes.buttonGroup} {...props}>
+        {children}
+      </div>
+    </Grid>
   );
 };
 
-let key;
+ButtonGroup.propTypes = {
+  children: PropTypes.node,
+  GridProps: PropTypes.object
+};
 
-const fileSchema = {
-  fields: [
-    {
-      component: 'text-field',
-      name: 'required',
-      label: 'required'
-    },
-    {
-      component: 'text-field',
-      name: 'field',
-      label: 'field',
-      resolveProps: (y, x, formOptions) => {
-        const value = formOptions.getFieldState('required')?.value;
+const Button = ({ label, variant, children, buttonType, ...props }) => (
+  <MUIButton color={variant} variant="contained" {...props}>
+    {label || children}
+  </MUIButton>
+);
 
-        //console.log({ value });
+Button.propTypes = {
+  children: PropTypes.node,
+  label: PropTypes.node,
+  variant: PropTypes.string,
+  buttonType: PropTypes.string
+};
 
-        if (value) {
-          key = key || Date.now();
+const MuiFormTemplate = (props) => (
+  <FormTemplate FormWrapper={Form} Button={Button} ButtonGroup={ButtonGroup} Title={Title} Description={Description} {...props} />
+);
 
-          return {
-            isRequired: true,
-            validate: [{ type: validatorTypes.REQUIRED }],
-            key
-          };
-        } else {
-          key = undefined;
-        }
+export default MuiFormTemplate;
+
+// eslint-disable-next-line react/prop-types
+const TextField = (props) => {
+  const { input, label, isRequired, WrapperProps } = useFieldApi(props);
+  return (
+    <Grid item xs={12} {...WrapperProps}>
+      <MuiTextField {...input} label={label} required={isRequired} />
+    </Grid>
+  );
+};
+
+const fields = [];
+
+for (let index = 0; index < 1000; index++) {
+  fields.push({
+    name: `field-${index}`,
+    label: `Text field ${index}`,
+    component: 'text-field',
+    ...(index > 0 ? {
+      condition: {
+        when: `field-${index - 1}`,
+        isEmpty: true
       }
-    }
-  ]
+    } : {})
+  });
+}
+
+const schema = {
+  fields
 };
 
 const App = () => {
@@ -59,13 +134,12 @@ const App = () => {
     <div style={{ padding: 20 }}>
       <FormRenderer
         componentMapper={{
-          ...componentMapper,
           [componentTypes.TEXT_FIELD]: TextField
         }}
-        onSubmit={(values, ...args) => console.log(values, args)}
-        FormTemplate={FormTemplate}
-        schema={fileSchema}
-        subscription={{ values: true }}
+        onSubmit={console.log}
+        FormTemplate={MuiFormTemplate}
+        schema={schema}
+        subscription={{ pristine: false }}
       />
     </div>
   );

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { FormRenderer, useFieldApi, componentTypes } from '../src';
+import { FormRenderer, useFieldApi, componentTypes, useFormApi } from '../src';
 import MuiTextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
 
@@ -108,9 +108,18 @@ const TextField = (props) => {
   );
 };
 
-const fields = [];
+const Spy = () => {
+  const formApi = useFormApi();
+  console.log(formApi);
+  return null;
+};
 
-for (let index = 0; index < 1000; index++) {
+const fields = [{
+  name: 'optionsSpy',
+  component: 'spy',
+}];
+
+for (let index = 0; index < 10; index++) {
   fields.push({
     name: `field-${index}`,
     label: `Text field ${index}`,
@@ -134,7 +143,8 @@ const App = () => {
     <div style={{ padding: 20 }}>
       <FormRenderer
         componentMapper={{
-          [componentTypes.TEXT_FIELD]: TextField
+          [componentTypes.TEXT_FIELD]: TextField,
+          spy: Spy
         }}
         onSubmit={console.log}
         FormTemplate={MuiFormTemplate}

--- a/packages/react-form-renderer/src/field-provider/field-provider.d.ts
+++ b/packages/react-form-renderer/src/field-provider/field-provider.d.ts
@@ -3,6 +3,7 @@ import { ComponentType, ReactNode } from 'react';
 export interface FieldProviderProps<T> {
   Component?: ComponentType<any>;
   render?: (props: T) => ReactNode;
+  skipRegistration?: boolean;
 }
 
 declare const FieldProvider: React.ComponentType<FieldProviderProps<object>>;

--- a/packages/react-form-renderer/src/form-renderer/form-renderer.js
+++ b/packages/react-form-renderer/src/form-renderer/form-renderer.js
@@ -26,8 +26,20 @@ const FormRenderer = ({
   ...props
 }) => {
   const [fileInputs, setFileInputs] = useState([]);
+  const registeredFields = useRef({});
   const focusDecorator = useRef(createFocusDecorator());
   let schemaError;
+
+  const setRegisteredFields = (fn => registeredFields.current = fn({...registeredFields.current}));
+  const internalRegisterField = (name) => {
+    setRegisteredFields(prev => prev[name] ? ({...prev, [name]: prev[name] + 1}) : ({...prev, [name]: 1}));
+  };
+
+  const internalUnRegisterField = (name) => {
+    setRegisteredFields(({[name]: currentField, ...prev}) => currentField && currentField > 1 ? ({[name]: currentField - 1, ...prev}) : prev);
+  };
+
+  const internalGetRegisteredFields = () => Object.entries(registeredFields.current).reduce((acc, [name, value]) => value > 0 ? [...acc, name] : acc, []);
 
   const validatorMapperMerged = { ...defaultValidatorMapper, ...validatorMapper };
 
@@ -80,8 +92,12 @@ const FormRenderer = ({
               reset,
               clearOnUnmount,
               renderForm,
+              internalRegisterField,
+              internalUnRegisterField,
               ...mutators,
-              ...form
+              ...form,
+              ffGetRegisteredFields: form.getRegisteredFields,
+              getRegisteredFields: internalGetRegisteredFields,
             }
           }}
         >

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import set from 'lodash/set';
+import { Field } from 'react-final-form';
 import RendererContext from '../renderer-context';
 import Condition from '../condition';
-import { Field } from 'react-final-form';
 import getConditionTriggers from '../get-condition-triggers';
 
 const FormFieldHideWrapper = ({ hideField, children }) => (hideField ? <div hidden>{children}</div> : children);
@@ -50,7 +50,7 @@ const ConditionTriggerDetector = ({ values = {}, triggers = [], children, condit
           condition={condition}
           field={field}
         >
-        {children}
+          {children}
         </ConditionTriggerDetector>
       )}
     </Field>
@@ -161,8 +161,6 @@ SingleField.propTypes = {
   resolveProps: PropTypes.func
 };
 
-const renderForm = (fields) => {
-  return fields.map((field) => (Array.isArray(field) ? renderForm(field) : <SingleField key={field.name} {...field} />));
-};
+const renderForm = (fields) =>fields.map((field) => (Array.isArray(field) ? renderForm(field) : <SingleField key={field.name} {...field} />));
 
 export default renderForm;

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -69,10 +69,10 @@ const FormConditionWrapper = ({ condition, children, field }) => {
   if (condition) {
     const triggers = getConditionTriggers(condition, field);
     return (
-    <ConditionTriggerDetector triggers={triggers} condition={condition} field={field}>
-      {children}
-    </ConditionTriggerDetector>
-  );
+      <ConditionTriggerDetector triggers={triggers} condition={condition} field={field}>
+        {children}
+      </ConditionTriggerDetector>
+    );
   }
 
   return children;

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import set from 'lodash/set';
 import RendererContext from '../renderer-context';
 import Condition from '../condition';
 import { Field } from 'react-final-form';
@@ -42,10 +43,10 @@ const ConditionTriggerDetector = ({ values = {}, triggers = [], children, condit
   const name = internalTriggers.shift();
   return (
     <Field name={name} subscription={{ value: true }}>
-      {({input: {value}}) =>(
+      {({input: {value}}) => (
         <ConditionTriggerDetector
           triggers={[...internalTriggers]}
-          values={{...values, [name]: value}}
+          values={set({...values}, name, value)}
           condition={condition}
           field={field}
         >

--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -2,59 +2,8 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import RendererContext from '../renderer-context';
 import Condition from '../condition';
-import { memoize } from '../common/helpers';
 import { Field } from 'react-final-form';
-
-const mergeFunctionTrigger = (fn, field) => {
-  let internalTriggers = [];
-  const internalWhen = fn(field);
-  if (Array.isArray(internalWhen)) {
-    internalTriggers = [...internalWhen];
-  } else {
-    internalTriggers.push(internalWhen);
-  }
-
-  return internalTriggers;
-};
-
-const getConditionTriggers = memoize((condition, field) => {
-  let triggers = [];
-  if (Array.isArray(condition)) {
-    return condition.reduce((acc, item) => [...acc, ...getConditionTriggers(item, field)], []);
-  }
-
-  const {when, ...rest} = condition;
-  const nestedKeys = ['and', 'or', 'sequence'];
-  if (typeof when === 'string') {
-    triggers = [...triggers, when];
-  }
-
-  if (typeof when === 'function') {
-    triggers = [...triggers, ...mergeFunctionTrigger(when, field)];
-  }
-
-  if (Array.isArray(when)) {
-    when.forEach(item => {
-      if (typeof item === 'string') {
-        triggers = [...triggers, item];
-      }
-
-      if (typeof item === 'function') {
-        triggers = [...triggers, ...mergeFunctionTrigger(item, field)];
-      }
-    });
-  }
-
-  nestedKeys.forEach(key => {
-    if (typeof rest[key] !== 'undefined') {
-    rest[key].forEach(item => {
-      triggers = [...triggers, ...getConditionTriggers(item, field)];
-    });
-    }
-  });
-
-  return Array.from(new Set(triggers));
-});
+import getConditionTriggers from '../get-condition-triggers';
 
 const FormFieldHideWrapper = ({ hideField, children }) => (hideField ? <div hidden>{children}</div> : children);
 

--- a/packages/react-form-renderer/src/get-condition-triggers/get-condition-triggers.d.ts
+++ b/packages/react-form-renderer/src/get-condition-triggers/get-condition-triggers.d.ts
@@ -1,0 +1,5 @@
+import { ConditionDefinition } from "../../condition";
+
+declare function getConditionTriggers(params:ConditionDefinition | ConditionDefinition[]): string[];
+
+export default getConditionTriggers;

--- a/packages/react-form-renderer/src/get-condition-triggers/get-condition-triggers.js
+++ b/packages/react-form-renderer/src/get-condition-triggers/get-condition-triggers.js
@@ -1,0 +1,54 @@
+import { memoize } from '../common';
+
+const mergeFunctionTrigger = (fn, field) => {
+  let internalTriggers = [];
+  const internalWhen = fn(field);
+  if (Array.isArray(internalWhen)) {
+    internalTriggers = [...internalWhen];
+  } else {
+    internalTriggers.push(internalWhen);
+  }
+
+  return internalTriggers;
+};
+
+const getConditionTriggers = memoize((condition, field) => {
+  let triggers = [];
+  if (Array.isArray(condition)) {
+    return condition.reduce((acc, item) => [...acc, ...getConditionTriggers(item, field)], []);
+  }
+
+  const {when, ...rest} = condition;
+  const nestedKeys = ['and', 'or', 'sequence'];
+  if (typeof when === 'string') {
+    triggers = [...triggers, when];
+  }
+
+  if (typeof when === 'function') {
+    triggers = [...triggers, ...mergeFunctionTrigger(when, field)];
+  }
+
+  if (Array.isArray(when)) {
+    when.forEach(item => {
+      if (typeof item === 'string') {
+        triggers = [...triggers, item];
+      }
+
+      if (typeof item === 'function') {
+        triggers = [...triggers, ...mergeFunctionTrigger(item, field)];
+      }
+    });
+  }
+
+  nestedKeys.forEach(key => {
+    if (typeof rest[key] !== 'undefined') {
+    rest[key].forEach(item => {
+      triggers = [...triggers, ...getConditionTriggers(item, field)];
+    });
+    }
+  });
+
+  return Array.from(new Set(triggers));
+});
+
+export default getConditionTriggers;

--- a/packages/react-form-renderer/src/get-condition-triggers/index.d.ts
+++ b/packages/react-form-renderer/src/get-condition-triggers/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './get-condition-triggers';

--- a/packages/react-form-renderer/src/get-condition-triggers/index.js
+++ b/packages/react-form-renderer/src/get-condition-triggers/index.js
@@ -1,0 +1,1 @@
+export { default } from './get-condition-triggers';

--- a/packages/react-form-renderer/src/renderer-context/renderer-context.d.ts
+++ b/packages/react-form-renderer/src/renderer-context/renderer-context.d.ts
@@ -14,6 +14,10 @@ export interface FormOptions extends FormApi {
   handleSubmit: () => Promise<AnyObject | undefined> | undefined;
   clearedValue?: any;
   renderForm: (fields: Field[]) => ReactNode[];
+  internalRegisterField: (name: string) => void;
+  internalUnregisterField: (name: string) => void;
+  getRegisteredFields: () => string[];
+  ffGetRegisteredFields: () => string[];
 }
 
 export interface RendererContextValue {

--- a/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/packages/react-form-renderer/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -217,38 +217,227 @@ exports[`renderForm function #condition should render condition field only if co
           }
         }
       >
-        <FormSpy
-          subscription={
+        <ConditionTriggerDetector
+          condition={
+            Array [
+              Object {
+                "is": "x",
+                "when": Array [
+                  "a",
+                  "b",
+                ],
+              },
+              Object {
+                "pattern": /fuzz/,
+                "when": "c",
+              },
+            ]
+          }
+          field={
             Object {
-              "values": true,
+              "component": "custom-component",
+              "name": "foo",
             }
           }
+          triggers={
+            Array [
+              "a",
+              "b",
+              "c",
+            ]
+          }
         >
-          <Component
-            condition={
-              Array [
-                Object {
-                  "is": "x",
-                  "when": Array [
-                    "a",
-                    "b",
-                  ],
-                },
-                Object {
-                  "pattern": /fuzz/,
-                  "when": "c",
-                },
-              ]
-            }
-            field={
+          <ForwardRef(Field)
+            name="a"
+            subscription={
               Object {
-                "component": "custom-component",
-                "name": "foo",
+                "value": true,
               }
             }
-            values={Object {}}
-          />
-        </FormSpy>
+          >
+            <ConditionTriggerDetector
+              condition={
+                Array [
+                  Object {
+                    "is": "x",
+                    "when": Array [
+                      "a",
+                      "b",
+                    ],
+                  },
+                  Object {
+                    "pattern": /fuzz/,
+                    "when": "c",
+                  },
+                ]
+              }
+              field={
+                Object {
+                  "component": "custom-component",
+                  "name": "foo",
+                }
+              }
+              triggers={
+                Array [
+                  "b",
+                  "c",
+                ]
+              }
+              values={
+                Object {
+                  "a": "",
+                }
+              }
+            >
+              <ForwardRef(Field)
+                name="b"
+                subscription={
+                  Object {
+                    "value": true,
+                  }
+                }
+              >
+                <ConditionTriggerDetector
+                  condition={
+                    Array [
+                      Object {
+                        "is": "x",
+                        "when": Array [
+                          "a",
+                          "b",
+                        ],
+                      },
+                      Object {
+                        "pattern": /fuzz/,
+                        "when": "c",
+                      },
+                    ]
+                  }
+                  field={
+                    Object {
+                      "component": "custom-component",
+                      "name": "foo",
+                    }
+                  }
+                  triggers={
+                    Array [
+                      "c",
+                    ]
+                  }
+                  values={
+                    Object {
+                      "a": "",
+                      "b": "",
+                    }
+                  }
+                >
+                  <ForwardRef(Field)
+                    name="c"
+                    subscription={
+                      Object {
+                        "value": true,
+                      }
+                    }
+                  >
+                    <ConditionTriggerDetector
+                      condition={
+                        Array [
+                          Object {
+                            "is": "x",
+                            "when": Array [
+                              "a",
+                              "b",
+                            ],
+                          },
+                          Object {
+                            "pattern": /fuzz/,
+                            "when": "c",
+                          },
+                        ]
+                      }
+                      field={
+                        Object {
+                          "component": "custom-component",
+                          "name": "foo",
+                        }
+                      }
+                      triggers={Array []}
+                      values={
+                        Object {
+                          "a": "",
+                          "b": "",
+                          "c": "",
+                        }
+                      }
+                    >
+                      <ConditionTriggerWrapper
+                        condition={
+                          Array [
+                            Object {
+                              "is": "x",
+                              "when": Array [
+                                "a",
+                                "b",
+                              ],
+                            },
+                            Object {
+                              "pattern": /fuzz/,
+                              "when": "c",
+                            },
+                          ]
+                        }
+                        field={
+                          Object {
+                            "component": "custom-component",
+                            "name": "foo",
+                          }
+                        }
+                        values={
+                          Object {
+                            "a": "",
+                            "b": "",
+                            "c": "",
+                          }
+                        }
+                      >
+                        <Component
+                          condition={
+                            Array [
+                              Object {
+                                "is": "x",
+                                "when": Array [
+                                  "a",
+                                  "b",
+                                ],
+                              },
+                              Object {
+                                "pattern": /fuzz/,
+                                "when": "c",
+                              },
+                            ]
+                          }
+                          field={
+                            Object {
+                              "component": "custom-component",
+                              "name": "foo",
+                            }
+                          }
+                          values={
+                            Object {
+                              "a": "",
+                              "b": "",
+                              "c": "",
+                            }
+                          }
+                        />
+                      </ConditionTriggerWrapper>
+                    </ConditionTriggerDetector>
+                  </ForwardRef(Field)>
+                </ConditionTriggerDetector>
+              </ForwardRef(Field)>
+            </ConditionTriggerDetector>
+          </ForwardRef(Field)>
+        </ConditionTriggerDetector>
       </FormConditionWrapper>
     </SingleField>
   </ReactFinalForm>
@@ -460,32 +649,148 @@ exports[`renderForm function #condition should render condition field only if on
           }
         }
       >
-        <FormSpy
-          subscription={
+        <ConditionTriggerDetector
+          condition={
             Object {
-              "values": true,
+              "is": "x",
+              "when": Array [
+                "a",
+                "b",
+              ],
             }
           }
+          field={
+            Object {
+              "component": "custom-component",
+              "name": "foo",
+            }
+          }
+          triggers={
+            Array [
+              "a",
+              "b",
+            ]
+          }
         >
-          <Component
-            condition={
+          <ForwardRef(Field)
+            name="a"
+            subscription={
               Object {
-                "is": "x",
-                "when": Array [
-                  "a",
+                "value": true,
+              }
+            }
+          >
+            <ConditionTriggerDetector
+              condition={
+                Object {
+                  "is": "x",
+                  "when": Array [
+                    "a",
+                    "b",
+                  ],
+                }
+              }
+              field={
+                Object {
+                  "component": "custom-component",
+                  "name": "foo",
+                }
+              }
+              triggers={
+                Array [
                   "b",
-                ],
+                ]
               }
-            }
-            field={
-              Object {
-                "component": "custom-component",
-                "name": "foo",
+              values={
+                Object {
+                  "a": "",
+                }
               }
-            }
-            values={Object {}}
-          />
-        </FormSpy>
+            >
+              <ForwardRef(Field)
+                name="b"
+                subscription={
+                  Object {
+                    "value": true,
+                  }
+                }
+              >
+                <ConditionTriggerDetector
+                  condition={
+                    Object {
+                      "is": "x",
+                      "when": Array [
+                        "a",
+                        "b",
+                      ],
+                    }
+                  }
+                  field={
+                    Object {
+                      "component": "custom-component",
+                      "name": "foo",
+                    }
+                  }
+                  triggers={Array []}
+                  values={
+                    Object {
+                      "a": "",
+                      "b": "",
+                    }
+                  }
+                >
+                  <ConditionTriggerWrapper
+                    condition={
+                      Object {
+                        "is": "x",
+                        "when": Array [
+                          "a",
+                          "b",
+                        ],
+                      }
+                    }
+                    field={
+                      Object {
+                        "component": "custom-component",
+                        "name": "foo",
+                      }
+                    }
+                    values={
+                      Object {
+                        "a": "",
+                        "b": "",
+                      }
+                    }
+                  >
+                    <Component
+                      condition={
+                        Object {
+                          "is": "x",
+                          "when": Array [
+                            "a",
+                            "b",
+                          ],
+                        }
+                      }
+                      field={
+                        Object {
+                          "component": "custom-component",
+                          "name": "foo",
+                        }
+                      }
+                      values={
+                        Object {
+                          "a": "",
+                          "b": "",
+                        }
+                      }
+                    />
+                  </ConditionTriggerWrapper>
+                </ConditionTriggerDetector>
+              </ForwardRef(Field)>
+            </ConditionTriggerDetector>
+          </ForwardRef(Field)>
+        </ConditionTriggerDetector>
       </FormConditionWrapper>
     </SingleField>
   </ReactFinalForm>

--- a/packages/react-form-renderer/src/tests/form-renderer/form-renderer.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/form-renderer.test.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import FormRenderer from '../../form-renderer';
@@ -6,6 +7,24 @@ import SchemaErrorComponent from '../../form-renderer/schema-error-component';
 import componentTypes from '../../component-types';
 import FormTemplate from '../../../../../__mocks__/mock-form-template';
 import useFieldApi from '../../use-field-api';
+import useFormApi from '../../use-form-api';
+
+const PropsSpy = () => <Fragment />;
+const ContextSpy = ({registerSpy, spyFF, ...props}) => {
+  useFieldApi(props);
+  const { getRegisteredFields, ffGetRegisteredFields, ...formApi } = useFormApi();
+  return (
+    <Fragment>
+      <button onClick={() => registerSpy(spyFF ? ffGetRegisteredFields() : getRegisteredFields())} id={props.name}></button>
+      <PropsSpy {...formApi} />
+    </Fragment>
+  );
+};
+
+const DuplicatedField = ({name, ...props}) => {
+  useFieldApi({name: name.split('@').pop(), ...props});
+  return <Fragment />;
+};
 
 const TextField = (props) => {
   const { input } = useFieldApi(props);
@@ -180,5 +199,118 @@ describe('<FormRenderer />', () => {
       wrapper.find('form').simulate('submit');
       expect(onSubmit).toHaveBeenCalledWith({ 'initial-convert': [{ value: 5 }, { value: 3 }, { value: 11 }, { value: 999 }] });
     });
+  });
+
+  it('should register new field to renderer context', () => {
+    const registerSpy = jest.fn();
+    const wrapper = mount(
+      <FormRenderer
+        FormTemplate={(props) => <FormTemplate {...props} />}
+        componentMapper={{
+          spy: {component: ContextSpy, registerSpy}
+        }}
+        schema={{ fields: [{component: 'spy', name: 'should-show'}] }}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    const button = wrapper.find('button#should-show');
+    act(() => {
+      button.simulate('click');
+    });
+    expect(registerSpy).toHaveBeenCalledWith(['should-show']);
+  });
+
+  it('should un-register field after unmount', () => {
+    const registerSpy = jest.fn();
+    const wrapper = mount(
+      <FormRenderer
+        FormTemplate={(props) => <FormTemplate {...props} />}
+        componentMapper={{
+          ...componentMapper,
+          spy: {component: ContextSpy, registerSpy}
+        }}
+        initialValues={{ x: 'a' }}
+        schema={{ fields: [
+          {component: 'spy', name: 'trigger'},
+          {component: 'text-field', name: 'x'},
+          {component: 'text-field', name: 'field-1', condition: {when: 'x', is: 'a'}}
+        ] }}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    const button = wrapper.find('button#trigger');
+    act(() => {
+      button.simulate('click');
+    });
+    expect(registerSpy).toHaveBeenCalledWith(['trigger', 'x', 'field-1']);
+    act(() => {
+      wrapper.find('input').first().simulate('change', { target: { value: '' } });
+    });
+    act(() => {
+      button.simulate('click');
+    });
+    expect(registerSpy).toHaveBeenCalledWith(['trigger', 'x']);
+  });
+
+  it('should not un-register field after unmount with multiple fields coppies', () => {
+    const registerSpy = jest.fn();
+    const wrapper = mount(
+      <FormRenderer
+        FormTemplate={(props) => <FormTemplate {...props} />}
+        componentMapper={{
+          ...componentMapper,
+          spy: {component: ContextSpy, registerSpy},
+          duplicate: DuplicatedField,
+        }}
+        initialValues={{ x: 'a' }}
+        schema={{ fields: [
+          {component: 'spy', name: 'trigger'},
+          {component: 'text-field', name: 'x'},
+          {component: 'text-field', name: 'field-1', condition: {when: 'x', is: 'a'}},
+          {component: 'duplicate', name: 'dupe@field-1'}
+        ] }}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    const button = wrapper.find('button#trigger');
+    act(() => {
+      button.simulate('click');
+    });
+    expect(registerSpy).toHaveBeenCalledWith(['trigger', 'x', 'field-1']);
+    act(() => {
+      wrapper.find('input').first().simulate('change', { target: { value: '' } });
+    });
+    act(() => {
+      button.simulate('click');
+    });
+    expect(registerSpy).toHaveBeenCalledWith(['trigger', 'x', 'field-1']);
+  });
+
+  it('should skip field registration', () => {
+    const registerSpy = jest.fn();
+    const wrapper = mount(
+      <FormRenderer
+        FormTemplate={(props) => <FormTemplate {...props} />}
+        componentMapper={{
+          ...componentMapper,
+          spy: {component: ContextSpy, registerSpy},
+          duplicate: DuplicatedField,
+        }}
+        initialValues={{ x: 'a' }}
+        schema={{ fields: [
+          {component: 'spy', name: 'trigger', skipRegistration: true},
+        ] }}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    const button = wrapper.find('button#trigger');
+    act(() => {
+      button.simulate('click');
+    });
+    expect(registerSpy).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -32,6 +32,8 @@ describe('renderForm function', () => {
         formOptions: {
           renderForm,
           getState: () => ({ dirty: true }),
+          internalRegisterField: jest.fn(),
+          internalUnRegisterField: jest.fn(),
           ...props.formOptions
         }
       }}

--- a/packages/react-form-renderer/src/tests/form-renderer/use-field-api.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/use-field-api.test.js
@@ -32,7 +32,9 @@ describe('useFieldApi', () => {
               <RendererContext.Provider
                 value={{
                   formOptions: {
-                    registerInputFile: registerInputFileSpy
+                    registerInputFile: registerInputFileSpy,
+                    internalRegisterField: jest.fn(),
+                    internalUnRegisterField: jest.fn(),
                   },
                   validatorMapper: { required: () => (value) => (!value ? 'required' : undefined) }
                 }}
@@ -197,7 +199,10 @@ describe('useFieldApi', () => {
             <RendererContext.Provider
               value={{
                 validatorMapper: { required: () => (value) => (!value ? 'required' : undefined), url: () => jest.fn() },
-                formOptions: {}
+                formOptions: {
+                  internalRegisterField: jest.fn(),
+                  internalUnRegisterField: jest.fn(),
+                }
               }}
             >
               <TestDummy validate={validate} />

--- a/packages/react-form-renderer/src/tests/get-condition-triggers/get-condition-triggers.test.js
+++ b/packages/react-form-renderer/src/tests/get-condition-triggers/get-condition-triggers.test.js
@@ -1,0 +1,35 @@
+import getConditionTriggers from '../../get-condition-triggers';
+
+describe('getConditionTriggers', () => {
+  test('should extract name from simple when definition', () => {
+    expect(getConditionTriggers({ when: 'a' })).toEqual(['a']);
+  });
+
+  test('should extract name from simple when array definition', () => {
+    expect(getConditionTriggers({ when: ['a', 'b'] })).toEqual(['a', 'b']);
+  });
+
+  test('should extract name from simple when function definition', () => {
+    expect(getConditionTriggers({ when: () => 'a' })).toEqual(['a']);
+  });
+
+  test('should extract name from combined when array definition', () => {
+    expect(getConditionTriggers({ when: ['a', () => 'b'] })).toEqual(['a', 'b']);
+  });
+
+  test('should extract name from combined when array definition if functions returns an array', () => {
+    expect(getConditionTriggers({ when: ['a', () => ['b', 'c']] })).toEqual(['a', 'b', 'c']);
+  });
+
+  test('should extract name from and condition definition', () => {
+    expect(getConditionTriggers({ and: [{ when: 'a' }, {when: ['b', 'c']}, { when: () => 'd' }] })).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('should extract name from or condition definition', () => {
+    expect(getConditionTriggers({ or: [{ when: 'a' }, {when: ['b', 'c']}, { when: () => 'd' }] })).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('should extract name from array of conditions', () => {
+    expect(getConditionTriggers([{ when: 'a' }, {when: 'b'}])).toEqual(['a', 'b']);
+  });
+});

--- a/packages/react-form-renderer/src/use-field-api/use-field-api.d.ts
+++ b/packages/react-form-renderer/src/use-field-api/use-field-api.d.ts
@@ -10,6 +10,7 @@ export interface ValidatorType extends Object {
 export interface UseFieldApiConfig extends AnyObject {
   name: string;
   validate?: ValidatorType[];
+  skipRegistration?: boolean;
   useWarnings?: boolean;
 }
 export interface UseFieldApiComponentConfig extends UseFieldConfig<any>  {

--- a/packages/react-form-renderer/src/use-field-api/use-field-api.js
+++ b/packages/react-form-renderer/src/use-field-api/use-field-api.js
@@ -87,6 +87,7 @@ const createFieldProps = (name, formOptions) => {
 const useFieldApi = ({
   name,
   resolveProps,
+  skipRegistration = false,
   ...props
 }) => {
   const { validatorMapper, formOptions } = useContext(RendererContext);
@@ -196,6 +197,10 @@ const useFieldApi = ({
 
   useEffect(
     () => {
+      if (!skipRegistration) {
+        formOptions.internalRegisterField(name);
+      }
+
       mounted.current = true;
       if (field.input.type === 'file') {
         formOptions.registerInputFile(field.input.name);
@@ -212,6 +217,10 @@ const useFieldApi = ({
 
         if (field.input.type === 'file') {
           formOptions.unRegisterInputFile(field.input.name);
+        }
+
+        if (!skipRegistration) {
+          formOptions.internalUnRegisterField(name);
         }
       };
     },

--- a/packages/suir-component-mapper/package.json
+++ b/packages/suir-component-mapper/package.json
@@ -63,6 +63,7 @@
     "@data-driven-forms/common": "*",
     "classnames": "^2.2.6",
     "clsx": "^1.0.4",
+    "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react-jss": "^10.1.1"
   }

--- a/packages/suir-component-mapper/src/field-array/field-array.js
+++ b/packages/suir-component-mapper/src/field-array/field-array.js
@@ -1,5 +1,6 @@
-import React, { useReducer } from 'react';
+import React, { memo, useReducer } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 import { useFormApi, FieldArray } from '@data-driven-forms/react-form-renderer';
 
 import { Button, Header, ButtonGroup } from 'semantic-ui-react';
@@ -37,7 +38,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const ArrayItem = ({
+const ArrayItem = memo(({
   fields,
   fieldIndex,
   name,
@@ -74,7 +75,7 @@ const ArrayItem = ({
       </div>
     </div>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   name: PropTypes.string,

--- a/templates/component-mapper/package.json
+++ b/templates/component-mapper/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@data-driven-forms/common": "*",
+    "lodash": "latest",
     "prop-types": "^15.7.2"
   }
 }

--- a/templates/component-mapper/src/field-array/field-array.js
+++ b/templates/component-mapper/src/field-array/field-array.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import { useFieldApi, useFormApi, FieldArray as FieldArrayFF } from '@data-driven-forms/react-form-renderer';
 
-const ArrayItem = ({ remove, fields, name }) => {
+const ArrayItem = memo(({ remove, fields, name }) => {
   const formOptions = useFormApi();
 
   const editedFields = fields.map((field) => ({
@@ -16,7 +17,7 @@ const ArrayItem = ({ remove, fields, name }) => {
       <button onClick={remove}>Remove</button>
     </div>
   );
-};
+}, ({remove: _prevRemove, ...prev}, {remove: _nextRemove, ...next}) => isEqual(prev, next));
 
 ArrayItem.propTypes = {
   remove: PropTypes.func,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13376,6 +13376,11 @@ lodash@^4.17.19, lodash@^4.17.20:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"


### PR DESCRIPTION
fixes #1016 

**Description**
The issue was that any field wrapped in the condition is subject to render, even if the `when` value did not change. This introduced improved `FormSpy` that listens only on a set of values in the form state. The effect of the new spy is that we no longer trigger render cycle in every condition wrapped field and by that extension skips the condition evaluation because it's not required.

See profiler snapshots and examples in the linked issue.


