### PR TITLE
Update clean script to run only before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:ts": "tslint -c ./tslint.json 'packages/**/*.d.ts'",
     "generate-template": "node ./scripts/generate-mapper.js",
     "clean-build": "node ./scripts/clean-build.js",
-    "preinstall": "node ./scripts/clean-build.js"
+    "prebuild": "node ./scripts/clean-build.js"
   },
   "workspaces": [
     "packages/**"

--- a/packages/react-renderer-demo/src/pages/development-setup.md
+++ b/packages/react-renderer-demo/src/pages/development-setup.md
@@ -65,6 +65,18 @@ yarn dev
 yarn lerna clean # will delete all node_modules
 ```
 
+This command **does not remove** the root `node_module` folder.
+
+### Cleaning built files
+
+To clean built files use:
+
+```bash
+yarn clean-build
+```
+
+This script is also ran automatically before each build.
+
 ## Tests
 
 You can test parsers using tests. Tests can be ran from core folder or from specific package.


### PR DESCRIPTION
We cannot run clean before install because we are missing packages needed in the clean script.