### PR TITLE
feat(pf4): introduce dual list tree select component

### DIFF
--- a/packages/pf4-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/pf4-component-mapper/src/dual-list-select/dual-list-select.js
@@ -4,6 +4,8 @@ import { DualListSelector } from '@patternfly/react-core';
 import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 import isEqual from 'lodash/isEqual';
 
+import DualListTree from '../dual-list-tree-select/dual-list-tree-select';
+
 import FormGroup from '../form-group';
 import DualListContext from '../dual-list-context';
 
@@ -124,4 +126,10 @@ DualList.propTypes = {
   isSortable: PropTypes.bool
 };
 
-export default DualList;
+const DualListWrapper = (props) => props.isTree ? <DualListTree {...props} /> : <DualList {...props}/>;
+
+DualListWrapper.propTypes = {
+  isTree: PropTypes.bool,
+};
+
+export default DualListWrapper;

--- a/packages/pf4-component-mapper/src/dual-list-tree-select/dual-list-tree-select.d.ts
+++ b/packages/pf4-component-mapper/src/dual-list-tree-select/dual-list-tree-select.d.ts
@@ -1,0 +1,19 @@
+import { UseFieldApiComponentConfig } from "@data-driven-forms/react-form-renderer";
+import { DualListSelectorProps } from "@patternfly/react-core";
+import { DualListSelectorTreeItemProps } from "@patternfly/react-core/dist/js/components/DualListSelector/DualListSelectorTreeItem";
+import FormGroupProps from "../form-group";
+
+export interface DualListTreeSelectOption extends DualListSelectorTreeItemProps {
+  value: any;
+}
+
+interface InternalDualListSelectProps {
+  options: Array<DualListTreeSelectOption | string>;
+  isSortable?: boolean;
+}
+
+export type DualListTreeSelectProps = InternalDualListSelectProps & FormGroupProps & UseFieldApiComponentConfig & DualListSelectorProps;
+
+declare const DualListSelectTree: React.ComponentType<DualListTreeSelectProps>;
+
+export default DualListSelectTree;

--- a/packages/pf4-component-mapper/src/dual-list-tree-select/dual-list-tree-select.js
+++ b/packages/pf4-component-mapper/src/dual-list-tree-select/dual-list-tree-select.js
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { DualListSelector } from '@patternfly/react-core';
+import { useFieldApi } from '@data-driven-forms/react-form-renderer';
+import isEqual from 'lodash/isEqual';
+
+import FormGroup from '../form-group';
+import DualListContext from '../dual-list-context';
+
+export const convertOptions = (options, sort) => {
+  if (Array.isArray(options)) {
+    let result = options.map((option) => convertOptions(option, sort)).filter(Boolean);
+
+    if (sort) {
+      const sortFn = (a, b) => (sort === 'asc' ? a.localeCompare(b) : b.localeCompare(a));
+
+      result = result.sort((a, b) => sortFn(a.text || a.label, b.text || b.label));
+    }
+
+    return result;
+  }
+
+  return {
+    text: options.label,
+    id: options.value || options.key || options.label || options.text,
+    isChecked: false,
+    ...options,
+    ...(options.children && { children: convertOptions(options.children, sort).filter(Boolean) })
+  };
+};
+
+export const selectedOptions = (options, value, selected) => {
+  if (Array.isArray(options)) {
+    return options.map((option) => selectedOptions(option, value, selected)).filter(Boolean);
+  }
+
+  if (options.value) {
+    if (selected ? value.includes(options.value) : !value.includes(options.value)) {
+      return options;
+    }
+  }
+
+  if (options.children) {
+    const someSelected = selectedOptions(options.children, value, selected).filter(Boolean);
+
+    if (someSelected.length) {
+      return {
+        ...options,
+        children: someSelected
+      };
+    }
+  }
+};
+
+export const getValueFromSelected = (options, newValue = []) => {
+  if (Array.isArray(options)) {
+    options.map((option) => getValueFromSelected(option, newValue));
+  }
+
+  if (options.value) {
+    newValue.push(options.value);
+  }
+
+  if (options.children) {
+    getValueFromSelected(options.children, newValue);
+  }
+
+  return newValue;
+};
+
+const DualListTreeSelect = (props) => {
+  const {
+    label,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    id,
+    input,
+    FormGroupProps,
+    options,
+    isSortable,
+    ...rest
+  } = useFieldApi({
+    ...props,
+    FieldProps: {
+      isEqual: (current, initial) => isEqual([...(current || [])].sort(), [...(initial || [])].sort())
+    }
+  });
+
+  const [sortConfig, setSortConfig] = useState(() => ({ left: isSortable && 'asc', right: isSortable && 'asc' }));
+
+  const value = input.value || [];
+
+  const leftOptions = selectedOptions(options, value, false);
+  const rightOptions = selectedOptions(options, value, true);
+
+  const onListChange = (_newLeft, newRight) => input.onChange(getValueFromSelected(newRight));
+
+  return (
+    <FormGroup
+      label={label}
+      isRequired={isRequired}
+      helperText={helperText}
+      meta={meta}
+      validateOnMount={validateOnMount}
+      description={description}
+      hideLabel={hideLabel}
+      id={id || input.name}
+      FormGroupProps={FormGroupProps}
+    >
+      <DualListContext.Provider value={{ sortConfig, setSortConfig }}>
+        <DualListSelector
+          availableOptions={convertOptions(leftOptions, sortConfig.left)}
+          chosenOptions={convertOptions(rightOptions, sortConfig.right)}
+          onListChange={onListChange}
+          id={id || input.name}
+          isTree
+          {...rest}
+        />
+      </DualListContext.Provider>
+    </FormGroup>
+  );
+};
+
+DualListTreeSelect.propTypes = {
+  label: PropTypes.node,
+  validateOnMount: PropTypes.bool,
+  isRequired: PropTypes.bool,
+  helperText: PropTypes.node,
+  description: PropTypes.node,
+  hideLabel: PropTypes.bool,
+  id: PropTypes.string,
+  isSearchable: PropTypes.bool,
+  isSortable: PropTypes.bool
+};
+
+export default DualListTreeSelect;

--- a/packages/pf4-component-mapper/src/dual-list-tree-select/index.d.ts
+++ b/packages/pf4-component-mapper/src/dual-list-tree-select/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './dual-list-tree-select';
+export * from './dual-list-tree-select';

--- a/packages/pf4-component-mapper/src/dual-list-tree-select/index.js
+++ b/packages/pf4-component-mapper/src/dual-list-tree-select/index.js
@@ -1,0 +1,2 @@
+export { default } from './dual-list-tree-select';
+export * from './dual-list-tree-select';

--- a/packages/pf4-component-mapper/src/index.js
+++ b/packages/pf4-component-mapper/src/index.js
@@ -3,6 +3,7 @@ export { default as FormTemplate } from './form-template';
 export { default as Checkbox } from './checkbox';
 export { default as DatePicker } from './date-picker';
 export { default as DualListSelect } from './dual-list-select';
+export { default as DualListSelectTree } from './dual-list-tree-select';
 export { default as DualListContext } from './dual-list-context';
 export { default as DualListSortButton } from './dual-list-sort-button';
 export { default as FieldArray } from './field-array';

--- a/packages/pf4-component-mapper/src/tests/dual-list-select.test.js
+++ b/packages/pf4-component-mapper/src/tests/dual-list-select.test.js
@@ -88,7 +88,35 @@ describe('DualListSelect', () => {
           <span key="pigeons">pigeons</span>
         ]
       }
-    ]
+    ],
+    [
+    'tree variant',
+      {
+        isTree: true,
+        options: [
+          {
+            value: 'cats',
+            label: 'cats'
+          },
+          {
+            value: 'cats_1',
+            label: 'cats_1'
+          },
+          {
+            value: 'cats_2',
+            label: 'cats_2'
+          },
+          {
+            value: 'zebras',
+            label: 'zebras'
+          },
+          {
+            value: 'pigeons',
+            label: 'pigeons'
+          }
+        ]
+      }
+    ],
   ].forEach(([title, props]) => {
     describe(`${title} values`, () => {
       beforeEach(() => {
@@ -290,10 +318,12 @@ describe('DualListSelect', () => {
         ).toHaveLength(schema.fields[0].options.length);
         await act(async () => {
           wrapper
+            .find('.pf-c-dual-list-selector__tools-filter')
             .find('input')
             .last()
             .instance().value = 'cats';
           wrapper
+            .find('.pf-c-dual-list-selector__tools-filter')
             .find('input')
             .last()
             .simulate('change');

--- a/packages/pf4-component-mapper/src/tests/dual-list-tree-select.test.js
+++ b/packages/pf4-component-mapper/src/tests/dual-list-tree-select.test.js
@@ -1,0 +1,384 @@
+import { convertOptions } from '../dual-list-tree-select';
+import { selectedOptions } from '../dual-list-tree-select/dual-list-tree-select';
+import { getValueFromSelected } from '../dual-list-tree-select/dual-list-tree-select';
+
+describe('DualListTreeSelect', () => {
+  const options = [{
+    label: 'bb',
+    hasBadge: true,
+    badgeProps: {
+        isRead: true
+    },
+    children: [{
+            value: 'value1',
+            label: 'c'
+        },
+        {
+            value: 'value2',
+            label: 'a'
+        },
+        {
+            label: 'Folder 2',
+            children: [{
+                label: 'value 3',
+                value: 'value 3'
+            }]
+        }
+    ]
+},
+{
+    label: 'aaa',
+    hasBadge: true,
+    badgeProps: {
+        isRead: true
+    },
+    children: [{
+            value: 'value12',
+            label: 'a'
+        },
+        {
+            value: 'value23',
+            label: 'z'
+        },
+        {
+            value: 'value231',
+            label: 't'
+        },
+        {
+            label: 'Folder 2',
+            children: [{
+                label: 'xsd',
+                value: 'zsadas'
+            }]
+        }
+    ]
+}
+];
+
+  it('getValueFromSelected', () => {
+    expect(getValueFromSelected(options)).toEqual(['value1', 'value2', 'value 3', 'value12', 'value23', 'value231', 'zsadas']);
+  });
+
+  it('getValueFromSelected - empty array', () => {
+    expect(getValueFromSelected([])).toEqual([]);
+  });
+
+  describe('selectedOptions', () => {
+    it('empty array', () => {
+        expect([]).toEqual([]);
+    });
+
+    it('get selected', () => {
+      const result = selectedOptions(options, ['value 3', 'value12'], true);
+      expect(result).toEqual([{
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              children: [{
+                  label: 'value 3',
+                  value: 'value 3'
+              }],
+              label: 'Folder 2'
+          }],
+          hasBadge: true,
+          label: 'bb'
+      }, {
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              label: 'a',
+              value: 'value12'
+          }],
+          hasBadge: true,
+          label: 'aaa'
+      }]);
+      expect(getValueFromSelected(result)).toEqual(['value 3', 'value12']);
+    });
+
+    it('get usselected', () => {
+      const result = selectedOptions(options, ['value 3', 'value12'], false);
+      expect(result).toEqual([{
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              label: 'c',
+              value: 'value1'
+          }, {
+              label: 'a',
+              value: 'value2'
+          }],
+          hasBadge: true,
+          label: 'bb'
+      }, {
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              label: 'z',
+              value: 'value23'
+          }, {
+              label: 't',
+              value: 'value231'
+          }, {
+              children: [{
+                  label: 'xsd',
+                  value: 'zsadas'
+              }],
+              label: 'Folder 2'
+          }],
+          hasBadge: true,
+          label: 'aaa'
+      }]);
+      expect(getValueFromSelected(result)).toEqual(['value1', 'value2', 'value23', 'value231', 'zsadas']);
+    });
+  });
+
+  describe('convertOptions', () => {
+    it('empty array', () => {
+        expect(convertOptions([])).toEqual([]);
+    });
+
+    it('converts DDF options to tree data', () => {
+      expect(convertOptions(options)).toEqual(
+        [{
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              id: 'value1',
+              isChecked: false,
+              label: 'c',
+              text: 'c',
+              value: 'value1'
+          }, {
+              id: 'value2',
+              isChecked: false,
+              label: 'a',
+              text: 'a',
+              value: 'value2'
+          }, {
+              children: [{
+                  id: 'value 3',
+                  isChecked: false,
+                  label: 'value 3',
+                  text: 'value 3',
+                  value: 'value 3'
+              }],
+              id: 'Folder 2',
+              isChecked: false,
+              label: 'Folder 2',
+              text: 'Folder 2'
+          }],
+          hasBadge: true,
+          id: 'bb',
+          isChecked: false,
+          label: 'bb',
+          text: 'bb'
+      }, {
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              id: 'value12',
+              isChecked: false,
+              label: 'a',
+              text: 'a',
+              value: 'value12'
+          }, {
+              id: 'value23',
+              isChecked: false,
+              label: 'z',
+              text: 'z',
+              value: 'value23'
+          }, {
+              id: 'value231',
+              isChecked: false,
+              label: 't',
+              text: 't',
+              value: 'value231'
+          }, {
+              children: [{
+                  id: 'zsadas',
+                  isChecked: false,
+                  label: 'xsd',
+                  text: 'xsd',
+                  value: 'zsadas'
+              }],
+              id: 'Folder 2',
+              isChecked: false,
+              label: 'Folder 2',
+              text: 'Folder 2'
+          }],
+          hasBadge: true,
+          id: 'aaa',
+          isChecked: false,
+          label: 'aaa',
+          text: 'aaa'
+      }]
+      );
+    });
+
+    it('converts DDF options to tree data and sorts ASC', () => {
+      expect(convertOptions(options, 'asc')).toEqual(
+        [{
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              id: 'value12',
+              isChecked: false,
+              label: 'a',
+              text: 'a',
+              value: 'value12'
+          }, {
+              children: [{
+                  id: 'zsadas',
+                  isChecked: false,
+                  label: 'xsd',
+                  text: 'xsd',
+                  value: 'zsadas'
+              }],
+              id: 'Folder 2',
+              isChecked: false,
+              label: 'Folder 2',
+              text: 'Folder 2'
+          }, {
+              id: 'value231',
+              isChecked: false,
+              label: 't',
+              text: 't',
+              value: 'value231'
+          }, {
+              id: 'value23',
+              isChecked: false,
+              label: 'z',
+              text: 'z',
+              value: 'value23'
+          }],
+          hasBadge: true,
+          id: 'aaa',
+          isChecked: false,
+          label: 'aaa',
+          text: 'aaa'
+      }, {
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              id: 'value2',
+              isChecked: false,
+              label: 'a',
+              text: 'a',
+              value: 'value2'
+          }, {
+              id: 'value1',
+              isChecked: false,
+              label: 'c',
+              text: 'c',
+              value: 'value1'
+          }, {
+              children: [{
+                  id: 'value 3',
+                  isChecked: false,
+                  label: 'value 3',
+                  text: 'value 3',
+                  value: 'value 3'
+              }],
+              id: 'Folder 2',
+              isChecked: false,
+              label: 'Folder 2',
+              text: 'Folder 2'
+          }],
+          hasBadge: true,
+          id: 'bb',
+          isChecked: false,
+          label: 'bb',
+          text: 'bb'
+      }]
+      );
+    });
+
+    it('converts DDF options to tree data and sorts DESC', () => {
+      expect(convertOptions(options, 'desc')).toEqual(
+        [{
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              children: [{
+                  id: 'value 3',
+                  isChecked: false,
+                  label: 'value 3',
+                  text: 'value 3',
+                  value: 'value 3'
+              }],
+              id: 'Folder 2',
+              isChecked: false,
+              label: 'Folder 2',
+              text: 'Folder 2'
+          }, {
+              id: 'value1',
+              isChecked: false,
+              label: 'c',
+              text: 'c',
+              value: 'value1'
+          }, {
+              id: 'value2',
+              isChecked: false,
+              label: 'a',
+              text: 'a',
+              value: 'value2'
+          }],
+          hasBadge: true,
+          id: 'bb',
+          isChecked: false,
+          label: 'bb',
+          text: 'bb'
+      }, {
+          badgeProps: {
+              isRead: true
+          },
+          children: [{
+              id: 'value23',
+              isChecked: false,
+              label: 'z',
+              text: 'z',
+              value: 'value23'
+          }, {
+              id: 'value231',
+              isChecked: false,
+              label: 't',
+              text: 't',
+              value: 'value231'
+          }, {
+              children: [{
+                  id: 'zsadas',
+                  isChecked: false,
+                  label: 'xsd',
+                  text: 'xsd',
+                  value: 'zsadas'
+              }],
+              id: 'Folder 2',
+              isChecked: false,
+              label: 'Folder 2',
+              text: 'Folder 2'
+          }, {
+              id: 'value12',
+              isChecked: false,
+              label: 'a',
+              text: 'a',
+              value: 'value12'
+          }],
+          hasBadge: true,
+          id: 'aaa',
+          isChecked: false,
+          label: 'aaa',
+          text: 'aaa'
+      }]
+      );
+    });
+  });
+});

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/dual-list-select.md
@@ -135,3 +135,7 @@ const CustomRightSortButton = () => {
   );
 };
 ```
+
+### isTree
+
+`isTree` follows the same structure as the [original prop](https://www.patternfly.org/v4/components/dual-list-selector#duallistselector), but you have to provide `value` for all leaves (not folders). You can also use `label` instead of `text` to preserve the same API as the standard variant. There is no `getValueFromNode` option for the tree variant.


### PR DESCRIPTION
**Description**

Introduces support for isTree variant of Dual List Selector (but it doesn't work properly because of issues in PF4...)

**Schema** *(if applicable)*

```jsx
import { componentTypes as components } from '@data-driven-forms/react-form-renderer';

const output = {
  title: 'Testing dual list',
  description: 'Description of testing dual list',
  fields: [
    {
      component: components.DUAL_LIST_SELECT,
      name: 'dual-list-select',
      label: 'choose favorite animal',
      isTree: true,
      isSearchable: true,
      isSortable: true,
      options: [
        {
          value: 'cats',
          label: 'cats'
        },
        {
          value: 'cats_1',
          label: 'cats_1'
        },
        {
          value: 'cats_2',
          label: 'cats_2'
        },
        {
          value: 'zebras',
          label: 'zebras'
        },
        {
          value: 'pigeons',
          label: 'pigeons'
        }
      ],
      options1: [
        {label: 'bb', hasBadge: true, badgeProps: { isRead: true }, children: [
          {value: 'value1', label: 'c'},
          {value: 'value2', label: 'a'},
          //{label: 'Folder 2', children: [{label: 'value 3', value: 'value 3'}]}
        ]},
        {label: 'aaa', hasBadge: true, badgeProps: { isRead: true }, children: [
          {value: 'value12', label: 'a'},
          {value: 'value23', label: 'z'},
          {value: 'value231', label: 't'},
          {label: 'Folder 2', children: [{label: 'xsd', value: 'zsadas'}]}
        ]}
      ]
    }
  ]
};

export default output;
```