### PR TITLE
Do not translate wizard flag import

### DIFF
--- a/packages/react-renderer-demo/src/doc-components/examples-texts/wizard.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/wizard.md
@@ -44,10 +44,13 @@ D) **conditional submit step**
 
 Based on a form state value, a step can change into the last step in the wizard and show *submit* button instead of *next* button.
 
-With default constant:
+With default constant: `@@ddf-common-wizard__conditional-submit-step`
+
+You can import this constant:
 
 ```jsx
-import { CONDITIONAL_SUBMIT_FLAG } from '@data-driven-forms/common/wizard'; // const value = @@ddf-common-wizard__conditional-submit-step
+--- { "switchable": false } ---
+import { CONDITIONAL_SUBMIT_FLAG } from '@data-driven-forms/common/wizard';
 
 ...
 // next step definition


### PR DESCRIPTION
By default, we are using imports from root and editor automatically translates them. In this case we want to disable it.

cc @nathanbaleeta 

![Screenshot 2021-04-22 at 8 34 58](https://user-images.githubusercontent.com/32869456/115667528-39efff00-a346-11eb-9f54-6a278167b585.png)
