### PR TITLE
feat(wizard): enable conditional submit step conversion

### DIFF
--- a/packages/ant-component-mapper/src/tests/wizard.test.js
+++ b/packages/ant-component-mapper/src/tests/wizard.test.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { Button } from 'antd';
 
 import { componentMapper, FormTemplate } from '../index';
+import { CONDITIONAL_SUBMIT_FLAG } from '@data-driven-forms/common/wizard';
 
 describe('wizard', () => {
   let initialProps;
@@ -378,5 +379,52 @@ describe('wizard', () => {
     expect(onCancel).toHaveBeenCalledWith({
       aws: 'something'
     });
+  });
+
+  it('conditional submit step', () => {
+    const submit = jest.fn();
+    schema = {
+      fields: [
+        {
+          component: componentTypes.WIZARD,
+          name: 'wizard',
+          fields: [
+            {
+              name: 'first-step',
+              nextStep: {
+                when: 'name',
+                stepMapper: {
+                  aws: 'summary',
+                  submit: CONDITIONAL_SUBMIT_FLAG
+                }
+              },
+              fields: [
+                {
+                  component: componentTypes.TEXT_FIELD,
+                  name: 'name',
+                  validate: [{ type: validatorTypes.REQUIRED }]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} onSubmit={submit} schema={schema} />);
+
+    wrapper.find('input').instance().value = 'bla';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    expect(wrapper.find('button.ant-btn.ant-btn-primary').text()).toEqual('Next');
+
+    wrapper.find('input').instance().value = 'submit';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    expect(wrapper.find('button.ant-btn.ant-btn-primary').text()).toEqual('Submit');
+    wrapper.find('button.ant-btn.ant-btn-primary').simulate('click');
+    expect(submit).toHaveBeenCalledWith({ name: 'submit' }, expect.any(Object), expect.any(Object));
   });
 });

--- a/packages/ant-component-mapper/src/wizard/step-buttons.js
+++ b/packages/ant-component-mapper/src/wizard/step-buttons.js
@@ -3,16 +3,28 @@ import PropTypes from 'prop-types';
 import { Button } from 'antd';
 import selectNext from '@data-driven-forms/common/wizard/select-next';
 
-const NextButton = ({ nextStep, handleNext, handleSubmit, buttonLabels, getState, valid, NextButtonProps, SubmitButtonProps }) => {
+const NextButton = ({
+  nextStep,
+  handleNext,
+  handleSubmit,
+  buttonLabels,
+  getState,
+  valid,
+  NextButtonProps,
+  SubmitButtonProps,
+  conditionalSubmitFlag
+}) => {
+  const nextResult = nextStep ? selectNext(nextStep, getState) : nextStep;
+  const progressNext = nextResult !== conditionalSubmitFlag && nextStep;
   return (
     <Button
       type="primary"
       htmlType="button"
-      onClick={() => (nextStep ? handleNext(selectNext(nextStep, getState)) : handleSubmit())}
+      onClick={() => (progressNext ? handleNext(nextResult) : handleSubmit())}
       disabled={!valid}
-      {...(nextStep ? NextButtonProps : SubmitButtonProps)}
+      {...(progressNext ? NextButtonProps : SubmitButtonProps)}
     >
-      {nextStep ? buttonLabels.next : buttonLabels.submit}
+      {progressNext ? buttonLabels.next : buttonLabels.submit}
     </Button>
   );
 };
@@ -30,7 +42,8 @@ NextButton.propTypes = {
     next: PropTypes.node.isRequired
   }).isRequired,
   NextButtonProps: PropTypes.object,
-  SubmitButtonProps: PropTypes.object
+  SubmitButtonProps: PropTypes.object,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 const WizardStepButtons = ({
@@ -44,7 +57,8 @@ const WizardStepButtons = ({
   NextButtonProps,
   CancelButtonProps,
   BackButtonProps,
-  SubmitButtonProps
+  SubmitButtonProps,
+  conditionalSubmitFlag
 }) => (
   <div {...ButtonProps}>
     {formOptions.onCancel && (
@@ -62,6 +76,7 @@ const WizardStepButtons = ({
       buttonLabels={buttonLabels}
       NextButtonProps={NextButtonProps}
       SubmitButtonProps={SubmitButtonProps}
+      conditionalSubmitFlag={conditionalSubmitFlag}
     />
   </div>
 );
@@ -70,6 +85,7 @@ WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
+  conditionalSubmitFlag: PropTypes.string.isRequired,
   nextStep: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({

--- a/packages/ant-component-mapper/src/wizard/wizard-step.js
+++ b/packages/ant-component-mapper/src/wizard/wizard-step.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import FormSpy from '@data-driven-forms/react-form-renderer/form-spy';
 import WizardStepButtons from './step-buttons';
 
 import './wizard-step.css';
@@ -9,7 +10,7 @@ const WizardStep = ({ fields, formOptions, WizardStepProps, ...rest }) => (
     <div className="ddorg__ant-component-mapper_wizard-step" {...WizardStepProps}>
       {fields.map((item) => formOptions.renderForm([item], formOptions))}
     </div>
-    <WizardStepButtons formOptions={formOptions} {...rest} />
+    <FormSpy>{() => <WizardStepButtons formOptions={formOptions} {...rest} />}</FormSpy>
   </Fragment>
 );
 

--- a/packages/ant-component-mapper/src/wizard/wizard.js
+++ b/packages/ant-component-mapper/src/wizard/wizard.js
@@ -26,7 +26,8 @@ const WizardInternal = ({
   NextButtonProps,
   BackButtonProps,
   CancelButtonProps,
-  SubmitButtonProps
+  SubmitButtonProps,
+  conditionalSubmitFlag
 }) => {
   const { onKeyDown, formOptions, handleNext, handlePrev, prevSteps, currentStep, jumpToStep, activeStepIndex } = useContext(WizardContext);
 
@@ -53,6 +54,7 @@ const WizardInternal = ({
         BackButtonProps={BackButtonProps}
         CancelButtonProps={CancelButtonProps}
         SubmitButtonProps={SubmitButtonProps}
+        conditionalSubmitFlag={conditionalSubmitFlag}
       />
     </div>
   );
@@ -70,7 +72,8 @@ WizardInternal.propTypes = {
   NextButtonProps: PropTypes.object,
   BackButtonProps: PropTypes.object,
   CancelButtonProps: PropTypes.object,
-  SubmitButtonProps: PropTypes.object
+  SubmitButtonProps: PropTypes.object,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 const WizardFinal = ({ buttonLabels, ...props }) => (

--- a/packages/blueprint-component-mapper/src/tests/wizard.test.js
+++ b/packages/blueprint-component-mapper/src/tests/wizard.test.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import { Button } from '@blueprintjs/core';
 
 import { componentMapper, FormTemplate } from '../index';
+import { CONDITIONAL_SUBMIT_FLAG } from '@data-driven-forms/common/wizard';
 
 describe('wizard', () => {
   let initialProps;
@@ -337,5 +338,52 @@ describe('wizard', () => {
     expect(onCancel).toHaveBeenCalledWith({
       aws: 'something'
     });
+  });
+
+  it('conditional submit step', () => {
+    const submit = jest.fn();
+    schema = {
+      fields: [
+        {
+          component: componentTypes.WIZARD,
+          name: 'wizard',
+          fields: [
+            {
+              name: 'first-step',
+              nextStep: {
+                when: 'name',
+                stepMapper: {
+                  aws: 'summary',
+                  submit: CONDITIONAL_SUBMIT_FLAG
+                }
+              },
+              fields: [
+                {
+                  component: componentTypes.TEXT_FIELD,
+                  name: 'name',
+                  validate: [{ type: validatorTypes.REQUIRED }]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} onSubmit={submit} schema={schema} />);
+
+    wrapper.find('input').instance().value = 'bla';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    expect(wrapper.find('button.bp3-button.bp3-intent-success').text()).toEqual('Nextarrow-right');
+
+    wrapper.find('input').instance().value = 'submit';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    expect(wrapper.find('button.bp3-button.bp3-intent-success').text()).toEqual('Submitarrow-up');
+    wrapper.find('button.bp3-button.bp3-intent-success').simulate('click');
+    expect(submit).toHaveBeenCalledWith({ name: 'submit' }, expect.any(Object), expect.any(Object));
   });
 });

--- a/packages/blueprint-component-mapper/src/wizard/step-buttons.js
+++ b/packages/blueprint-component-mapper/src/wizard/step-buttons.js
@@ -6,17 +6,21 @@ import { createUseStyles } from 'react-jss';
 
 import { Button, Intent } from '@blueprintjs/core';
 
-const NextButton = ({ nextStep, handleNext, buttonLabels, getState, handleSubmit, isDisabled, ...props }) => (
-  <Button
-    disabled={isDisabled}
-    onClick={() => (nextStep ? handleNext(selectNext(nextStep, getState)) : handleSubmit())}
-    rightIcon={nextStep ? 'arrow-right' : 'arrow-up'}
-    intent={Intent.SUCCESS}
-    {...props}
-  >
-    {nextStep ? buttonLabels.next : buttonLabels.submit}
-  </Button>
-);
+const NextButton = ({ nextStep, handleNext, buttonLabels, getState, handleSubmit, isDisabled, conditionalSubmitFlag, ...props }) => {
+  const nextResult = nextStep ? selectNext(nextStep, getState) : nextStep;
+  const progressNext = nextResult !== conditionalSubmitFlag && nextStep;
+  return (
+    <Button
+      disabled={isDisabled}
+      onClick={() => (progressNext ? handleNext(nextResult) : handleSubmit())}
+      rightIcon={progressNext ? 'arrow-right' : 'arrow-up'}
+      intent={Intent.SUCCESS}
+      {...props}
+    >
+      {progressNext ? buttonLabels.next : buttonLabels.submit}
+    </Button>
+  );
+};
 
 NextButton.propTypes = {
   handleNext: PropTypes.func,
@@ -29,7 +33,8 @@ NextButton.propTypes = {
   nextStep: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   getState: PropTypes.func,
   handleSubmit: PropTypes.func,
-  isDisabled: PropTypes.bool
+  isDisabled: PropTypes.bool,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 const useStyles = createUseStyles({
@@ -57,7 +62,8 @@ const StepButtons = ({
   CancelButtonProps,
   BackButtonProps,
   NextButtonProps,
-  SubmitButtonProps
+  SubmitButtonProps,
+  conditionalSubmitFlag
 }) => {
   const { buttonGroup } = useStyles();
 
@@ -77,6 +83,7 @@ const StepButtons = ({
           handleNext={handleNext}
           isDisabled={!formOptions.valid || isNextDisabled}
           handleSubmit={formOptions.handleSubmit}
+          conditionalSubmitFlag={conditionalSubmitFlag}
           {...(currentStep.nextStep ? NextButtonProps : SubmitButtonProps)}
         />
       </div>
@@ -88,6 +95,7 @@ StepButtons.propTypes = {
   currentStep: PropTypes.object,
   handlePrev: PropTypes.func,
   handleNext: PropTypes.func,
+  conditionalSubmitFlag: PropTypes.string.isRequired,
   formOptions: PropTypes.shape({
     onCancel: PropTypes.func,
     renderForm: PropTypes.func,

--- a/packages/blueprint-component-mapper/src/wizard/wizard.js
+++ b/packages/blueprint-component-mapper/src/wizard/wizard.js
@@ -11,7 +11,7 @@ const WizardInternal = ({ WizardProps, ...props }) => {
   return (
     <div onKeyDown={onKeyDown} {...WizardProps}>
       {currentStep.fields.map((item) => formOptions.renderForm([item], formOptions))}
-      <FormSpy subscription={{ valid: true, submitting: true, validating: true }}>
+      <FormSpy>
         {({ valid, submitting, validating }) => (
           <StepButtons isNextDisabled={!valid || submitting || validating} {...props} {...rest} currentStep={currentStep} formOptions={formOptions} />
         )}

--- a/packages/carbon-component-mapper/src/wizard/wizard.js
+++ b/packages/carbon-component-mapper/src/wizard/wizard.js
@@ -110,6 +110,7 @@ const WizardInternal = ({
   ProgressIndicatorProps,
   vertical,
   WizardBodyProps,
+  conditionalSubmitFlag,
   ...props
 }) => {
   const { formOptions, currentStep, handlePrev, onKeyDown, handleNext, activeStepIndex, selectNext, jumpToStep } = useContext(WizardContext);
@@ -132,30 +133,34 @@ const WizardInternal = ({
     <div onKeyDown={onKeyDown} {...props}>
       <WizardLayout nav={nav ? nav : null} fields={fields} WizardBodyProps={WizardBodyProps} />
       <FormSpy>
-        {({ invalid, validating, submitting }) => (
-          <div {...ButtonSetProps} className={clsx(buttonSet, ButtonSetProps.className)}>
-            {currentStep.nextStep ? (
-              <Button
-                onClick={() => handleNext(selectNext(currentStep.nextStep, formOptions.getState))}
-                disabled={!formOptions.valid || invalid || validating || submitting}
-                {...NextButtonProps}
-              >
-                {finalButtoLabels.next}
+        {({ invalid, validating, submitting }) => {
+          const nextResult = currentStep.nextStep ? selectNext(currentStep.nextStep, formOptions.getState) : currentStep.nextStep;
+          const progressNext = nextResult !== conditionalSubmitFlag && currentStep.nextStep;
+          return (
+            <div {...ButtonSetProps} className={clsx(buttonSet, ButtonSetProps.className)}>
+              {progressNext ? (
+                <Button
+                  onClick={() => handleNext(nextResult)}
+                  disabled={!formOptions.valid || invalid || validating || submitting}
+                  {...NextButtonProps}
+                >
+                  {finalButtoLabels.next}
+                </Button>
+              ) : (
+                <Button
+                  onClick={() => formOptions.handleSubmit()}
+                  disabled={!formOptions.valid || invalid || validating || submitting}
+                  {...SubmitButtonProps}
+                >
+                  {finalButtoLabels.submit}
+                </Button>
+              )}
+              <Button kind="secondary" onClick={handlePrev} disabled={activeStepIndex === 0} {...BackButtonProps}>
+                {finalButtoLabels.back}
               </Button>
-            ) : (
-              <Button
-                onClick={() => formOptions.handleSubmit()}
-                disabled={!formOptions.valid || invalid || validating || submitting}
-                {...SubmitButtonProps}
-              >
-                {finalButtoLabels.submit}
-              </Button>
-            )}
-            <Button kind="secondary" onClick={handlePrev} disabled={activeStepIndex === 0} {...BackButtonProps}>
-              {finalButtoLabels.back}
-            </Button>
-          </div>
-        )}
+            </div>
+          );
+        }}
       </FormSpy>
     </div>
   );
@@ -178,7 +183,8 @@ WizardInternal.propTypes = {
   ButtonSetProps: PropTypes.object,
   ProgressIndicatorProps: PropTypes.object,
   vertical: PropTypes.bool,
-  WizardBodyProps: PropTypes.object
+  WizardBodyProps: PropTypes.object,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 WizardInternal.defaultProps = {

--- a/packages/common/src/wizard/consts.d.ts
+++ b/packages/common/src/wizard/consts.d.ts
@@ -1,0 +1,1 @@
+export const CONDITIONAL_SUBMIT_FLAG = '@@ddf-common-wizard__conditional-submit-step';

--- a/packages/common/src/wizard/consts.js
+++ b/packages/common/src/wizard/consts.js
@@ -1,0 +1,1 @@
+export const CONDITIONAL_SUBMIT_FLAG = '@@ddf-common-wizard__conditional-submit-step';

--- a/packages/common/src/wizard/index.d.ts
+++ b/packages/common/src/wizard/index.d.ts
@@ -1,3 +1,4 @@
 export { default } from './wizard';
 export * from './wizard';
+export * from './consts';
 export { default as selectNext } from './select-next';

--- a/packages/common/src/wizard/index.js
+++ b/packages/common/src/wizard/index.js
@@ -1,2 +1,4 @@
 export { default } from './wizard';
 export * from './wizard';
+export * from './consts';
+export { default as selectNext } from './select-next';

--- a/packages/common/src/wizard/wizard.d.ts
+++ b/packages/common/src/wizard/wizard.d.ts
@@ -1,5 +1,4 @@
 import { AnyObject, Field } from "@data-driven-forms/react-form-renderer";
-
 export interface WizardProps extends AnyObject {
   fields: Field[];
   isDynamic?: boolean;

--- a/packages/common/src/wizard/wizard.js
+++ b/packages/common/src/wizard/wizard.js
@@ -8,6 +8,7 @@ import flattenDeep from 'lodash/flattenDeep';
 import handleEnter from './enter-handler';
 import reducer, { DYNAMIC_WIZARD_TYPES, findCurrentStep } from './reducer';
 import selectNext from './select-next';
+import { CONDITIONAL_SUBMIT_FLAG } from './consts';
 
 const Wizard = ({ fields, isDynamic, crossroads, Wizard, component, initialState, ...props }) => {
   const formOptions = useFormApi();
@@ -106,7 +107,12 @@ Wizard.propTypes = {
   crossroads: PropTypes.arrayOf(PropTypes.string),
   Wizard: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   component: PropTypes.any,
-  initialState: PropTypes.object
+  initialState: PropTypes.object,
+  conditionalSubmitFlag: PropTypes.string
+};
+
+Wizard.defaultProps = {
+  conditionalSubmitFlag: CONDITIONAL_SUBMIT_FLAG
 };
 
 export default Wizard;

--- a/packages/mui-component-mapper/src/wizard/step-buttons.js
+++ b/packages/mui-component-mapper/src/wizard/step-buttons.js
@@ -7,16 +7,20 @@ import { FormSpy } from '@data-driven-forms/react-form-renderer';
 import { Button, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-const NextButton = ({ nextStep, valid, handleNext, nextLabel, getState, handleSubmit, submitLabel }) => (
-  <Button
-    variant="contained"
-    color="primary"
-    disabled={!valid || getState().validating || getState().submitting}
-    onClick={() => (nextStep ? handleNext(selectNext(nextStep, getState)) : handleSubmit())}
-  >
-    {nextStep ? nextLabel : submitLabel}
-  </Button>
-);
+const NextButton = ({ nextStep, valid, handleNext, nextLabel, getState, handleSubmit, submitLabel, conditionalSubmitFlag }) => {
+  const nextResult = nextStep ? selectNext(nextStep, getState) : nextStep;
+  const progressNext = nextResult !== conditionalSubmitFlag && nextStep;
+  return (
+    <Button
+      variant="contained"
+      color="primary"
+      disabled={!valid || getState().validating || getState().submitting}
+      onClick={() => (progressNext ? handleNext(nextResult) : handleSubmit())}
+    >
+      {progressNext ? nextLabel : submitLabel}
+    </Button>
+  );
+};
 
 NextButton.propTypes = {
   nextStep: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
@@ -25,7 +29,8 @@ NextButton.propTypes = {
   valid: PropTypes.bool,
   handleNext: PropTypes.func.isRequired,
   nextLabel: PropTypes.node.isRequired,
-  getState: PropTypes.func.isRequired
+  getState: PropTypes.func.isRequired,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 const useStyles = makeStyles(() => ({
@@ -59,7 +64,8 @@ const WizardStepButtons = ({ buttons: Buttons, ...props }) => {
     handleNext,
     buttonLabels: { cancel, submit, back, next },
     formOptions,
-    ButtonContainerProps
+    ButtonContainerProps,
+    conditionalSubmitFlag
   } = props;
 
   return (
@@ -70,7 +76,7 @@ const WizardStepButtons = ({ buttons: Buttons, ...props }) => {
       {...ButtonContainerProps}
       className={clsx(classes.buttonsContainer, ButtonContainerProps.className)}
     >
-      <FormSpy subscription={{ valid: true, validating: true, submitting: true }}>
+      <FormSpy subscription={{ values: true, valid: true, validating: true, submitting: true }}>
         {() => (
           <React.Fragment>
             <Grid item md={2} xs={2}>
@@ -80,7 +86,14 @@ const WizardStepButtons = ({ buttons: Buttons, ...props }) => {
               <Button disabled={disableBack} onClick={handlePrev} className={classes.button}>
                 {back}
               </Button>
-              <NextButton {...formOptions} handleNext={handleNext} nextStep={nextStep} nextLabel={next} submitLabel={submit} />
+              <NextButton
+                {...formOptions}
+                conditionalSubmitFlag={conditionalSubmitFlag}
+                handleNext={handleNext}
+                nextStep={nextStep}
+                nextLabel={next}
+                submitLabel={submit}
+              />
             </Grid>
           </React.Fragment>
         )}
@@ -94,6 +107,7 @@ WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
+  conditionalSubmitFlag: PropTypes.string.isRequired,
   nextStep: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({

--- a/packages/mui-component-mapper/src/wizard/wizard.js
+++ b/packages/mui-component-mapper/src/wizard/wizard.js
@@ -7,7 +7,7 @@ import { WizardContext } from '@data-driven-forms/react-form-renderer';
 import { Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-import Wizard from '@data-driven-forms/common/wizard/wizard';
+import Wizard from '@data-driven-forms/common/wizard';
 import WizardNav from './wizard-nav';
 import WizardStepButtons from './step-buttons';
 
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const WizardInternal = ({ buttonLabels, stepsInfo, ButtonContainerProps, StepperProps, WizardBodyProps, WizardProps }) => {
+const WizardInternal = ({ buttonLabels, stepsInfo, ButtonContainerProps, StepperProps, WizardBodyProps, WizardProps, conditionalSubmitFlag }) => {
   const { formOptions, currentStep, handlePrev, onKeyDown, handleNext, activeStepIndex, prevSteps } = useContext(WizardContext);
 
   const classes = useStyles();
@@ -43,6 +43,7 @@ const WizardInternal = ({ buttonLabels, stepsInfo, ButtonContainerProps, Stepper
           handleNext={handleNext}
           handlePrev={handlePrev}
           disableBack={prevSteps.length === 0}
+          conditionalSubmitFlag={conditionalSubmitFlag}
           ButtonContainerProps={ButtonContainerProps}
         />
       </Grid>
@@ -63,7 +64,8 @@ WizardInternal.propTypes = {
   ButtonContainerProps: PropTypes.object,
   StepperProps: PropTypes.object,
   WizardBodyProps: PropTypes.object,
-  WizardProps: PropTypes.object
+  WizardProps: PropTypes.object,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 WizardInternal.defaultProps = {

--- a/packages/pf4-component-mapper/src/wizard/wizard-components/step-buttons.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/step-buttons.js
@@ -4,16 +4,20 @@ import { Button } from '@patternfly/react-core';
 import selectNext from '@data-driven-forms/common/wizard/select-next';
 import { FormSpy } from '@data-driven-forms/react-form-renderer';
 
-const NextButton = ({ nextStep, valid, handleNext, nextLabel, getState, handleSubmit, submitLabel }) => (
-  <Button
-    variant="primary"
-    type="button"
-    isDisabled={!valid || getState().validating}
-    onClick={() => (nextStep ? handleNext(selectNext(nextStep, getState)) : handleSubmit())}
-  >
-    {nextStep ? nextLabel : submitLabel}
-  </Button>
-);
+const NextButton = ({ nextStep, valid, handleNext, nextLabel, getState, handleSubmit, submitLabel, conditionalSubmitFlag }) => {
+  const nextResult = nextStep ? selectNext(nextStep, getState) : nextStep;
+  const progressNext = nextResult !== conditionalSubmitFlag && nextStep;
+  return (
+    <Button
+      variant="primary"
+      type="button"
+      isDisabled={!valid || getState().validating}
+      onClick={() => (progressNext ? handleNext(selectNext(nextStep, getState)) : handleSubmit())}
+    >
+      {progressNext ? nextLabel : submitLabel}
+    </Button>
+  );
+};
 
 NextButton.propTypes = {
   nextStep: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
@@ -22,7 +26,8 @@ NextButton.propTypes = {
   valid: PropTypes.bool,
   handleNext: PropTypes.func.isRequired,
   nextLabel: PropTypes.node.isRequired,
-  getState: PropTypes.func.isRequired
+  getState: PropTypes.func.isRequired,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 const WizardStepButtons = ({
@@ -33,7 +38,8 @@ const WizardStepButtons = ({
   handleNext,
   buttonsClassName,
   buttonLabels: { cancel, submit, back, next },
-  formOptions
+  formOptions,
+  conditionalSubmitFlag
 }) => (
   <footer className={`pf-c-wizard__footer ${buttonsClassName ? buttonsClassName : ''}`}>
     {Buttons ? (
@@ -53,7 +59,14 @@ const WizardStepButtons = ({
       <FormSpy>
         {() => (
           <React.Fragment>
-            <NextButton {...formOptions} handleNext={handleNext} nextStep={nextStep} nextLabel={next} submitLabel={submit} />
+            <NextButton
+              {...formOptions}
+              conditionalSubmitFlag={conditionalSubmitFlag}
+              handleNext={handleNext}
+              nextStep={nextStep}
+              nextLabel={next}
+              submitLabel={submit}
+            />
             <Button type="button" variant="secondary" isDisabled={disableBack} onClick={handlePrev}>
               {back}
             </Button>
@@ -71,6 +84,7 @@ const WizardStepButtons = ({
 
 WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
+  conditionalSubmitFlag: PropTypes.string.isRequired,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
   nextStep: PropTypes.oneOfType([

--- a/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-step.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-step.js
@@ -94,7 +94,8 @@ WizardStep.propTypes = {
   customTitle: PropTypes.node,
   name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hasNoBodyPadding: PropTypes.bool,
-  StepTemplate: PropTypes.elementType
+  StepTemplate: PropTypes.elementType,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 WizardStep.defaultProps = {

--- a/packages/pf4-component-mapper/src/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard.js
@@ -43,6 +43,7 @@ const WizardInternal = ({
   navAriaLabel,
   StepTemplate,
   className,
+  conditionalSubmitFlag,
   ...rest
 }) => {
   const {
@@ -137,6 +138,7 @@ const WizardInternal = ({
               </FormSpy>
             </WizardNav>
             <WizardStep
+              conditionalSubmitFlag={conditionalSubmitFlag}
               buttonLabels={buttonLabels}
               buttonsClassName={buttonsClassName}
               showTitles={showTitles}
@@ -175,7 +177,8 @@ WizardInternal.propTypes = {
   navAriaLabel: PropTypes.string,
   container: PropTypes.instanceOf(Element),
   StepTemplate: PropTypes.elementType,
-  className: PropTypes.string
+  className: PropTypes.string,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
 const defaultLabels = {

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/wizard.md
@@ -1,10 +1,11 @@
 ## Docs for steps
 
-|Props|Type|Description|
-|----|-------------|----------------|
-|name|string,number|Name of the step|
-|nextStep|object/stepKey of next step/function|See below|
-|fields|array|As usual|
+|Props|Type|Required|Default|Description|
+|-----|----|--------|-------|-----------|
+|name|string,number|no|`undefined`|Name of the step|
+|nextStep|object/stepKey of next step/function|no|`undefined`|See below|
+|fields|array|yes|`undefined`|As usual|
+|conditionalSubmitFlag|string|no|`"@@ddf-common-wizard__conditional-submit-step"`|See below|
 
 ### nextStep
 
@@ -37,6 +38,58 @@ another option is to use custom function. The custom function receives as the fi
 
 ```jsx
 nextStep: ({ values }) => (values.aws === '123' &&& values.password === 'secret') ? 'secretStep' : 'genericStep'
+```
+
+D) **conditional submit step**
+
+Based on a form state value, a step can change into the last step in the wizard and show *submit* button instead of *next* button.
+
+With default constant:
+
+```jsx
+import { CONDITIONAL_SUBMIT_FLAG } from '@data-driven-forms/common/wizard'; // const value = @@ddf-common-wizard__conditional-submit-step
+
+...
+// next step definition
+
+nextStep: {
+        when: 'source-type',
+        stepMapper: {
+          aws: 'aws-step',
+          google: CONDITIONAL_SUBMIT_FLAG,
+          ...
+        },
+},
+```
+
+Or with custom constant value defined by `conditionalSubmitFlag` prop:
+
+```jsx
+const schema = {
+  fields: [{
+    {
+      "component": "wizard",
+      "name": "wizard",
+      // custom flag definition
+      conditionalSubmitFlag: 'make-me-final-step',
+      fields: [{
+        name: 'step-1',
+        // next step definition
+        nextStep: {
+          when: 'value',
+          stepMapper: {
+            "value-one": 'step-2',
+            "value-two": 'make-me-final-step',
+          },
+        }
+        ...
+      }, {
+        name: 'step-2'
+        ...
+      }]
+...
+  }}]
+}
 ```
 
 ### initialState

--- a/packages/suir-component-mapper/src/tests/wizard.test.js
+++ b/packages/suir-component-mapper/src/tests/wizard.test.js
@@ -3,6 +3,7 @@ import { FormRenderer, componentTypes, validatorTypes } from '@data-driven-forms
 import { mount } from 'enzyme';
 
 import { componentMapper, FormTemplate } from '../index';
+import { CONDITIONAL_SUBMIT_FLAG } from '@data-driven-forms/common/wizard';
 
 describe('wizard', () => {
   let initialProps;
@@ -368,5 +369,52 @@ describe('wizard', () => {
     expect(onCancel).toHaveBeenCalledWith({
       aws: 'something'
     });
+  });
+
+  it('conditional submit step', () => {
+    const submit = jest.fn();
+    schema = {
+      fields: [
+        {
+          component: componentTypes.WIZARD,
+          name: 'wizard',
+          fields: [
+            {
+              name: 'first-step',
+              nextStep: {
+                when: 'name',
+                stepMapper: {
+                  aws: 'summary',
+                  submit: CONDITIONAL_SUBMIT_FLAG
+                }
+              },
+              fields: [
+                {
+                  component: componentTypes.TEXT_FIELD,
+                  name: 'name',
+                  validate: [{ type: validatorTypes.REQUIRED }]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const wrapper = mount(<FormRenderer {...initialProps} onSubmit={submit} schema={schema} />);
+
+    wrapper.find('input').instance().value = 'bla';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    expect(wrapper.find('button.ui.blue.icon.right.labeled.button').text()).toEqual('Continue');
+
+    wrapper.find('input').instance().value = 'submit';
+    wrapper.find('input').simulate('change');
+    wrapper.update();
+
+    expect(wrapper.find('button.ui.blue.button').text()).toEqual('Submit');
+    wrapper.find('button.ui.blue.button').simulate('click');
+    expect(submit).toHaveBeenCalledWith({ name: 'submit' }, expect.any(Object), expect.any(Object));
   });
 });

--- a/packages/suir-component-mapper/src/wizard/step-buttons.js
+++ b/packages/suir-component-mapper/src/wizard/step-buttons.js
@@ -13,17 +13,21 @@ const useStyles = createUseStyles({
   }
 });
 
-const NextButton = ({ nextStep, valid, handleNext, nextLabel, getState, handleSubmit, submitLabel }) => (
-  <Button
-    icon={nextStep ? 'right arrow' : undefined}
-    color="blue"
-    labelPosition={nextStep ? 'right' : undefined}
-    content={nextStep ? nextLabel : submitLabel}
-    disabled={!valid || getState().validating || getState().submitting}
-    onClick={() => (nextStep ? handleNext(selectNext(nextStep, getState)) : handleSubmit())}
-    type="button"
-  />
-);
+const NextButton = ({ nextStep, valid, handleNext, nextLabel, getState, handleSubmit, submitLabel, conditionalSubmitFlag }) => {
+  const nextResult = nextStep ? selectNext(nextStep, getState) : nextStep;
+  const progressNext = nextResult !== conditionalSubmitFlag && nextStep;
+  return (
+    <Button
+      icon={progressNext ? 'right arrow' : undefined}
+      color="blue"
+      labelPosition={progressNext ? 'right' : undefined}
+      content={progressNext ? nextLabel : submitLabel}
+      disabled={!valid || getState().validating || getState().submitting}
+      onClick={() => (progressNext ? handleNext(nextResult) : handleSubmit())}
+      type="button"
+    />
+  );
+};
 
 NextButton.propTypes = {
   nextStep: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
@@ -32,10 +36,11 @@ NextButton.propTypes = {
   valid: PropTypes.bool,
   handleNext: PropTypes.func.isRequired,
   nextLabel: PropTypes.node.isRequired,
-  getState: PropTypes.func.isRequired
+  getState: PropTypes.func.isRequired,
+  conditionalSubmitFlag: PropTypes.string.isRequired
 };
 
-const WizardStepButtons = ({ buttons: Buttons, ...props }) => {
+const WizardStepButtons = ({ conditionalSubmitFlag, buttons: Buttons, ...props }) => {
   const classes = useStyles();
   if (Buttons) {
     return <Buttons {...props} />;
@@ -51,7 +56,7 @@ const WizardStepButtons = ({ buttons: Buttons, ...props }) => {
   } = props;
 
   return (
-    <FormSpy subscription={{ valid: true, validating: true, submitting: true }}>
+    <FormSpy subscription={{ values: true, valid: true, validating: true, submitting: true }}>
       {() => (
         <div className={classes.root}>
           <Button type="button" onClick={formOptions.onCancel}>
@@ -59,7 +64,14 @@ const WizardStepButtons = ({ buttons: Buttons, ...props }) => {
           </Button>
           <div>
             <Button icon="left arrow" labelPosition="left" content={back} type="button" disabled={disableBack} onClick={handlePrev} />
-            <NextButton {...formOptions} handleNext={handleNext} nextStep={nextStep} nextLabel={next} submitLabel={submit} />
+            <NextButton
+              {...formOptions}
+              conditionalSubmitFlag={conditionalSubmitFlag}
+              handleNext={handleNext}
+              nextStep={nextStep}
+              nextLabel={next}
+              submitLabel={submit}
+            />
           </div>
         </div>
       )}
@@ -71,6 +83,7 @@ WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
+  conditionalSubmitFlag: PropTypes.string.isRequired,
   nextStep: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({

--- a/packages/suir-component-mapper/src/wizard/wizard.js
+++ b/packages/suir-component-mapper/src/wizard/wizard.js
@@ -5,7 +5,7 @@ import Wizard from '@data-driven-forms/common/wizard/wizard';
 import WizardNav from './wizard-nav';
 import WizardStepButtons from './step-buttons';
 
-const WizardInternal = ({ buttonLabels, stepsInfo }) => {
+const WizardInternal = ({ buttonLabels, stepsInfo, conditionalSubmitFlag }) => {
   const { formOptions, currentStep, handlePrev, onKeyDown, handleNext, activeStepIndex, prevSteps } = useContext(WizardContext);
 
   const buttonLabelsFinal = {
@@ -23,6 +23,7 @@ const WizardInternal = ({ buttonLabels, stepsInfo }) => {
         {currentStep.fields.map((item) => formOptions.renderForm([item], formOptions))}
         <WizardStepButtons
           {...currentStep}
+          conditionalSubmitFlag={conditionalSubmitFlag}
           formOptions={formOptions}
           buttonLabels={buttonLabelsFinal}
           handleNext={handleNext}
@@ -36,6 +37,7 @@ const WizardInternal = ({ buttonLabels, stepsInfo }) => {
 
 WizardInternal.propTypes = {
   buttonLabels: PropTypes.object,
+  conditionalSubmitFlag: PropTypes.string.isRequired,
   stepsInfo: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.node,


### PR DESCRIPTION
based on a feature request in discord

If a conditional next step contains a submit flag (can be configured), the step will show submit button instead of a next button and wizard won't progress further.
```jsx
nextStep: {
        when: 'source-type',
        stepMapper: {
          aws: 'aws-step',
          google: CONDITIONAL_SUBMIT_FLAG,
          ...
        },
},
```

Flag value can be configured via `conditionalSubmitFlag` flag in wizard component schema:
```jsx
const schema = {
  fields: [{
    {
      "component": "wizard",
      "name": "wizard",
      // custom flag definition
      conditionalSubmitFlag: 'make-me-final-step',
      fields: [{
        name: 'step-1',
        // next step definition
        nextStep: {
          when: 'value',
          stepMapper: {
            "value-one": 'step-2',
            "value-two": 'make-me-final-step',
          },
        }
        ...
      }, {
        name: 'step-2'
        ...
      }]
...
  }}]
}
```

@rvsia if you can think of a better name/value for the flag, feel free to post it. I could not come with anything better.