### PR TITLE
Reorganize form template documentation page

### DIFF
--- a/packages/react-renderer-demo/src/components/navigation/schemas/custom-examples.schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/custom-examples.schema.js
@@ -18,6 +18,14 @@ const customExamplesSchema = [
   {
     component: 'custom-wizard',
     linkText: 'Custom wizard'
+  },
+  {
+    component: 'custom-form-buttons',
+    linkText: 'Custom form buttons'
+  },
+  {
+    component: 'form-level-errors',
+    linkText: 'Form level errors'
   }
 ];
 

--- a/packages/react-renderer-demo/src/pages/components/form-template.md
+++ b/packages/react-renderer-demo/src/pages/components/form-template.md
@@ -5,12 +5,23 @@ import CodeExample from '@docs/code-example';
 
 # FormTemplate
 
-FormTemplate component allows you to fully customize the form layout. FormTemplate receives only two props:
+[FormTemplate component](/components/renderer#formtemplate) allows you to fully customize the form layout. FormTemplate receives only two props from renderer: `formFields` and `schema`.
 
-|Prop|Description|
-|----|-----------|
-|formFields|Fields of the form.|
-|schema|Schema from renderer. You can use it to extract a form title, description or whatever you need.|
+## Props
+
+### formFields
+
+*node*
+
+Fields of the form.
+
+### schema
+
+*object*
+
+[Schema](/components/renderer#schema) from renderer. You can use it to extract a form title, description or whatever you need.
+
+## Minimal FormTemplate
 
 Minimal FormTemplate could look like this:
 
@@ -30,18 +41,6 @@ const FormTemplate = ({schema, formFields}) => {
 
 With using `useFormApi` hook you can get access to all form information and functions you need. For example, you can use it to display form errors wherever you want to.
 
-## Customize form buttons
-
-You can customize form buttons in your [FormTemplate](/components/renderer#formtemplate) component
-
-<CodeExample source="components/form-template/custom-buttons" mode="preview" />
-
-## Form level validation
-
-To display all form errors, you will need to add a component to your FormTemplate. Following example shows how to list all errors at the top of a form.
-
-<CodeExample source="components/form-template/form-level-validation" mode="preview" mapper="mui" />
-
 ## Default FormTemplates
 
 FormTemplates of the provided DDF mappers offers additional customization via using props.
@@ -55,20 +54,114 @@ import { FormTemplate } from '@data-driven-forms/pf4-component-mapper'
 />
 ```
 
-|Prop|Type|Description|Default|
-|----|:--:|----------:|------:|
-|buttonClassName|string|Class which will be given to the buttons wrapper.|{ }|
-|buttonOrder|array of strings|You can specify the order of the form buttons.|`[ 'submit', 'reset', 'cancel' ]`|
-|buttonGroupProps|object|Props passed to an element wrapping all buttons.|undefined|
-|buttonsProps|object|Props passed to buttons. Please follow this structure: `{ submit: submitButtonProps, cancel: cancelButtonProps, reset: resetButtonProps }`|undefined|
-|cancelLabel|node|Label for cancel button.|'Cancel'|
-|canReset|bool|Show/hide reset button.|false|
-|disableSubmit|array of strings|You can specify a form attributes (see [here](https://final-form.org/docs/final-form/types/FormState)) which will make the submit button disabled. |[ ]|
-|formWrapperProps|object|Props passed to a form wrapper.|undefined|
-|headerProps|object|Props passed to a header element.|undefined|
-|resetLabel|node|Label for reset button.|'Reset'|
-|showFormControls|bool|You can disable showing form buttons. Use it with wizard component which has its own buttons.|true|
-|submitLabel|node|Label for submit button.|'Submit'|
-|titleProps|object|Props passed to a title element.|undefined|
+### Props
+
+#### buttonClassName
+
+*string*
+
+Class which will be given to the buttons wrapper.
+
+---
+
+#### buttonOrder
+
+*string[]*
+
+You can specify the order of the form buttons.
+
+*Example*
+
+`[ 'submit', 'reset', 'cancel' ]`
+
+---
+#### buttonGroupProps
+
+*object*
+
+Props passed to an element wrapping all buttons.
+
+---
+#### buttonsProps
+
+*object*
+
+Props passed to buttons. Please follow this structure: `{ submit: submitButtonProps, cancel: cancelButtonProps, reset: resetButtonProps }`.
+
+---
+#### cancelLabel
+
+*node = 'Cancel'*
+
+Label for cancel button.
+
+---
+#### canReset
+
+*boolean*
+
+Shows/hides the reset button.
+
+---
+#### disableSubmit
+
+*string[]*
+
+You can specify a form attributes (see [here](https://final-form.org/docs/final-form/types/FormState)) which will make the submit button disabled when true.
+
+---
+#### formWrapperProps
+
+*object*
+
+Props passed to a form wrapper.
+
+---
+
+#### headerProps
+
+*object*
+
+Props passed to a header element.
+
+---
+
+#### resetLabel
+
+*node = 'Reset'*
+
+Label for reset button.
+
+---
+
+#### showFormControls
+
+*boolean = true*
+
+You can disable showing form buttons. Use it with wizard component which has its own buttons.
+
+---
+
+#### submitLabel
+
+*node = 'Submit'*
+
+Label for submit button.
+
+---
+
+#### titleProps
+
+*object*
+
+Props passed to a title element.
+
+---
+
+## Examples
+
+**[Custom form buttons](/examples/custom-form-buttons)**
+
+**[Form level errors](/examples/form-level-errors)**
 
 </DocPage>

--- a/packages/react-renderer-demo/src/pages/examples/custom-form-buttons.md
+++ b/packages/react-renderer-demo/src/pages/examples/custom-form-buttons.md
@@ -1,0 +1,14 @@
+import DocPage from '@docs/doc-page';
+import CodeExample from '@docs/code-example';
+
+<DocPage>
+
+# Custom form buttons
+
+You can customize form buttons in your [FormTemplate](/components/form-template) component.
+
+## Preview
+
+<CodeExample source="components/form-template/custom-buttons" mode="preview" />
+
+</DocPage>

--- a/packages/react-renderer-demo/src/pages/examples/form-level-errors.md
+++ b/packages/react-renderer-demo/src/pages/examples/form-level-errors.md
@@ -1,0 +1,14 @@
+import DocPage from '@docs/doc-page';
+import CodeExample from '@docs/code-example';
+
+<DocPage>
+
+# Form level errors
+
+To display all form errors, you will need to add a component to your [FormTemplate](/components/form-template). Following example shows how to list all errors at the top of a form.
+
+## Preview
+
+<CodeExample source="components/form-template/form-level-validation" mode="preview" />
+
+</DocPage>


### PR DESCRIPTION
 - seperate examples
 - better searchability