### PR TITLE
Add ability to validate fields in the form schema separately 

### DIFF
--- a/packages/react-form-renderer/src/form-renderer/render-form.js
+++ b/packages/react-form-renderer/src/form-renderer/render-form.js
@@ -5,6 +5,7 @@ import { Field } from 'react-final-form';
 import RendererContext from '../renderer-context';
 import Condition from '../condition';
 import getConditionTriggers from '../get-condition-triggers';
+import prepareComponentProps from '../prepare-component-props';
 
 const FormFieldHideWrapper = ({ hideField, children }) => (hideField ? <div hidden>{children}</div> : children);
 
@@ -87,57 +88,7 @@ FormConditionWrapper.propTypes = {
 const SingleField = ({ component, condition, hideField, ...rest }) => {
   const { actionMapper, componentMapper } = useContext(RendererContext);
 
-  let componentProps = {
-    component,
-    ...rest
-  };
-
-  const componentBinding = componentMapper[component];
-  let Component;
-  if (typeof componentBinding === 'object' && Object.prototype.hasOwnProperty.call(componentBinding, 'component')) {
-    const { component, ...mapperProps } = componentBinding;
-    Component = component;
-    componentProps = {
-      ...mapperProps,
-      ...componentProps,
-      // merge mapper and field actions
-      ...(mapperProps.actions && rest.actions ? { actions: { ...mapperProps.actions, ...rest.actions } } : {}),
-      // merge mapper and field resolveProps
-      ...(mapperProps.resolveProps && rest.resolveProps
-        ? {
-            resolveProps: (...args) => ({
-              ...mapperProps.resolveProps(...args),
-              ...rest.resolveProps(...args)
-            })
-          }
-        : {})
-    };
-  } else {
-    Component = componentBinding;
-  }
-
-  /**
-   * Map actions to props
-   */
-  let overrideProps = {};
-  let mergedResolveProps; // new object has to be created because of references
-  if (componentProps.actions) {
-    Object.keys(componentProps.actions).forEach((prop) => {
-      const [action, ...args] = componentProps.actions[prop];
-      overrideProps[prop] = actionMapper[action](...args);
-    });
-
-    // Merge componentProps resolve props and actions resolve props
-    if (componentProps.resolveProps && overrideProps.resolveProps) {
-      mergedResolveProps = (...args) => ({
-        ...componentProps.resolveProps(...args),
-        ...overrideProps.resolveProps(...args)
-      });
-    }
-
-    // do not pass actions object to components
-    delete componentProps.actions;
-  }
+  const { componentProps, Component, overrideProps, mergedResolveProps } = prepareComponentProps({ component, rest, componentMapper, actionMapper });
 
   return (
     <FormConditionWrapper condition={condition} field={componentProps}>

--- a/packages/react-form-renderer/src/get-validates/get-validates.d.ts
+++ b/packages/react-form-renderer/src/get-validates/get-validates.d.ts
@@ -1,0 +1,12 @@
+import { Schema, AnyObject, ComponentMapper } from "../common-types";
+import { ActionMapper } from "../form-renderer";
+
+export interface GetValidatesOptions {
+    values: AnyObject;
+    componentMapper: ComponentMapper;
+    actionMapper: ActionMapper;
+}
+
+declare function getValidates(schema: Schema, options: GetValidatesOptions, validations?: AnyObject): AnyObject;
+
+export default getValidates;

--- a/packages/react-form-renderer/src/get-validates/get-validates.js
+++ b/packages/react-form-renderer/src/get-validates/get-validates.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 
 import prepareComponentProps from '../prepare-component-props';
+import { dataTypeValidator } from '../validators/validator-functions';
 
 const getValidates = (schema, { componentMapper, actionMapper, values }, validations = {}) => {
   if (Array.isArray(schema)) {
@@ -30,6 +31,10 @@ const getValidates = (schema, { componentMapper, actionMapper, values }, validat
       }
 
       validate = validate || overrideProps.validate || componentProps.validate;
+
+      if (schema.dataType) {
+        validate = [...(validate || []), dataTypeValidator(schema.dataType)()];
+      }
 
       if (validate) {
         if (validations[schema.name]) {

--- a/packages/react-form-renderer/src/get-validates/get-validates.js
+++ b/packages/react-form-renderer/src/get-validates/get-validates.js
@@ -1,0 +1,51 @@
+import get from 'lodash/get';
+
+import prepareComponentProps from '../prepare-component-props';
+
+const getValidates = (schema, { componentMapper, actionMapper, values }, validations = {}) => {
+  if (Array.isArray(schema)) {
+    schema.map((field) => getValidates(field, { componentMapper, actionMapper, values }, validations));
+  } else {
+    if (schema.component) {
+      let validate;
+
+      const { componentProps, overrideProps, mergedResolveProps } = prepareComponentProps({
+        component: schema.component,
+        rest: schema,
+        componentMapper,
+        actionMapper
+      });
+
+      let resolveProps = mergedResolveProps || overrideProps.resolveProps || componentProps.resolveProps;
+
+      // fake form state with only values
+      if (resolveProps) {
+        const { validate: resolvePropsValidate } = resolveProps(
+          schema,
+          { input: { value: get(values, schema.name) }, meta: {} },
+          { getState: () => ({ values }) }
+        );
+
+        validate = resolvePropsValidate;
+      }
+
+      validate = validate || overrideProps.validate || componentProps.validate;
+
+      if (validate) {
+        if (validations[schema.name]) {
+          validations[schema.name].push(validate);
+        } else {
+          validations[schema.name] = [validate];
+        }
+      }
+    }
+
+    if (schema.fields) {
+      getValidates(schema.fields, { componentMapper, actionMapper, values }, validations);
+    }
+  }
+
+  return validations;
+};
+
+export default getValidates;

--- a/packages/react-form-renderer/src/get-validates/index.d.ts
+++ b/packages/react-form-renderer/src/get-validates/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './get-validates';

--- a/packages/react-form-renderer/src/get-validates/index.js
+++ b/packages/react-form-renderer/src/get-validates/index.js
@@ -1,0 +1,1 @@
+export { default } from './get-validates';

--- a/packages/react-form-renderer/src/get-visible-fields/get-visible-fields.d.ts
+++ b/packages/react-form-renderer/src/get-visible-fields/get-visible-fields.d.ts
@@ -1,0 +1,5 @@
+import { Schema, AnyObject } from "../common-types";
+
+declare function getVisibleFields(schema: Schema, values: AnyObject ): Schema;
+
+export default getVisibleFields;

--- a/packages/react-form-renderer/src/get-visible-fields/get-visible-fields.js
+++ b/packages/react-form-renderer/src/get-visible-fields/get-visible-fields.js
@@ -1,0 +1,27 @@
+import parseCondition from '../parse-condition';
+
+const getVisibleFields = (schema, values) => {
+  if (Array.isArray(schema)) {
+    return schema.map((field) => getVisibleFields(field, values)).filter(Boolean);
+  }
+
+  if (schema.condition) {
+    const result = parseCondition(schema.condition, values, schema);
+
+    if (result.visible) {
+      return {
+        ...schema,
+        ...(schema.fields && { fields: getVisibleFields(schema.fields, values).filter(Boolean) })
+      };
+    } else {
+      return null;
+    }
+  }
+
+  return {
+    ...schema,
+    ...(schema.fields && { fields: getVisibleFields(schema.fields, values).filter(Boolean) })
+  };
+};
+
+export default getVisibleFields;

--- a/packages/react-form-renderer/src/get-visible-fields/index.d.ts
+++ b/packages/react-form-renderer/src/get-visible-fields/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './get-visible-fields';

--- a/packages/react-form-renderer/src/get-visible-fields/index.js
+++ b/packages/react-form-renderer/src/get-visible-fields/index.js
@@ -1,0 +1,1 @@
+export { default } from './get-visible-fields';

--- a/packages/react-form-renderer/src/prepare-component-props/index.d.ts
+++ b/packages/react-form-renderer/src/prepare-component-props/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './prepare-component-props';

--- a/packages/react-form-renderer/src/prepare-component-props/index.js
+++ b/packages/react-form-renderer/src/prepare-component-props/index.js
@@ -1,0 +1,1 @@
+export { default } from './prepare-component-props';

--- a/packages/react-form-renderer/src/prepare-component-props/prepare-component-props.d.ts
+++ b/packages/react-form-renderer/src/prepare-component-props/prepare-component-props.d.ts
@@ -1,0 +1,13 @@
+import { AnyObject, ComponentMapper } from "../common-types";
+import { ActionMapper } from "../form-renderer";
+
+export interface PrepareComponentPropsOptions {
+    component: string;
+    rest: AnyObject;
+    componentMapper: ComponentMapper;
+    actionMapper: ActionMapper;
+}
+
+declare function prepareComponentProps(PrepareComponentPropsOptions: AnyObject): AnyObject;
+
+export default prepareComponentProps;

--- a/packages/react-form-renderer/src/prepare-component-props/prepare-component-props.js
+++ b/packages/react-form-renderer/src/prepare-component-props/prepare-component-props.js
@@ -1,0 +1,62 @@
+const prepareComponentProps = ({ component, rest, componentMapper, actionMapper }) => {
+  let componentProps = {
+    component,
+    ...rest
+  };
+
+  const componentBinding = componentMapper[component];
+  let Component;
+  if (typeof componentBinding === 'object' && Object.prototype.hasOwnProperty.call(componentBinding, 'component')) {
+    const { component, ...mapperProps } = componentBinding;
+    Component = component;
+    componentProps = {
+      ...mapperProps,
+      ...componentProps,
+      // merge mapper and field actions
+      ...(mapperProps.actions && rest.actions ? { actions: { ...mapperProps.actions, ...rest.actions } } : {}),
+      // merge mapper and field resolveProps
+      ...(mapperProps.resolveProps && rest.resolveProps
+        ? {
+            resolveProps: (...args) => ({
+              ...mapperProps.resolveProps(...args),
+              ...rest.resolveProps(...args)
+            })
+          }
+        : {})
+    };
+  } else {
+    Component = componentBinding;
+  }
+
+  /**
+   * Map actions to props
+   */
+  let overrideProps = {};
+  let mergedResolveProps; // new object has to be created because of references
+  if (componentProps.actions) {
+    Object.keys(componentProps.actions).forEach((prop) => {
+      const [action, ...args] = componentProps.actions[prop];
+      overrideProps[prop] = actionMapper[action](...args);
+    });
+
+    // Merge componentProps resolve props and actions resolve props
+    if (componentProps.resolveProps && overrideProps.resolveProps) {
+      mergedResolveProps = (...args) => ({
+        ...componentProps.resolveProps(...args),
+        ...overrideProps.resolveProps(...args)
+      });
+    }
+
+    // do not pass actions object to components
+    delete componentProps.actions;
+  }
+
+  return {
+    componentProps,
+    overrideProps,
+    mergedResolveProps,
+    Component
+  };
+};
+
+export default prepareComponentProps;

--- a/packages/react-form-renderer/src/tests/validation/get-validates.test.js
+++ b/packages/react-form-renderer/src/tests/validation/get-validates.test.js
@@ -51,7 +51,8 @@ describe('getValidates', () => {
           name: 'xx',
           component: 'componentDefault',
           resolveProps: (_props, _inputMeta, { getState }) => ({ validate: [{ type: getState().values['x'] }] })
-        }
+        },
+        { name: 'datatype-validation', component: 'default', dataType: 'number' }
       ]
     };
 
@@ -77,7 +78,8 @@ describe('getValidates', () => {
       'simple-resolve': [[{ type: 'from-resolve-props' }]],
       'component-actions-resolve': [[{ type: 'actions>resolveProps' }]],
       x: [[{ type: 'value-of-x' }]],
-      xx: [[{ type: 'value-of-x' }]]
+      xx: [[{ type: 'value-of-x' }]],
+      'datatype-validation': [[expect.any(Function)]]
     });
   });
 });

--- a/packages/react-form-renderer/src/tests/validation/get-validates.test.js
+++ b/packages/react-form-renderer/src/tests/validation/get-validates.test.js
@@ -1,0 +1,83 @@
+import getValidates from '../../get-validates';
+
+describe('getValidates', () => {
+  const noop = () => {};
+
+  it('returns all the validates from the schema', () => {
+    const values = { x: 'value-of-x' };
+
+    const componentMapper = {
+      default: noop,
+      complexResolve: {
+        component: noop,
+        resolveProps: () => ({
+          validate: [{ type: 'complexResolve' }]
+        })
+      },
+      componentDefault: {
+        component: noop,
+        validate: [{ type: 'componentDefault' }]
+      },
+      componentActions: {
+        component: noop,
+        actions: {
+          validate: ['componentAction']
+        }
+      },
+      componentActionsResolve: {
+        component: noop,
+        actions: {
+          resolveProps: ['returnValidate']
+        }
+      }
+    };
+
+    const schema = {
+      fields: [
+        { name: 'no-validate' },
+        { name: 'no-validate-1', component: 'default' },
+        { name: 'simple', component: 'default', validate: [{ type: 'simple' }] },
+        { name: 'double', component: 'default', validate: [{ type: 'double-1' }] },
+        { name: 'double', component: 'default', validate: [{ type: 'double-2' }] },
+        { fields: [{ name: 'simple-2', component: 'default', validate: [{ type: 'simple-2' }] }] },
+        { name: 'component-default', component: 'componentDefault' },
+        { name: 'component-default-override', component: 'componentDefault', validate: [{ type: 'override' }] },
+        { name: 'component-actions', component: 'componentActions' },
+        { name: 'component-actions-resolve', component: 'componentActionsResolve' },
+        { name: 'complex-resolve', component: 'complexResolve' },
+        { name: 'simple-resolve', component: 'default', resolveProps: () => ({ validate: [{ type: 'from-resolve-props' }] }) },
+        { name: 'x', component: 'componentDefault', resolveProps: (_props, { input: { value } }) => ({ validate: [{ type: value }] }) },
+        {
+          name: 'xx',
+          component: 'componentDefault',
+          resolveProps: (_props, _inputMeta, { getState }) => ({ validate: [{ type: getState().values['x'] }] })
+        }
+      ]
+    };
+
+    const actionMapper = {
+      componentAction: () => [{ type: 'from-action' }],
+      returnValidate: () => () => ({ validate: [{ type: 'actions>resolveProps' }] })
+    };
+
+    expect(
+      getValidates(schema, {
+        componentMapper,
+        actionMapper,
+        values
+      })
+    ).toEqual({
+      'complex-resolve': [[{ type: 'complexResolve' }]],
+      'component-actions': [[{ type: 'from-action' }]],
+      'component-default': [[{ type: 'componentDefault' }]],
+      'component-default-override': [[{ type: 'override' }]],
+      double: [[{ type: 'double-1' }], [{ type: 'double-2' }]],
+      simple: [[{ type: 'simple' }]],
+      'simple-2': [[{ type: 'simple-2' }]],
+      'simple-resolve': [[{ type: 'from-resolve-props' }]],
+      'component-actions-resolve': [[{ type: 'actions>resolveProps' }]],
+      x: [[{ type: 'value-of-x' }]],
+      xx: [[{ type: 'value-of-x' }]]
+    });
+  });
+});

--- a/packages/react-form-renderer/src/tests/validation/get-visible-fields.test.js
+++ b/packages/react-form-renderer/src/tests/validation/get-visible-fields.test.js
@@ -1,0 +1,65 @@
+import getVisibleFields from '../../get-visible-fields';
+
+describe('getVisibleFields', () => {
+  it('parses conditions', () => {
+    let schema = {
+      fields: [
+        {
+          name: 'visible-1',
+          component: 'text'
+        },
+        {
+          name: 'visible-2',
+          condition: { when: 'x', is: 1 }
+        },
+        {
+          name: 'invisible-1',
+          condition: { not: { when: 'x', is: 1 } }
+        },
+        {
+          name: 'visible-nested',
+          fields: [
+            {
+              name: 'visible-nested-1',
+              condition: { when: 'y.nested.x', is: 1 }
+            },
+            {
+              name: 'invisible-nested-1',
+              condition: { not: { when: 'y.nested.x', is: 1 } }
+            }
+          ]
+        },
+        {
+          name: 'visible-nested-2',
+          condition: { when: 'y.nested.x', is: 1 },
+          fields: [{ name: 'visible-nested-2-1' }]
+        },
+        {
+          name: 'invisible-nested',
+          condition: { when: 'x', is: 2 },
+          fields: [
+            {
+              name: 'invisible-nested-1',
+              condition: { when: 'x', is: 1 }
+            },
+            {
+              name: 'invisible-nested-2',
+              condition: { not: { when: 'x', is: 1 } }
+            }
+          ]
+        }
+      ]
+    };
+
+    const values = { x: 1, y: { nested: { x: 1 } } };
+
+    expect(getVisibleFields(schema, values)).toEqual({
+      fields: [
+        { name: 'visible-1', component: 'text' },
+        { name: 'visible-2', condition: { is: 1, when: 'x' } },
+        { name: 'visible-nested', fields: [{ condition: { is: 1, when: 'y.nested.x' }, name: 'visible-nested-1' }] },
+        { name: 'visible-nested-2', condition: { is: 1, when: 'y.nested.x' }, fields: [{ name: 'visible-nested-2-1' }] }
+      ]
+    });
+  });
+});

--- a/packages/react-form-renderer/src/tests/validation/validation.test.js
+++ b/packages/react-form-renderer/src/tests/validation/validation.test.js
@@ -1,0 +1,125 @@
+import validation from '../../validation';
+
+describe('validation', () => {
+  let schema;
+  let options;
+
+  beforeEach(() => {
+    schema = undefined;
+    options = undefined;
+  });
+
+  it('no schema', async () => {
+    expect.assertions(1);
+
+    try {
+      await validation(schema, options);
+    } catch (e) {
+      expect(e.toString()).toEqual('Error: validation requires a schema as the first argument.');
+    }
+  });
+
+  it('options is not object', async () => {
+    expect.assertions(1);
+
+    schema = {};
+
+    try {
+      await validation(schema, options);
+    } catch (e) {
+      expect(e.toString()).toEqual('Error: options argument has to be type of object, provided: undefined');
+    }
+  });
+
+  it('wrong schema', async () => {
+    expect.assertions(1);
+
+    schema = { fields: [{ name: 'field-1', component: 'checkbox', validate: [{ type: 'custom-type' }] }] };
+    options = {};
+
+    try {
+      await validation(schema, options);
+    } catch (e) {
+      expect(e.toString().trim()).toEqual(`DefaultSchemaError: 
+        Error occured in field definition with name: "field-1".
+        Field validator at index: 0 does not have correct "type" property!
+        Received "custom-type", expected one of: [required,min-length,max-length,exact-length,min-items,pattern,max-number-value,min-number-value,url].`);
+    }
+  });
+
+  it('returns correct an array errors', async () => {
+    const asyncValidate = jest.fn().mockImplementation((pass) => {
+      const method = pass ? 'resolve' : 'reject';
+
+      return Promise[method]().catch(() => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'some async validation error';
+      });
+    });
+
+    schema = {
+      fields: [
+        { name: 'no-validation', component: 'checkbox' },
+        { name: 'pass', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'invisible', component: 'dual-list', condition: { when: 'x', is: 'abc' }, validate: [{ type: 'required' }] },
+        { name: 'fail', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'subform', component: 'subform', fields: [{ name: 'fail-in-nest', component: 'select', validate: [{ type: 'required' }] }] },
+        { name: 'fail.nested', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'passes.nested', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'fail-function', component: 'select', validate: [() => 'error-message-from-function'] },
+        { name: 'fail-custom', component: 'select', validate: [{ type: 'custom' }] },
+        { name: 'async-fail', component: 'select', validate: [asyncValidate] },
+        { name: 'async-pass', component: 'select', validate: [asyncValidate] },
+        { name: 'datatype-fail', component: 'select', dataType: 'number' },
+        { name: 'fail-multiple', component: 'select', validate: [{ type: 'required' }, { type: 'pattern', pattern: /abc/ }] },
+        { name: 'double-fail', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'double-fail', component: 'select', validate: [{ type: 'pattern', pattern: /abc/ }] },
+        { name: 'double-fail-1', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'double-fail-1', component: 'select', validate: [{ type: 'pattern', pattern: /abc/ }] },
+        { name: 'double-fail-2', component: 'select', validate: [{ type: 'required' }] },
+        { name: 'double-fail-2', component: 'select', dataType: 'number' },
+        { name: 'combined-fail', component: 'select', dataType: 'number', validate: [{ type: 'required' }] },
+        { name: 'combined-fail-1', component: 'select', dataType: 'number', validate: [{ type: 'required' }] },
+        { name: 'combined-pass', component: 'select', dataType: 'number', validate: [{ type: 'required' }] }
+      ]
+    };
+    options = {
+      values: {
+        pass: 'some-value',
+        'async-pass': 'some-value',
+        passes: { nested: 'some-value' },
+        'datatype-fail': 'abc',
+        'fail-multiple': 'ccc',
+        'double-fail': 'ccc',
+        'double-fail-2': 'ccc',
+        'combined-fail-1': 'string',
+        'combined-pass': 123
+      },
+      validatorMapper: {
+        custom: () => () => 'custom error validator'
+      }
+    };
+
+    const results = await validation(schema, options);
+
+    expect(results).toEqual({
+      'async-fail': 'some async validation error',
+      'datatype-fail': 'Values must be number',
+      fail: 'Required',
+      'fail-custom': 'custom error validator',
+      'fail-function': 'error-message-from-function',
+      'fail-in-nest': 'Required',
+      'fail.nested': 'Required',
+      'fail-multiple': 'Value does not match pattern: /abc/.',
+      'double-fail': 'Value does not match pattern: /abc/.',
+      'double-fail-1': 'Required',
+      'double-fail-2': 'Values must be number',
+      'combined-fail': 'Required',
+      'combined-fail-1': 'Values must be number'
+    });
+    expect(asyncValidate.mock.calls).toEqual([
+      [undefined, options.values, {}],
+      ['some-value', options.values, {}]
+    ]);
+  });
+});

--- a/packages/react-form-renderer/src/tests/validation/validation.test.js
+++ b/packages/react-form-renderer/src/tests/validation/validation.test.js
@@ -122,4 +122,32 @@ describe('validation', () => {
       ['some-value', options.values, {}]
     ]);
   });
+
+  it('handle warnings', async () => {
+    schema = {
+      fields: [
+        { name: 'warning', component: 'checkbox', validate: [{ type: 'required', warning: true }], useWarnings: true },
+        { name: 'error', component: 'select', validate: [{ type: 'required' }] }
+      ]
+    };
+    options = {};
+
+    const results = await validation(schema, options);
+
+    expect(results).toEqual({ error: 'Required', warning: { error: 'Required', type: 'warning' } });
+  });
+
+  it('omit warnings', async () => {
+    schema = {
+      fields: [
+        { name: 'warning', component: 'checkbox', validate: [{ type: 'required', warning: true }], useWarnings: true },
+        { name: 'error', component: 'select', validate: [{ type: 'required' }] }
+      ]
+    };
+    options = { omitWarnings: true };
+
+    const results = await validation(schema, options);
+
+    expect(results).toEqual({ error: 'Required' });
+  });
 });

--- a/packages/react-form-renderer/src/validation/index.d.ts
+++ b/packages/react-form-renderer/src/validation/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './validation';

--- a/packages/react-form-renderer/src/validation/index.js
+++ b/packages/react-form-renderer/src/validation/index.js
@@ -1,0 +1,1 @@
+export { default } from './validation';

--- a/packages/react-form-renderer/src/validation/validation.d.ts
+++ b/packages/react-form-renderer/src/validation/validation.d.ts
@@ -1,0 +1,9 @@
+import { Schema, AnyObject } from "../common-types";
+
+export interface ValidationOptions {
+    values: AnyObject;
+}
+
+declare function validation(schema: Schema, options: ValidationOptions): AnyObject;
+
+export default validation;

--- a/packages/react-form-renderer/src/validation/validation.d.ts
+++ b/packages/react-form-renderer/src/validation/validation.d.ts
@@ -1,7 +1,14 @@
-import { Schema, AnyObject } from "../common-types";
+import { Schema, AnyObject, ComponentMapper, SchemaValidatorMapper } from "../common-types";
+import { ActionMapper } from "../form-renderer";
+import { ValidatorMapper } from "../validator-mapper";
 
 export interface ValidationOptions {
     values: AnyObject;
+    componentMapper?: ComponentMapper;
+    validatorMapper?: ValidatorMapper;
+    actionMapper?: ActionMapper;
+    schemaValidatorMapper?: SchemaValidatorMapper;
+    omitWarnings?: boolean;
 }
 
 declare function validation(schema: Schema, options: ValidationOptions): AnyObject;

--- a/packages/react-form-renderer/src/validation/validation.js
+++ b/packages/react-form-renderer/src/validation/validation.js
@@ -1,0 +1,75 @@
+import get from 'lodash/get';
+
+import composeValidators from '../compose-validators';
+import defaultSchemaValidator from '../default-schema-validator';
+import getValidates from '../get-validates';
+import getVisibleFields from '../get-visible-fields';
+import defaultValidatorMapper from '../validator-mapper';
+import { getValidate } from '../use-field-api/validator-helpers';
+
+const DEFAULT_COMPONENT = 'default-component';
+
+const noop = () => {};
+
+const changeToDefaultComponent = (schema) => {
+  if (Array.isArray(schema)) {
+    return schema.map(changeToDefaultComponent);
+  }
+
+  return {
+    ...schema,
+    ...(schema.component && { component: DEFAULT_COMPONENT }),
+    ...(schema.fields && { fields: changeToDefaultComponent(schema.fields) })
+  };
+};
+
+const validation = async (schema, options) => {
+  if (!schema) {
+    throw new Error('validation requires a schema as the first argument.');
+  }
+
+  if (typeof options !== 'object') {
+    throw new Error(`options argument has to be type of object, provided: ${typeof options}`);
+  }
+
+  const { values, componentMapper, validatorMapper, actionMapper, schemaValidatorMapper } = options;
+
+  const validatorMapperMerged = { ...defaultValidatorMapper, ...validatorMapper };
+
+  const validatorTypes = Object.keys(validatorMapperMerged);
+  const actionTypes = Object.keys(actionMapper || {});
+
+  let finalComponentMapper = componentMapper;
+  let finalSchema = schema;
+
+  if (!finalComponentMapper) {
+    finalComponentMapper = { [DEFAULT_COMPONENT]: noop };
+    finalSchema = changeToDefaultComponent(schema);
+  }
+
+  defaultSchemaValidator(finalSchema, finalComponentMapper, validatorTypes, actionTypes, schemaValidatorMapper);
+
+  finalSchema = getVisibleFields(finalSchema, values);
+
+  const validates = getValidates(finalSchema, { componentMapper: finalComponentMapper, actionMapper, values });
+
+  return await Object.keys(validates).reduce(async (accP, name) => {
+    const acc = await accP;
+    let error;
+    let index = 0;
+
+    while (!error && index + 1 <= validates[name].length) {
+      const validateFn = composeValidators(getValidate(validates[name][index], schema.dataType, validatorMapperMerged));
+      error = await validateFn(get(values, name), values, {});
+      index = index + 1;
+    }
+
+    if (error) {
+      return { ...acc, [name]: error };
+    }
+
+    return acc;
+  }, {});
+};
+
+export default validation;

--- a/packages/react-form-renderer/src/validation/validation.js
+++ b/packages/react-form-renderer/src/validation/validation.js
@@ -32,7 +32,7 @@ const validation = async (schema, options) => {
     throw new Error(`options argument has to be type of object, provided: ${typeof options}`);
   }
 
-  const { values, componentMapper, validatorMapper, actionMapper, schemaValidatorMapper } = options;
+  const { values, componentMapper, validatorMapper, actionMapper, schemaValidatorMapper, omitWarnings } = options;
 
   const validatorMapperMerged = { ...defaultValidatorMapper, ...validatorMapper };
 
@@ -59,8 +59,14 @@ const validation = async (schema, options) => {
     let index = 0;
 
     while (!error && index + 1 <= validates[name].length) {
-      const validateFn = composeValidators(getValidate(validates[name][index], schema.dataType, validatorMapperMerged));
-      error = await validateFn(get(values, name), values, {});
+      const validateFn = composeValidators(getValidate(validates[name][index], undefined, validatorMapperMerged));
+
+      const fieldError = await validateFn(get(values, name), values, {});
+
+      if (fieldError?.type !== 'warning' || (fieldError?.type === 'warning' && !omitWarnings)) {
+        error = fieldError;
+      }
+
       index = index + 1;
     }
 

--- a/packages/react-renderer-demo/src/components/navigation/schemas/schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/schema.js
@@ -5,6 +5,7 @@ import schemaHooks from './hooks.schema';
 import mappersSchema from './mappers.schema';
 import customExamplesSchema from './custom-examples.schema';
 import providedMappersSchema from './provider-mappers.schema';
+import utilitiesSchema from './utilities.schema';
 
 const schema = [
   {
@@ -44,6 +45,12 @@ const schema = [
     link: 'provided-mappers',
     noRoute: true,
     fields: providedMappersSchema
+  },
+  {
+    title: 'Utilities',
+    link: 'utilities',
+    noRoute: true,
+    fields: utilitiesSchema
   },
   {
     title: 'Examples',

--- a/packages/react-renderer-demo/src/components/navigation/schemas/utilities.schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/utilities.schema.js
@@ -1,0 +1,8 @@
+const customExamplesSchema = [
+  {
+    component: 'standalone-validation',
+    linkText: 'Standalone validation'
+  }
+];
+
+export default customExamplesSchema;

--- a/packages/react-renderer-demo/src/examples/components/utilities/standalone-validation.js
+++ b/packages/react-renderer-demo/src/examples/components/utilities/standalone-validation.js
@@ -1,0 +1,84 @@
+import validation from '@data-driven-forms/react-form-renderer/validation';
+import React, { useEffect, useState } from 'react';
+
+const asyncValidate = (pass) => {
+  const method = pass ? 'resolve' : 'reject';
+
+  return Promise[method]().catch(() => {
+    // eslint-disable-next-line no-throw-literal
+    throw 'some async validation error';
+  });
+};
+
+const schema = {
+  fields: [
+    { name: 'no-validation', component: 'checkbox' },
+    { name: 'pass', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'invisible', component: 'dual-list', condition: { when: 'x', is: 'abc' }, validate: [{ type: 'required' }] },
+    { name: 'fail', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'subform', component: 'subform', fields: [{ name: 'fail-in-nest', component: 'select', validate: [{ type: 'required' }] }] },
+    { name: 'fail.nested', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'passes.nested', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'fail-function', component: 'select', validate: [() => 'error-message-from-function'] },
+    { name: 'fail-custom', component: 'select', validate: [{ type: 'custom' }] },
+    { name: 'async-fail', component: 'select', validate: [asyncValidate] },
+    { name: 'async-pass', component: 'select', validate: [asyncValidate] },
+    { name: 'datatype-fail', component: 'select', dataType: 'number' },
+    { name: 'fail-multiple', component: 'select', validate: [{ type: 'required' }, { type: 'pattern', pattern: /abc/ }] },
+    { name: 'double-fail', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'double-fail', component: 'select', validate: [{ type: 'pattern', pattern: /abc/ }] },
+    { name: 'double-fail-1', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'double-fail-1', component: 'select', validate: [{ type: 'pattern', pattern: /abc/ }] },
+    { name: 'double-fail-2', component: 'select', validate: [{ type: 'required' }] },
+    { name: 'double-fail-2', component: 'select', dataType: 'number' },
+    { name: 'combined-fail', component: 'select', dataType: 'number', validate: [{ type: 'required' }] },
+    { name: 'combined-fail-1', component: 'select', dataType: 'number', validate: [{ type: 'required' }] },
+    { name: 'combined-pass', component: 'select', dataType: 'number', validate: [{ type: 'required' }] }
+  ]
+};
+
+const options = {
+  values: {
+    pass: 'some-value',
+    'async-pass': 'some-value',
+    passes: { nested: 'some-value' },
+    'datatype-fail': 'abc',
+    'fail-multiple': 'ccc',
+    'double-fail': 'ccc',
+    'double-fail-2': 'ccc',
+    'combined-fail-1': 'string',
+    'combined-pass': 123
+  },
+  validatorMapper: {
+    custom: () => () => 'custom error validator'
+  }
+};
+
+const StandaloneValidation = () => {
+  const [errors, setErrors] = useState();
+
+  useEffect(() => {
+    (async () => {
+      const formErrors = await validation(schema, options);
+
+      setErrors(formErrors);
+    })();
+  }, []);
+
+  if (!errors) {
+    return 'Validating...';
+  }
+
+  return (
+    <React.Fragment>
+      <h1>Schema</h1>
+      <pre>Check code example</pre>
+      <h1>Options</h1>
+      <pre>Check code example</pre>
+      <h1>Errors</h1>
+      <pre>{JSON.stringify(errors, null, 2)}</pre>
+    </React.Fragment>
+  );
+};
+
+export default StandaloneValidation;

--- a/packages/react-renderer-demo/src/pages/utilities/standalone-validation.md
+++ b/packages/react-renderer-demo/src/pages/utilities/standalone-validation.md
@@ -1,0 +1,99 @@
+import DocPage from '@docs/doc-page';
+import CodeExample from '@docs/code-example';
+
+<DocPage>
+
+# Standalone validation
+
+*@data-driven-forms/react-form-renderer/validation*
+
+*(schema: Schema, options: Options) => object: Errors*
+
+Data Driven Forms provides an async function that validates values based on a provided schema. This feature can be useful to implement validation on backend endpoints with using the same schema as in frontend applications.
+
+## Schema
+
+*object*
+
+The same [schema](/schema/introduction) as for the form renderer. Validation supports all features except array validators that are being used by field arrays. This functionallity will be implemented in the future.
+
+## Options
+
+*object*
+
+```ts
+{
+  values: AnyObject;
+  componentMapper?: ComponentMapper;
+  validatorMapper?: ValidatorMapper;
+  actionMapper?: ActionMapper;
+  schemaValidatorMapper?: SchemaValidatorMapper;
+  omitWarnings?: boolean;
+}
+```
+
+### Values
+
+*object*
+
+Form values as sent from the renderer.
+
+---
+
+### componentMapper
+
+*object*
+
+If not provided, all components are valid. [Read more](/components/renderer#componentmapper).
+
+---
+
+### validatorMapper
+
+[Read more](/mappers/validator-mapper).
+
+---
+
+### actionMapper
+
+[Read more](/mappers/action-mapper).
+
+---
+
+### schemaValidatorMapper
+
+[Read more](/mappers/schema-validator-mapper).
+
+---
+
+### omitWarnings
+
+*boolean*
+
+If this attribute set to true, warnings will be ignored and won't appear in the errors object.
+
+---
+
+## Errors
+
+*object*
+
+A flat structure of errors.
+
+```jsx
+{
+  field: 'This field is required',
+  'field-with-warning': { type: 'warning', error: 'This is warning' },
+  'nested.field': 'Some error message'
+}
+```
+
+## Schemas changed according to meta
+
+If your form is changing according to form state or field states, be aware that this function will miss all meta information.
+
+## Examples
+
+<CodeExample source="components/utilities/standalone-validation" mode="preview" />
+
+</DocPage>


### PR DESCRIPTION
TODO:
- [x] multiple asyncs
- [x] warnings
- [x] tests
- [x] docs

# Standalone validation

*@data-driven-forms/react-form-renderer/validation*

*(schema: Schema, options: Options) => object: Errors*

Data Driven Forms provides an async function that validates values based on a provided schema. This feature can be useful to implement validation on backend endpoints with using the same schema as in frontend applications.

## Schema

*object*

The same [schema](/schema/introduction) as for the form renderer. Validation supports all features except array validators that are being used by field arrays. This functionallity will be implemented in the future.

## Options

*object*

```ts
{
  values: AnyObject;
  componentMapper?: ComponentMapper;
  validatorMapper?: ValidatorMapper;
  actionMapper?: ActionMapper;
  schemaValidatorMapper?: SchemaValidatorMapper;
  omitWarnings?: boolean;
}
```

### Values

*object*

Form values as sent from the renderer.

---

### componentMapper

*object*

If not provided, all components are valid. [Read more](/components/renderer#componentmapper).

---

### validatorMapper

[Read more](/mappers/validator-mapper).

---

### actionMapper

[Read more](/mappers/action-mapper).

---

### schemaValidatorMapper

[Read more](/mappers/schema-validator-mapper).

---

### omitWarnings

*boolean*

If this attribute set to true, warnings will be ignored and won't appear in the errors object.

---

## Errors

*object*

A flat structure of errors.

```jsx
{
  field: 'This field is required',
  'field-with-warning': { type: 'warning', error: 'This is warning' },
  'nested.field': 'Some error message'
}
```

## Schemas changed according to meta

If your form is changing according to form state or field states, be aware that this function will miss all meta information.

## Examples

```jsx
import validation from '@data-driven-forms/react-form-renderer/validation';
import React, { useEffect, useState } from 'react';

const asyncValidate = (pass) => {
  const method = pass ? 'resolve' : 'reject';

  return Promise[method]().catch(() => {
    // eslint-disable-next-line no-throw-literal
    throw 'some async validation error';
  });
};

const schema = {
  fields: [
    { name: 'no-validation', component: 'checkbox' },
    { name: 'pass', component: 'select', validate: [{ type: 'required' }] },
    { name: 'invisible', component: 'dual-list', condition: { when: 'x', is: 'abc' }, validate: [{ type: 'required' }] },
    { name: 'fail', component: 'select', validate: [{ type: 'required' }] },
    { name: 'subform', component: 'subform', fields: [{ name: 'fail-in-nest', component: 'select', validate: [{ type: 'required' }] }] },
    { name: 'fail.nested', component: 'select', validate: [{ type: 'required' }] },
    { name: 'passes.nested', component: 'select', validate: [{ type: 'required' }] },
    { name: 'fail-function', component: 'select', validate: [() => 'error-message-from-function'] },
    { name: 'fail-custom', component: 'select', validate: [{ type: 'custom' }] },
    { name: 'async-fail', component: 'select', validate: [asyncValidate] },
    { name: 'async-pass', component: 'select', validate: [asyncValidate] },
    { name: 'datatype-fail', component: 'select', dataType: 'number' },
    { name: 'fail-multiple', component: 'select', validate: [{ type: 'required' }, { type: 'pattern', pattern: /abc/ }] },
    { name: 'double-fail', component: 'select', validate: [{ type: 'required' }] },
    { name: 'double-fail', component: 'select', validate: [{ type: 'pattern', pattern: /abc/ }] },
    { name: 'double-fail-1', component: 'select', validate: [{ type: 'required' }] },
    { name: 'double-fail-1', component: 'select', validate: [{ type: 'pattern', pattern: /abc/ }] },
    { name: 'double-fail-2', component: 'select', validate: [{ type: 'required' }] },
    { name: 'double-fail-2', component: 'select', dataType: 'number' },
    { name: 'combined-fail', component: 'select', dataType: 'number', validate: [{ type: 'required' }] },
    { name: 'combined-fail-1', component: 'select', dataType: 'number', validate: [{ type: 'required' }] },
    { name: 'combined-pass', component: 'select', dataType: 'number', validate: [{ type: 'required' }] }
  ]
};

const options = {
  values: {
    pass: 'some-value',
    'async-pass': 'some-value',
    passes: { nested: 'some-value' },
    'datatype-fail': 'abc',
    'fail-multiple': 'ccc',
    'double-fail': 'ccc',
    'double-fail-2': 'ccc',
    'combined-fail-1': 'string',
    'combined-pass': 123
  },
  validatorMapper: {
    custom: () => () => 'custom error validator'
  }
};

const StandaloneValidation = () => {
  const [errors, setErrors] = useState();

  useEffect(() => {
    (async () => {
      const formErrors = await validation(schema, options);

      setErrors(formErrors);
    })();
  }, []);

  if (!errors) {
    return 'Validating...';
  }

  return (
    <React.Fragment>
      <h1>Schema</h1>
      <pre>Check code example</pre>
      <h1>Options</h1>
      <pre>Check code example</pre>
      <h1>Errors</h1>
      <pre>{JSON.stringify(errors, null, 2)}</pre>
    </React.Fragment>
  );
};

export default StandaloneValidation;
```

# Schema

Check code example

# Options
Check code example

# Errors

```jsx
{
  "fail": "Required",
  "fail-in-nest": "Required",
  "fail.nested": "Required",
  "fail-function": "error-message-from-function",
  "fail-custom": "custom error validator",
  "async-fail": "some async validation error",
  "datatype-fail": "Values must be number",
  "fail-multiple": "Value does not match pattern: /abc/.",
  "double-fail": "Value does not match pattern: /abc/.",
  "double-fail-1": "Required",
  "double-fail-2": "Values must be number",
  "combined-fail": "Required",
  "combined-fail-1": "Values must be number"
}
```