### PR TITLE
fix(carbon): Fix console error in search component for placeholder prop

### DIFF
--- a/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.js
@@ -109,7 +109,7 @@ const Toolbar = ({ sortTitle, onFilter, onSort, sortDirection, placeholder, Tool
 
   return (
     <div {...ToolbarProps} className={clsx(toolbar, ToolbarProps.className)}>
-      <Search onChange={(e) => onFilter(e.target.value)} labelText="" placeHolderText={placeholder} {...SearchProps} />
+      <Search onChange={(e) => onFilter(e.target.value)} labelText="" placeholder={placeholder} {...SearchProps} />
       <TooltipIcon onClick={onSort} tooltipText={sortTitle} {...SortProps} className={clsx(tooltipButton, SortProps.className)}>
         {sortDirection ? <CaretSortDown32 /> : <CaretSortUp32 />}
       </TooltipIcon>


### PR DESCRIPTION
Search component props has renamed in carbon components, so we are getting console error.

<img width="618" alt="Screen Shot 2021-05-14 at 11 16 15 AM" src="https://user-images.githubusercontent.com/37085529/118512048-783bcc80-b700-11eb-989d-baffda95a234.png">
