### PR TITLE
fix(carbon): fix empty initial value in multi select

### DIFF
--- a/packages/carbon-component-mapper/src/select/select.js
+++ b/packages/carbon-component-mapper/src/select/select.js
@@ -16,8 +16,10 @@ export const multiOnChange = (input, simpleValue) => ({ selectedItem, selectedIt
   }
 };
 
-const getMultiValue = (value, options) =>
-  (Array.isArray(value) ? value : [value]).map((item) => (typeof item === 'object' ? item : options.find(({ value }) => value === item))) || [];
+export const getMultiValue = (value, options) =>
+  (Array.isArray(value) ? value : value ? [value] : []).map((item) =>
+    typeof item === 'object' ? item : options.find(({ value }) => value === item)
+  );
 
 const ClearedMultiSelectFilterable = ({
   invalidText,

--- a/packages/carbon-component-mapper/src/tests/select.test.js
+++ b/packages/carbon-component-mapper/src/tests/select.test.js
@@ -7,6 +7,7 @@ import FormTemplate from '../form-template';
 import componentMapper from '../component-mapper';
 import { Select, MultiSelect, ComboBox } from 'carbon-components-react';
 import { multiOnChange } from '../select';
+import { getMultiValue } from '../select/select';
 
 describe('<Select />', () => {
   it('renders select', () => {
@@ -191,6 +192,40 @@ describe('<Select />', () => {
       multiOnChange(input, false)({ selectedItems: [{ value: '123' }, { value: '345' }] });
 
       expect(input.onChange).toHaveBeenCalledWith([{ value: '123' }, { value: '345' }]);
+    });
+  });
+
+  describe('getMultiValue', () => {
+    let value;
+    let options;
+
+    beforeEach(() => {
+      value = undefined;
+      options = [];
+    });
+
+    it('undefined', () => {
+      expect(getMultiValue(value, options)).toEqual([]);
+    });
+
+    it('array', () => {
+      value = ['dogs'];
+      options = [
+        { label: 'cats', value: 'cats' },
+        { label: 'dogs', value: 'dogs' }
+      ];
+
+      expect(getMultiValue(value, options)).toEqual([{ label: 'dogs', value: 'dogs' }]);
+    });
+
+    it('single', () => {
+      value = 'dogs';
+      options = [
+        { label: 'cats', value: 'cats' },
+        { label: 'dogs', value: 'dogs' }
+      ];
+
+      expect(getMultiValue(value, options)).toEqual([{ label: 'dogs', value: 'dogs' }]);
     });
   });
 });


### PR DESCRIPTION
**Description**

Creates an array with `undefined`.

`(Array.isArray(value) ? value : [value])` => `value = undefined` => `[undefined]` => 😢 


**Schema**

```jsx
            schema={{
              fields: [
                {
                  component: 'select',
                  name: 'multi',
                  isMulti: true,
                  options: [
                    { label: 'cats', value: 'cats' },
                    { label: 'dogs', value: 'dogs' }
                  ]
                }
              ]
            }}
```