### PR TITLE
fix(carbon): pass isMulti to ddf select

### DIFF
--- a/packages/carbon-component-mapper/src/select/select.js
+++ b/packages/carbon-component-mapper/src/select/select.js
@@ -269,6 +269,7 @@ const Select = (props) => {
       simpleValue={false}
       {...rest}
       {...input}
+      isMulti={isMulti}
       loadOptions={loadOptions}
       invalidText={invalidText}
       loadOptionsChangeCounter={loadOptionsChangeCounter}


### PR DESCRIPTION
Fixes #https://github.com/data-driven-forms/react-forms/issues/1080

**Description**

Carbon select omits `isMulti`

**Schema** *(if applicable)*

```jsx
{
                  component: "select",
                  name: "days",
                  label: "Days",
                  isMulti: true,
                  initialValue: [1, 2, 4],
                  options: [
                    {
                      value: 0,
                      label: "Sunday"
                    },
                    {
                      value: 1,
                      label: "Monday"
                    },
                    {
                      value: 2,
                      label: "Tuesday"
                    },
                    {
                      value: 3,
                      label: "Wedensday"
                    },
                    {
                      value: 4,
                      label: "Thursday"
                    },
                    {
                      value: 5,
                      label: "Friday"
                    },
                    {
                      value: 6,
                      label: "Saturday"
                    }
                  ]
                }
```