### PR TITLE
fix(pf4): pass rest props to option in mutliple checkbox

### DIFF
--- a/packages/pf4-component-mapper/src/checkbox/multiple-choice-list.js
+++ b/packages/pf4-component-mapper/src/checkbox/multiple-choice-list.js
@@ -6,11 +6,14 @@ import { Checkbox } from '@patternfly/react-core';
 import MultipleChoiceListCommon, { wrapperProps } from '@data-driven-forms/common/multiple-choice-list';
 import FormGroup from '../form-group/form-group';
 
-const FinalCheckbox = (props) => <Checkbox isChecked={props.checked} {...props} onChange={(_value, e) => props.onChange(e)} />;
+const FinalCheckbox = ({ option, ...props }) => (
+  <Checkbox isChecked={props.checked} {...props} onChange={(_value, e) => props.onChange(e)} {...option} />
+);
 
 FinalCheckbox.propTypes = {
   checked: PropTypes.bool,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  option: PropTypes.object
 };
 
 const Wrapper = ({ meta, children, ...rest }) => (


### PR DESCRIPTION
**Description**

Pass the rest of option to a single checkbox in mutliple checkbox. Allows to disable just one option:

![Screenshot 2021-07-14 at 10 08 22](https://user-images.githubusercontent.com/32869456/125586921-d978b523-1bf7-4403-a310-ce2f6f37dbe3.png)


**Schema**

```jsx
schema={{
    fields: [ {
        "component": "checkbox",
        "label": "Checkbox",
        "name": "checkbox",
        initialValue: ['1'],
        "options": [
          {
            "label": "Dog",
            "value": "1",
            isDisabled: true
          },
          {
            "label": "Cats",
            "value": "2"
          },
          {
            "label": "Hamsters",
            "value": "3"
          }
        ]
      }]
}}
```