### PR TITLE
Fix grid for landing page cards

### DIFF
--- a/packages/react-renderer-demo/src/components/landing-page/landing-page-cards.js
+++ b/packages/react-renderer-demo/src/components/landing-page/landing-page-cards.js
@@ -265,7 +265,7 @@ const LandingPageCards = () => {
                 </a>
               </RouterLink>
             </Grid>
-            <Grid item xs={6} md={3} xl={2}>
+            <Grid item xs={6} md={4} xl={2}>
               <Typography variant="h6" className={classes.textBottom}>
                 BlueprintJS
               </Typography>
@@ -275,7 +275,7 @@ const LandingPageCards = () => {
                 </a>
               </RouterLink>
             </Grid>
-            <Grid item xs={6} md={3} xl={2}>
+            <Grid item xs={6} md={4} xl={2}>
               <Typography variant="h6" className={classes.textBottom}>
                 Semantic UI
               </Typography>
@@ -285,7 +285,7 @@ const LandingPageCards = () => {
                 </a>
               </RouterLink>
             </Grid>
-            <Grid item xs={6} md={3} xl={2}>
+            <Grid item xs={6} md={4} xl={2}>
               <Typography variant="h6" className={classes.textBottom}>
                 Ant Design
               </Typography>
@@ -295,7 +295,7 @@ const LandingPageCards = () => {
                 </a>
               </RouterLink>
             </Grid>
-            <Grid item xs={12} md={3} xl={12}>
+            <Grid item xs={6} md={4} xl={2}>
               <Typography variant="h6" className={classes.textBottom}>
                 Carbon Design System
               </Typography>
@@ -305,7 +305,7 @@ const LandingPageCards = () => {
                 </a>
               </RouterLink>
             </Grid>
-            <Grid item xs={12} md={8}>
+            <Grid item xs={8} md={8} xl={8}>
               <Typography variant="body2" gutterBottom className={classes.mappersText}>
                 This list represents a set of provided mappers. Each mapper brings all basic form components from its design system. You can
                 immediately use form inputs such as text fields, selects, radios, checkboxes or wizards. However, this selection does not limit you as


### PR DESCRIPTION
After PF3 removal, the grid went offset

**Before**

![Screenshot 2021-04-07 at 15 37 04](https://user-images.githubusercontent.com/32869456/113875644-478a7e00-97b7-11eb-939b-2073662e422c.png)

**After**

![Screenshot 2021-04-07 at 15 36 59](https://user-images.githubusercontent.com/32869456/113875658-49ecd800-97b7-11eb-958d-dcbf502855a8.png)

