### PR TITLE
feat(carbon): allow to group options in single select

### DIFF
--- a/packages/carbon-component-mapper/src/tests/select.test.js
+++ b/packages/carbon-component-mapper/src/tests/select.test.js
@@ -5,7 +5,7 @@ import { FormRenderer, componentTypes } from '@data-driven-forms/react-form-rend
 
 import FormTemplate from '../form-template';
 import componentMapper from '../component-mapper';
-import { Select, MultiSelect, ComboBox } from 'carbon-components-react';
+import { Select, MultiSelect, ComboBox, SelectItem, SelectItemGroup } from 'carbon-components-react';
 import { getMultiValue } from '../select/select';
 
 describe('<Select />', () => {
@@ -29,6 +29,42 @@ describe('<Select />', () => {
     );
 
     expect(wrapper.find(Select)).toHaveLength(1);
+  });
+
+  it('renders select with categories', () => {
+    const schema = {
+      fields: [
+        {
+          component: componentTypes.SELECT,
+          name: 'select',
+          label: 'select',
+          options: [
+            {
+              label: 'Category 1',
+              options: [
+                { label: 'value 1', value: '111' },
+                { label: 'value 2', value: '222' }
+              ]
+            },
+            {
+              label: 'Category 2',
+              options: [
+                { label: 'value 3', value: '333' },
+                { label: 'value 4', value: '444' }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const wrapper = mount(
+      <FormRenderer onSubmit={jest.fn()} FormTemplate={(props) => <FormTemplate {...props} />} schema={schema} componentMapper={componentMapper} />
+    );
+
+    expect(wrapper.find(Select)).toHaveLength(1);
+    expect(wrapper.find(SelectItemGroup)).toHaveLength(2);
+    expect(wrapper.find(SelectItem)).toHaveLength(4);
   });
 
   ['isSearchable', 'isClearable'].forEach((setting) => {

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/select.md
@@ -1,3 +1,31 @@
 import SelectCommon from '../select.md';
 
+## Single select with categories
+
+For single (not clearable/not searchable) select, you can use categories to group your options by adding an `options` array.
+
+```jsx
+{
+    component: 'select',
+    name: 'select-with-categories',
+    label: 'With categories',
+    options: [
+        {
+            label: 'Category 1',
+            options: [
+                { label: 'value 1', value: '111' },
+                { label: 'value 2', value: '222' }
+            ]
+        },
+        {
+            label: 'Category 2',
+            options: [
+                { label: 'value 3', value: '333' },
+                { label: 'value 4', value: '444' }
+            ]
+        }
+    ]
+}
+```
+
 <SelectCommon/>


### PR DESCRIPTION
Fixes see Discord

**Description**

Adds an ability to group options in simple single select.

**Schema** *(if applicable)*

```jsx
{
    component: 'select',
    name: 'select-with-categories',
    label: 'With categories',
    options: [
        {
            label: 'Category 1',
            options: [
                { label: 'value 1', value: '111' },
                { label: 'value 2', value: '222' }
            ]
        },
        {
            label: 'Category 2',
            options: [
                { label: 'value 3', value: '333' },
                { label: 'value 4', value: '444' }
            ]
        }
    ]
}
```

**After**

![Screenshot 2021-06-23 at 9 36 37](https://user-images.githubusercontent.com/32869456/123056574-53c1c700-d407-11eb-95ae-1c07e4c275c0.png)
![Screenshot 2021-06-23 at 9 36 32](https://user-images.githubusercontent.com/32869456/123056583-56242100-d407-11eb-941b-4317933a6d92.png)

