### PR TITLE
Add form alerts and add implementation for PF4

### DIFF
--- a/packages/common/src/form-template/form-template.js
+++ b/packages/common/src/form-template/form-template.js
@@ -121,6 +121,8 @@ const FormTemplate = ({
   descriptionProps,
   buttonGroupProps,
   buttonsProps,
+  alertProps,
+  BeforeError,
   ...rest
 }) => {
   const {
@@ -136,6 +138,14 @@ const FormTemplate = ({
           {(title || label) && <Title {...titleProps}>{title || label}</Title>}
           {description && <Description {...descriptionProps}>{description}</Description>}
         </Header>
+      )}
+      {BeforeError && (
+        <FormSpy subscription={{ submitError: true, error: true }}>
+          {() => {
+            const state = getState();
+            return <BeforeError formError={state.error || state.submitError} formSpyProps={state} alertProps={alertProps} />;
+          }}
+        </FormSpy>
       )}
       {formFields}
       {showFormControls && (
@@ -174,7 +184,9 @@ FormTemplate.propTypes = {
   titleProps: PropTypes.object,
   descriptionProps: PropTypes.object,
   buttonGroupProps: PropTypes.object,
-  buttonsProps: PropTypes.object
+  buttonsProps: PropTypes.object,
+  BeforeError: PropTypes.elementType,
+  alertProps: PropTypes.object
 };
 
 FormTemplate.defaultProps = {

--- a/packages/pf4-component-mapper/src/form-template/form-template.js
+++ b/packages/pf4-component-mapper/src/form-template/form-template.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import FormTemplate from '@data-driven-forms/common/form-template';
 
-import { Button as PF4Button, ActionGroup, Form, TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { Button as PF4Button, ActionGroup, Form, TextContent, Text, TextVariants, Alert } from '@patternfly/react-core';
 
 export const Button = ({ label, bsStyle, children, disabled, buttonType, ...props }) => (
   <PF4Button variant={buttonType === 'cancel' ? 'link' : bsStyle || 'secondary'} isDisabled={disabled} {...props}>
@@ -50,8 +50,39 @@ Description.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])
 };
 
+export const FormError = ({ formError, alertProps }) => {
+  if (typeof formError === 'object' && formError.title) {
+    const { title, description, ...props } = formError;
+
+    return (
+      <Alert variant="danger" isInline title={title} {...props} {...alertProps}>
+        {description}
+      </Alert>
+    );
+  }
+
+  if (typeof formError === 'string') {
+    return <Alert variant="danger" isInline title={formError} {...alertProps} />;
+  }
+
+  return null;
+};
+
+FormError.propTypes = {
+  formError: PropTypes.any,
+  alertProps: PropTypes.object
+};
+
 const PF4FormTemplate = (props) => (
-  <FormTemplate FormWrapper={Form} Button={Button} ButtonGroup={ButtonGroup} Title={Title} Description={Description} {...props} />
+  <FormTemplate
+    BeforeError={FormError}
+    FormWrapper={Form}
+    Button={Button}
+    ButtonGroup={ButtonGroup}
+    Title={Title}
+    Description={Description}
+    {...props}
+  />
 );
 
 export default PF4FormTemplate;

--- a/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
+++ b/packages/pf4-component-mapper/src/tests/wizard/step-buttons.test.js
@@ -328,7 +328,7 @@ describe('<WizardSTepButtons', () => {
     });
   });
 
-  it.only('conditional submit step', () => {
+  it('conditional submit step', () => {
     const submit = jest.fn();
     const schema = {
       fields: [

--- a/packages/react-form-renderer/src/form-error/form-error.d.ts
+++ b/packages/react-form-renderer/src/form-error/form-error.d.ts
@@ -1,0 +1,3 @@
+export const FormError: 'FINAL_FORM/form-error'
+
+export default FormError;

--- a/packages/react-form-renderer/src/form-error/form-error.js
+++ b/packages/react-form-renderer/src/form-error/form-error.js
@@ -1,0 +1,3 @@
+import { FORM_ERROR } from 'final-form';
+
+export default FORM_ERROR;

--- a/packages/react-form-renderer/src/form-error/index.d.ts
+++ b/packages/react-form-renderer/src/form-error/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './form-error';

--- a/packages/react-form-renderer/src/form-error/index.js
+++ b/packages/react-form-renderer/src/form-error/index.js
@@ -1,0 +1,1 @@
+export { default } from './form-error';

--- a/packages/react-form-renderer/src/index.js
+++ b/packages/react-form-renderer/src/index.js
@@ -8,6 +8,7 @@ export { default as FieldProvider } from './field-provider';
 export { default as FormRenderer } from './form-renderer';
 export { default as FormSpy } from './form-spy';
 export { default as Form } from './form';
+export { default as FormError } from './form-error';
 export { default as parseCondition } from './parse-condition';
 export { default as RendererContext } from './renderer-context';
 export { default as schemaErrors } from './schema-errors';

--- a/packages/react-renderer-demo/src/pages/components/form-template.md
+++ b/packages/react-renderer-demo/src/pages/components/form-template.md
@@ -56,6 +56,14 @@ import { FormTemplate } from '@data-driven-forms/pf4-component-mapper'
 
 ### Props
 
+#### alertProps
+
+*object*
+
+Props passed to `FormError` alert component.
+
+---
+
 #### buttonClassName
 
 *string*


### PR DESCRIPTION
Part of https://github.com/data-driven-forms/react-forms/issues/923

**Description**

Adds `BeforeError` component to common FormTemplate.

Adds `alertProps` to common FormTemplate.

Adds implementation of the Alert for PF4 mapper (based on [guidelines](https://www.patternfly.org/v4/components/form/design-guidelines#error-validation-on-submission))

Reexports `FORM_ERROR` as `FormError` in the renderer package.

**Schema** *(if applicable)*

```jsx
    validate={({something}) => {
        if(something?.length > 3) {
            return {[FormError]: 'too long'}
        }

        if(something) {
            return {[FormError]: 'too short'}
        }

        return {}
    }}
```

![Kapture 2021-05-31 at 14 41 34](https://user-images.githubusercontent.com/32869456/120195369-fd55d400-c21e-11eb-9b47-7c391a773bbd.gif)
