### PR TITLE
Add description to pf select

### DIFF
--- a/packages/pf4-component-mapper/src/select/select/option.css
+++ b/packages/pf4-component-mapper/src/select/select/option.css
@@ -1,4 +1,0 @@
-.ddorg__pf4-component-mapper__select-option-description {
-    font-size: 12px;
-    color: rgb(106, 110, 115);
-}

--- a/packages/pf4-component-mapper/src/select/select/option.css
+++ b/packages/pf4-component-mapper/src/select/select/option.css
@@ -1,0 +1,4 @@
+.ddorg__pf4-component-mapper__select-option-description {
+    font-size: 12px;
+    color: rgb(106, 110, 115);
+}

--- a/packages/pf4-component-mapper/src/select/select/option.js
+++ b/packages/pf4-component-mapper/src/select/select/option.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import './option.css';
-
 import { CheckIcon } from '@patternfly/react-icons';
 
 const Option = ({ item, isActive, isSelected, ...props }) => (
@@ -21,7 +19,7 @@ const Option = ({ item, isActive, isSelected, ...props }) => (
           <CheckIcon />
         </span>
       )}
-      {item.description && <div className="ddorg__pf4-component-mapper__select-option-description">{item.description}</div>}
+      {item.description && <div className="pf-c-select__menu-item-description">{item.description}</div>}
     </button>
   </li>
 );

--- a/packages/pf4-component-mapper/src/select/select/option.js
+++ b/packages/pf4-component-mapper/src/select/select/option.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import './option.css';
+
 import { CheckIcon } from '@patternfly/react-icons';
 
 const Option = ({ item, isActive, isSelected, ...props }) => (
@@ -19,6 +21,7 @@ const Option = ({ item, isActive, isSelected, ...props }) => (
           <CheckIcon />
         </span>
       )}
+      {item.description && <div className="ddorg__pf4-component-mapper__select-option-description">{item.description}</div>}
     </button>
   </li>
 );
@@ -27,7 +30,8 @@ Option.propTypes = {
   item: PropTypes.shape({
     label: PropTypes.node,
     isDisabled: PropTypes.bool,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    description: PropTypes.node
   }).isRequired,
   isActive: PropTypes.bool,
   isSelected: PropTypes.bool,

--- a/packages/pf4-component-mapper/src/tests/select/select.test.js
+++ b/packages/pf4-component-mapper/src/tests/select/select.test.js
@@ -8,6 +8,7 @@ import { act } from 'react-dom/test-utils';
 import ValueContainer from '../../select/select/value-container';
 import FormTemplate from '../../form-template';
 import componentMapper from '../../component-mapper';
+import Option from '../../select/select/option';
 
 describe('<Select />', () => {
   let initialProps;
@@ -73,6 +74,42 @@ describe('<Select />', () => {
         .find('h1')
         .text()
     ).toEqual('Translated');
+  });
+
+  it('should render description', async () => {
+    const wrapper = mount(
+      <FormRenderer
+        onSubmit={jest.fn}
+        FormTemplate={FormTemplate}
+        componentMapper={componentMapper}
+        schema={{
+          fields: [
+            {
+              component: componentTypes.SELECT,
+              name: 'select',
+              options: [
+                {
+                  label: <h1>Translated</h1>,
+                  value: 'translated',
+                  description: 'some description'
+                }
+              ]
+            }
+          ]
+        }}
+      />
+    );
+
+    expect(wrapper.find(ValueContainer).find('h1')).toHaveLength(0);
+
+    wrapper.find('.pf-c-select__toggle').simulate('click');
+
+    expect(
+      wrapper
+        .find(Option)
+        .find('.ddorg__pf4-component-mapper__select-option-description')
+        .text()
+    ).toEqual('some description');
   });
 
   it('should return single simple value', async () => {

--- a/packages/pf4-component-mapper/src/tests/select/select.test.js
+++ b/packages/pf4-component-mapper/src/tests/select/select.test.js
@@ -107,7 +107,7 @@ describe('<Select />', () => {
     expect(
       wrapper
         .find(Option)
-        .find('.ddorg__pf4-component-mapper__select-option-description')
+        .find('.pf-c-select__menu-item-description')
         .text()
     ).toEqual('some description');
   });

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/pf4/select.md
@@ -31,6 +31,16 @@ const asyncLoadOptions = (searchValue) => new Promise(resolve => setTimeout(() =
 }, 2000));
 ```
 
+## Description
+
+PF4 select can render a description for each option. Just add a `description` attribute to its object (can be `React.node`):
+
+```jsx
+options: [
+  { value: 'value', label: 'Some label', description: 'Some description' }
+]
+```
+
 import SelectCommon from '../select.md';
 
 <SelectCommon/>


### PR DESCRIPTION
Fixes #1113 

**Description**

Adds description to PF4 select options.

**Schema** *(if applicable)*

```jsx
options: [
  { value: 'value', label: 'Some label', description: 'Some description' }
]
```

<img width="843" alt="Screenshot 2021-08-30 at 19 08 45" src="https://user-images.githubusercontent.com/32869456/131378541-56e7a978-3c71-4ceb-9581-99ed539ffd7c.png">
