### PR TITLE
Select all

### DIFF
--- a/packages/carbon-component-mapper/src/select/select.js
+++ b/packages/carbon-component-mapper/src/select/select.js
@@ -8,13 +8,7 @@ import fnToString from '@data-driven-forms/common/utils/fn-to-string';
 import { Select as CarbonSelect, MultiSelect, SelectItem, ComboBox } from 'carbon-components-react';
 import prepareProps from '../prepare-props';
 
-export const multiOnChange = (input, simpleValue) => ({ selectedItem, selectedItems }) => {
-  if (simpleValue) {
-    return input.onChange(selectedItems?.map(({ value }) => value) || selectedItem.value);
-  } else {
-    return input.onChange(selectedItems || selectedItem);
-  }
-};
+const onChangeWrapper = (onChange) => ({ selectedItem, selectedItems }) => onChange(selectedItems || selectedItem);
 
 export const getMultiValue = (value, options) =>
   (Array.isArray(value) ? value : value ? [value] : []).map((item) =>
@@ -43,7 +37,7 @@ const ClearedMultiSelectFilterable = ({
     disabled={isDisabled}
     {...rest}
     placeholder={carbonLabel || placeholder}
-    onChange={originalOnChange}
+    onChange={onChangeWrapper(onChange)}
     titleText={rest.labelText}
     id={rest.name}
     invalid={Boolean(invalidText)}
@@ -94,7 +88,7 @@ const ClearedMultiSelect = ({
     disabled={isDisabled}
     {...rest}
     label={carbonLabel || placeholder}
-    onChange={originalOnChange}
+    onChange={onChangeWrapper(onChange)}
     titleText={rest.labelText}
     id={rest.name}
     invalid={Boolean(invalidText)}
@@ -206,6 +200,7 @@ const ClearedSelectSearchable = ({
   originalOnChange,
   placeholder,
   labelText,
+  onChange,
   ...rest
 }) => (
   <ComboBox
@@ -218,7 +213,7 @@ const ClearedSelectSearchable = ({
     items={options}
     placeholder={placeholder}
     titleText={labelText}
-    onChange={originalOnChange}
+    onChange={onChangeWrapper(onChange)}
   />
 );
 
@@ -273,7 +268,6 @@ const Select = (props) => {
       loadOptions={loadOptions}
       invalidText={invalidText}
       loadOptionsChangeCounter={loadOptionsChangeCounter}
-      originalOnChange={multiOnChange(input, rest.simpleValue)}
       helperText={text}
     />
   );

--- a/packages/carbon-component-mapper/src/tests/select.test.js
+++ b/packages/carbon-component-mapper/src/tests/select.test.js
@@ -6,7 +6,6 @@ import { FormRenderer, componentTypes } from '@data-driven-forms/react-form-rend
 import FormTemplate from '../form-template';
 import componentMapper from '../component-mapper';
 import { Select, MultiSelect, ComboBox } from 'carbon-components-react';
-import { multiOnChange } from '../select';
 import { getMultiValue } from '../select/select';
 
 describe('<Select />', () => {
@@ -170,28 +169,6 @@ describe('<Select />', () => {
       );
 
       expect(wrapper.find(MultiSelect.Filterable)).toHaveLength(1);
-    });
-  });
-
-  describe('multichange', () => {
-    const input = {
-      onChange: jest.fn()
-    };
-
-    beforeEach(() => {
-      input.onChange.mockReset();
-    });
-
-    it('simpleValue', () => {
-      multiOnChange(input, true)({ selectedItems: [{ value: '123' }, { value: '345' }] });
-
-      expect(input.onChange).toHaveBeenCalledWith(['123', '345']);
-    });
-
-    it('not simple value', () => {
-      multiOnChange(input, false)({ selectedItems: [{ value: '123' }, { value: '345' }] });
-
-      expect(input.onChange).toHaveBeenCalledWith([{ value: '123' }, { value: '345' }]);
     });
   });
 

--- a/packages/common/src/select/select.js
+++ b/packages/common/src/select/select.js
@@ -11,8 +11,17 @@ import useIsMounted from '../hooks/use-is-mounted';
 const getSelectValue = (stateValue, simpleValue, isMulti, allOptions) =>
   simpleValue ? allOptions.filter(({ value }) => (isMulti ? stateValue.includes(value) : isEqual(value, stateValue))) : stateValue;
 
-const handleSelectChange = (option, simpleValue, isMulti, onChange) => {
+const handleSelectChange = (option, simpleValue, isMulti, onChange, allOptions) => {
   const sanitizedOption = !option && isMulti ? [] : option;
+
+  if (isMulti && option.find(({ selectAll }) => selectAll)) {
+    return onChange(allOptions.filter(({ selectAll }) => !selectAll).map(({ value }) => value));
+  }
+
+  if (isMulti && option.find(({ selectNone }) => selectNone)) {
+    return onChange([]);
+  }
+
   return simpleValue
     ? onChange(isMulti ? sanitizedOption.map((item) => item.value) : sanitizedOption ? sanitizedOption.value : undefined)
     : onChange(sanitizedOption);
@@ -147,7 +156,7 @@ const Select = ({
       classNamePrefix={classNamePrefix}
       isMulti={isMulti}
       value={getSelectValue(selectValue, simpleValue, isMulti, state.options)}
-      onChange={(option) => handleSelectChange(option, simpleValue, isMulti, onChange)}
+      onChange={(option) => handleSelectChange(option, simpleValue, isMulti, onChange, state.options)}
       onInputChange={onInputChange}
       isFetching={Object.values(state.promises).some((value) => value)}
       noOptionsMessage={renderNoOptionsMessage()}

--- a/packages/common/src/select/select.js
+++ b/packages/common/src/select/select.js
@@ -8,17 +8,45 @@ import fnToString from '../utils/fn-to-string';
 import reducer from './reducer';
 import useIsMounted from '../hooks/use-is-mounted';
 
-const getSelectValue = (stateValue, simpleValue, isMulti, allOptions) =>
-  simpleValue ? allOptions.filter(({ value }) => (isMulti ? stateValue.includes(value) : isEqual(value, stateValue))) : stateValue;
+const getSelectValue = (stateValue, simpleValue, isMulti, allOptions) => {
+  let enhancedValue = stateValue;
 
-const handleSelectChange = (option, simpleValue, isMulti, onChange, allOptions) => {
-  const sanitizedOption = !option && isMulti ? [] : option;
+  let hasSelectAll = isMulti && allOptions.find(({ selectAll }) => selectAll);
+  let hasSelectNone = isMulti && allOptions.find(({ selectNone }) => selectNone);
 
-  if (isMulti && option.find(({ selectAll }) => selectAll)) {
-    return onChange(allOptions.filter(({ selectAll }) => !selectAll).map(({ value }) => value));
+  if (hasSelectAll || hasSelectNone) {
+    enhancedValue = enhancedValue || [];
+    const optionsLength = allOptions.filter(({ selectAll, selectNone }) => !selectAll && !selectNone).length;
+
+    const selectedAll = optionsLength === enhancedValue.length;
+    const selectedNone = enhancedValue.length === 0;
+
+    enhancedValue = [
+      ...enhancedValue,
+      ...(hasSelectAll && selectedAll ? [simpleValue ? hasSelectAll.value : hasSelectAll] : []),
+      ...(hasSelectNone && selectedNone ? [simpleValue ? hasSelectNone.value : hasSelectNone] : [])
+    ];
   }
 
-  if (isMulti && option.find(({ selectNone }) => selectNone)) {
+  return simpleValue ? allOptions.filter(({ value }) => (isMulti ? enhancedValue.includes(value) : isEqual(value, enhancedValue))) : enhancedValue;
+};
+
+const handleSelectChange = (option, simpleValue, isMulti, onChange, allOptions, removeSelectAll, removeSelectNone) => {
+  let enhanceOption = option;
+
+  if (removeSelectNone) {
+    enhanceOption = enhanceOption.filter(({ selectNone }) => !selectNone);
+  } else if (removeSelectAll) {
+    enhanceOption = enhanceOption.filter(({ selectAll }) => !selectAll);
+  }
+
+  const sanitizedOption = !enhanceOption && isMulti ? [] : enhanceOption;
+
+  if (isMulti && enhanceOption.find(({ selectAll }) => selectAll)) {
+    return onChange(allOptions.filter(({ selectAll, selectNone }) => !selectAll && !selectNone).map(({ value }) => value));
+  }
+
+  if (isMulti && enhanceOption.find(({ selectNone }) => selectNone)) {
     return onChange([]);
   }
 
@@ -145,6 +173,10 @@ const Select = ({
 
   const selectValue = pluckSingleValue ? (isMulti ? value : Array.isArray(value) && value[0] ? value[0] : value) : value;
 
+  const filteredLength = state.options.filter(({ selectAll, selectNone }) => !selectAll && !selectNone).length;
+  const shouldRemoveSelectAll = isMulti && state.options.find(({ selectAll }) => selectAll) && selectValue.length === filteredLength;
+  const shouldRemoveSelectNone = isMulti && state.options.find(({ selectNone }) => selectNone) && selectValue.length === 0;
+
   return (
     <SelectComponent
       className={clsx(classNamePrefix, {
@@ -156,7 +188,7 @@ const Select = ({
       classNamePrefix={classNamePrefix}
       isMulti={isMulti}
       value={getSelectValue(selectValue, simpleValue, isMulti, state.options)}
-      onChange={(option) => handleSelectChange(option, simpleValue, isMulti, onChange, state.options)}
+      onChange={(option) => handleSelectChange(option, simpleValue, isMulti, onChange, state.options, shouldRemoveSelectAll, shouldRemoveSelectNone)}
       onInputChange={onInputChange}
       isFetching={Object.values(state.promises).some((value) => value)}
       noOptionsMessage={renderNoOptionsMessage()}

--- a/packages/common/src/tests/select/select.test.js
+++ b/packages/common/src/tests/select/select.test.js
@@ -344,11 +344,31 @@ describe('Select test', () => {
       wrapper.update();
 
       expect(state.value).toEqual([
+        { label: 'Select all', selectAll: true },
         { label: 'Dogs', value: 'd' },
         { label: 'Cats', value: 'c' },
         { label: 'Hamsters', value: 'h' }
       ]);
       expect(inputValue).toEqual(['d', 'c', 'h']);
+
+      // remove hamsters
+      await act(async () => {
+        wrapper
+          .find('#onChange')
+          .props()
+          .onClick([
+            { label: 'Select all', selectAll: true },
+            { label: 'Dogs', value: 'd' },
+            { label: 'Cats', value: 'c' }
+          ]);
+      });
+      wrapper.update();
+
+      expect(state.value).toEqual([
+        { label: 'Dogs', value: 'd' },
+        { label: 'Cats', value: 'c' }
+      ]);
+      expect(inputValue).toEqual(['d', 'c']);
     });
 
     it('selects none', async () => {
@@ -380,8 +400,86 @@ describe('Select test', () => {
       });
       wrapper.update();
 
-      expect(state.value).toEqual([]);
+      expect(state.value).toEqual([{ label: 'Select none', selectNone: true }]);
       expect(inputValue).toEqual('');
+
+      // adds one
+      await act(async () => {
+        wrapper
+          .find('#onChange')
+          .props()
+          .onClick([
+            { label: 'Select none', selectNone: true },
+            { label: 'Dogs', value: 'd' }
+          ]);
+      });
+      wrapper.update();
+
+      expect(state.value).toEqual([{ label: 'Dogs', value: 'd' }]);
+      expect(inputValue).toEqual(['d']);
+    });
+
+    it('with select all and select none at that same time', async () => {
+      field = {
+        ...field,
+        isMulti: true,
+        options: [
+          { label: 'Select all', selectAll: true, value: 'select-all' },
+          { label: 'Select none', selectNone: true, value: 'select-none' },
+          ...field.options
+        ]
+      };
+
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            {...rendererProps}
+            schema={{
+              fields: [
+                {
+                  ...field,
+                  component: componentTypes.SELECT,
+                  name: 'select'
+                }
+              ]
+            }}
+          />
+        );
+      });
+      wrapper.update();
+
+      await act(async () => {
+        wrapper
+          .find('#onChange')
+          .props()
+          .onClick([{ label: 'Select all', selectAll: true, value: 'select-all' }]);
+      });
+      wrapper.update();
+
+      expect(state.value).toEqual([
+        { label: 'Select all', selectAll: true, value: 'select-all' },
+        { label: 'Dogs', value: 'd' },
+        { label: 'Cats', value: 'c' },
+        { label: 'Hamsters', value: 'h' }
+      ]);
+      expect(inputValue).toEqual(['d', 'c', 'h']);
+
+      await act(async () => {
+        wrapper
+          .find('#onChange')
+          .props()
+          .onClick([
+            { label: 'Select all', selectAll: true },
+            { label: 'Dogs', value: 'd' },
+            { label: 'Cats', value: 'c' },
+            { label: 'Hamsters', value: 'h' },
+            { label: 'Select none', selectNone: true, value: 'select-none' }
+          ]);
+      });
+      wrapper.update();
+
+      expect(state.value).toEqual([{ label: 'Select none', selectNone: true, value: 'select-none' }]);
+      expect(inputValue).toEqual([]);
     });
   });
 

--- a/packages/common/src/tests/select/select.test.js
+++ b/packages/common/src/tests/select/select.test.js
@@ -313,6 +313,76 @@ describe('Select test', () => {
       ]);
       expect(inputValue).toEqual(['d', 'c']);
     });
+
+    it('selects all values', async () => {
+      field = { ...field, isMulti: true, options: [{ label: 'Select all', selectAll: true }, ...field.options] };
+
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            {...rendererProps}
+            schema={{
+              fields: [
+                {
+                  ...field,
+                  component: componentTypes.SELECT,
+                  name: 'select'
+                }
+              ]
+            }}
+          />
+        );
+      });
+      wrapper.update();
+
+      await act(async () => {
+        wrapper
+          .find('#onChange')
+          .props()
+          .onClick([{ label: 'Select all', selectAll: true }]);
+      });
+      wrapper.update();
+
+      expect(state.value).toEqual([
+        { label: 'Dogs', value: 'd' },
+        { label: 'Cats', value: 'c' },
+        { label: 'Hamsters', value: 'h' }
+      ]);
+      expect(inputValue).toEqual(['d', 'c', 'h']);
+    });
+
+    it('selects none', async () => {
+      field = { ...field, isMulti: true, options: [{ label: 'Select none', selectNone: true }, ...field.options], initialValue: ['d', 'c', 'h'] };
+
+      await act(async () => {
+        wrapper = mount(
+          <FormRenderer
+            {...rendererProps}
+            schema={{
+              fields: [
+                {
+                  ...field,
+                  component: componentTypes.SELECT,
+                  name: 'select'
+                }
+              ]
+            }}
+          />
+        );
+      });
+      wrapper.update();
+
+      await act(async () => {
+        wrapper
+          .find('#onChange')
+          .props()
+          .onClick([{ label: 'Select none', selectNone: true }]);
+      });
+      wrapper.update();
+
+      expect(state.value).toEqual([]);
+      expect(inputValue).toEqual('');
+    });
   });
 
   describe('loadOptions', () => {

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/select.md
@@ -1,0 +1,3 @@
+import SelectCommon from '../select.md';
+
+<SelectCommon/>

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/mui/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/mui/select.md
@@ -1,0 +1,3 @@
+import SelectCommon from '../select.md';
+
+<SelectCommon/>

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/select.md
@@ -30,3 +30,7 @@ const asyncLoadOptions = (searchValue) => new Promise(resolve => setTimeout(() =
   return resolve(options);
 }, 2000));
 ```
+
+import SelectCommon from '../select.md';
+
+<SelectCommon/>

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/select.md
@@ -1,0 +1,64 @@
+import Chip from '@material-ui/core/Chip';
+
+## Common select features
+
+This mapper component is using the common select component to provide additional features.
+
+## loadOptions
+
+*(currentSearchValue: string) => Promise< Options >*
+
+Using `loadOptions` function you can dynamically load options when the component is mounted or when the value in search bar is changed. You can also trigger a reload via changing `loadOptionsChangeCounter` *number* attribute.
+
+---
+
+## simpleValue
+
+*boolean*
+
+When is `true`, the select will store only values of the selected options. Otherwise, it stores the whole objects.
+
+---
+
+## selectAll
+
+*boolean* | <Chip label="Experimental" color="secondary" />
+
+When provided to an option object, this option will select all available options.
+
+```jsx
+options: [{
+        label: 'Select all',
+        value: 'select-all',
+        selectAll: true,
+    },
+    ...
+    ]
+```
+
+---
+
+## selectNone
+
+*boolean* | <Chip label="Experimental" color="secondary" />
+
+
+When provided to an option object, this option will clear the selection.
+
+```jsx
+options: [{
+        label: 'Select none',
+        value: 'select-none',
+        selectNone: true,
+    },
+    ...
+    ]
+```
+
+---
+
+## noValueUpdates
+
+*boolean*
+
+By default, the common select unselects values that are not available as an option. If you want to disable this behavior, you can do it via setting this option to `true`.

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/suir/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/suir/select.md
@@ -3,3 +3,7 @@
 |----|----|-------|----------------|
 |FormFieldGridProps|object|`{}`|`div`|
 |HelperTextProps|object|`{}`|`p`|
+
+import SelectCommon from '../select.md';
+
+<SelectCommon/>


### PR DESCRIPTION
**Description**

- Carbon select is now using the shared onChange function
- `selectAll: true` option selects all (except itself)
- `selectNone: true` option deselect all

**After**

![Kapture 2021-06-17 at 08 40 01](https://user-images.githubusercontent.com/32869456/122344977-a141be00-cf47-11eb-9642-d7b0ef8ce682.gif)

**Schema**

```jsx
schema={{
    fields: [
      {
        component: 'select',
        name: 'select',
        isMulti: true,
        simpleValue: true,
        isSearchable: true,
        options: [
          { label: 'Select all', selectAll: true, value: 'select-all' },
          { label: 'Select none', selectNone: true, value: 'select-none' },
          { label: 'Dogs', value: 'd' },
          { label: 'Cats', value: 'c' },
          { label: 'Hamsters', value: 'h' },
        ]
      }
    ]
  }} 
```

**Checklist:** 

- [x] Documentation update
- [x] tests