### PR TITLE
Fix wrong set of Date

### DIFF
--- a/packages/react-form-renderer/src/tests/form-renderer/enhanced-on-change.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/enhanced-on-change.test.js
@@ -29,7 +29,7 @@ describe('#enhancedOnChange', () => {
     expect(enhancedOnChange({ onChange: (value) => value, clearedValue }, value)).toEqual('Me');
   });
 
-  it('should return booelan events correctly with initialValue set', () => {
+  it('should return boolean events correctly with initialValue set', () => {
     const initial = false;
     const valueFalse = {
       target: {
@@ -63,6 +63,11 @@ describe('#enhancedOnChange', () => {
       const value = undefined;
       expect(enhancedOnChange({ onChange: (value) => value, initial, clearedValue }, value)).toEqual(clearedValue);
       expect(enhancedOnChange({ onChange: (value) => value, initial, clearedValue }, '')).toEqual(clearedValue);
+    });
+
+    it('should not set delete value after sending date', () => {
+      const value = new Date(2021, 7, 20);
+      expect(enhancedOnChange({ onChange: (value) => value, initial, clearedValue }, value)).toEqual(value);
     });
 
     it('should not set delete value after sending number 0', () => {

--- a/packages/react-form-renderer/src/use-field-api/enhanced-on-change.js
+++ b/packages/react-form-renderer/src/use-field-api/enhanced-on-change.js
@@ -42,6 +42,10 @@ const checkEmpty = (value) => {
     return false;
   }
 
+  if (value instanceof Date) {
+    return false;
+  }
+
   if (!isEmpty(value)) {
     return false;
   }


### PR DESCRIPTION
Fix #1109 

I found out that there is unexpected behavior for passed date objects. It will be handled as empty object in `checkEmpty` function. These is because of `isEmpty` function from **lodash** - it will return **true** for Date. https://github.com/lodash/lodash/issues/5131
