### PR TITLE
Switch to node14 and update documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: ~/react-forms
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     steps:
       - checkout
       - run:
@@ -33,7 +33,7 @@ jobs:
   release:
     working_directory: ~/react-forms
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     steps:
       - attach_workspace:
           at: ~/react-forms
@@ -45,7 +45,7 @@ jobs:
   predeploy:
     working_directory: ~/react-forms
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     steps:
       - attach_workspace:
           at: ~/react-forms
@@ -60,7 +60,7 @@ jobs:
   deploy:
     working_directory: ~/react-forms
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     steps:
       - attach_workspace:
           at: ~/react-forms

--- a/README.md
+++ b/README.md
@@ -34,29 +34,40 @@ Data Driven Forms is a React library used for rendering and managing forms with 
 
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
-  - [Material-UI Mapper](#material-ui-mapper)
-  - [PatternFly 4 Mapper](#patternfly-4-mapper)
-  - [BlueprintJS Mapper](#blueprintjs-mapper)
-  - [Semantic UI Mapper](#semantic-ui-mapper)
-  - [Ant Design Mapper](#ant-design-mapper)
-  - [Carbon Mapper](#carbon-mapper)
+  - [Provided mappers](#provided-mappers)
+    - [Material-UI Mapper](#material-ui-mapper)
+    - [PatternFly 4 Mapper](#patternfly-4-mapper)
+    - [BlueprintJS Mapper](#blueprintjs-mapper)
+    - [Semantic UI Mapper](#semantic-ui-mapper)
+    - [Ant Design Mapper](#ant-design-mapper)
+    - [Carbon Mapper](#carbon-mapper)
+  - [Basic provided components](#basic-provided-components)
 - [Usage](#usage)
   - [Custom mapper](#custom-mapper)
-- [Basic provided components](#basic-provided-components)
 - [Documentation](#documentation)
-- [Useful links](#useful-links)
 - [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
+  - [Requirements](#requirements)
+  - [Common commands](#common-commands)
+    - [Install](#install)
+    - [Build](#build)
+    - [Run a playground](#run-a-playground)
+    - [Run documentation](#run-documentation)
+    - [How to clean node_modules](#how-to-clean-node_modules)
+    - [Cleaning built files](#cleaning-built-files)
+    - [Tests](#tests)
+  - [Checklist before you send a PR](#checklist-before-you-send-a-pr)
+    - [Build passes](#build-passes)
+    - [Linter passes](#linter-passes)
+    - [Write tests](#write-tests)
+    - [Documentation update](#documentation-update)
+    - [Correct commit message](#correct-commit-message)
+- [Useful links](#useful-links)
 - [Contribution](#contribution)
 - [LICENSE](#license)
 
-### Installation
+# Installation
 
-Add React Form Renderer
-
-#### [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
+## [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
 
 ```console
 $ npm install @data-driven-forms/react-form-renderer -S
@@ -66,10 +77,10 @@ $ npm install @data-driven-forms/react-form-renderer -S
 $ yarn add @data-driven-forms/react-form-renderer
 ```
 
-Optionally you can install one of provided mappers:
+## Provided mappers
 
 
-#### [Material-UI Mapper](https://data-driven-forms.org/mappers/mui-component-mapper)
+### [Material-UI Mapper](https://data-driven-forms.org/mappers/mui-component-mapper)
 
 ```console
 $ npm install @data-driven-forms/mui-component-mapper -S
@@ -79,7 +90,7 @@ $ npm install @data-driven-forms/mui-component-mapper -S
 $ yarn add @data-driven-forms/mui-component-mapper
 ```
 
-#### [PatternFly 4 Mapper](https://data-driven-forms.org/mappers/pf4-component-mapper)
+### [PatternFly 4 Mapper](https://data-driven-forms.org/mappers/pf4-component-mapper)
 
 ```console
 $ npm install @data-driven-forms/pf4-component-mapper -S
@@ -89,7 +100,7 @@ $ npm install @data-driven-forms/pf4-component-mapper -S
 $ yarn add @data-driven-forms/pf4-component-mapper
 ```
 
-#### [BlueprintJS Mapper](https://data-driven-forms.org/mappers/blueprint-component-mapper)
+### [BlueprintJS Mapper](https://data-driven-forms.org/mappers/blueprint-component-mapper)
 
 ```console
 $ npm install @data-driven-forms/blueprint-component-mapper -S
@@ -99,7 +110,7 @@ $ npm install @data-driven-forms/blueprint-component-mapper -S
 $ yarn add @data-driven-forms/blueprint-component-mapper
 ```
 
-#### [Semantic UI Mapper](https://data-driven-forms.org/mappers/suir-component-mapper)
+### [Semantic UI Mapper](https://data-driven-forms.org/mappers/suir-component-mapper)
 
 ```console
 $ npm install @data-driven-forms/suir-component-mapper -S
@@ -109,7 +120,7 @@ $ npm install @data-driven-forms/suir-component-mapper -S
 $ yarn add @data-driven-forms/suir-component-mapper
 ```
 
-#### [Ant Design Mapper](https://data-driven-forms.org/mappers/ant-component-mapper)
+### [Ant Design Mapper](https://data-driven-forms.org/mappers/ant-component-mapper)
 
 ```console
 $ npm install @data-driven-forms/ant-component-mapper -S
@@ -119,7 +130,7 @@ $ npm install @data-driven-forms/ant-component-mapper -S
 $ yarn add @data-driven-forms/ant-component-mapper
 ```
 
-#### [Carbon Mapper](https://data-driven-forms.org/mappers/carbon-component-mapper)
+### [Carbon Mapper](https://data-driven-forms.org/mappers/carbon-component-mapper)
 
 ```console
 $ npm install @data-driven-forms/carbon-component-mapper -S
@@ -131,7 +142,29 @@ $ yarn add @data-driven-forms/carbon-component-mapper
 
 Component libraries in mappers are external dependencies. Make sure to install them and their styles in your bundles.
 
-### Usage
+## Basic provided components
+
+Provided mappers of Data Driven Forms support contains following set of components:
+
+- [Text input](https://data-driven-forms.org/mappers/text-field?mapper=mui)
+- [Text area](https://data-driven-forms.org/mappers/textarea?mapper=mui)
+- [Checkbox](https://data-driven-forms.org/mappers/checkbox?mapper=mui) ([Multiple checkboxes](https://data-driven-forms.org/mappers/checkbox-multiple?mapper=mui))
+- [Select (dropdown)](https://data-driven-forms.org/mappers/select?mapper=mui)
+- [Dual list select](https://data-driven-forms.org/mappers/dual-list-select?mapper=mui)
+- [Field array](https://data-driven-forms.org/mappers/field-array?mapper=mui)
+- [Switch](https://data-driven-forms.org/mappers/switch?mapper=mui)
+- [Radio buttons](https://data-driven-forms.org/mappers/radio?mapper=mui)
+- [Date picker](https://data-driven-forms.org/mappers/date-picker?mapper=mui)
+- [Time picker](https://data-driven-forms.org/mappers/time-picker?mapper=mui)
+- [Tabs](https://data-driven-forms.org/mappers/tabs?mapper=mui)
+- [Slider](https://data-driven-forms.org/mappers/slider?mapper=mui)
+- [Sub-form](https://data-driven-forms.org/mappers/sub-form?mapper=mui)
+- [Plain text](https://data-driven-forms.org/mappers/plain-text?mapper=mui)
+- [Wizard](https://data-driven-forms.org/mappers/wizard?mapper=mui)
+
+Any other components can be added to mapper and renderer with the form renderer. Existing components can be also overriden.
+
+# Usage
 
 In order to Data Driven Forms in your component you need the renderer and a component mapper, which provides component mapper and form template.
 
@@ -158,7 +191,7 @@ const Form = () => (
 )
 ```
 
-#### Custom mapper
+## Custom mapper
 
 You can also use custom mapper.
 
@@ -196,33 +229,139 @@ For more information, please check [this page](https://data-driven-forms.org/ren
 
 Mappers can be also generated by using `yarn generate-template` [command](https://data-driven-forms.org/renderer/development-setup#generatingamappertemplate).
 
-### Basic provided components
-
-Data Driven Forms supports all kinds of component, basic set is consisted of:
-
-- [Text input](https://data-driven-forms.org/mappers/text-field?mapper=mui)
-- [Text area](https://data-driven-forms.org/mappers/textarea?mapper=mui)
-- [Checkbox](https://data-driven-forms.org/mappers/checkbox?mapper=mui) ([Multiple checkboxes](https://data-driven-forms.org/mappers/checkbox-multiple?mapper=mui))
-- [Select (dropdown)](https://data-driven-forms.org/mappers/select?mapper=mui)
-- [Dual list select](https://data-driven-forms.org/mappers/dual-list-select?mapper=mui)
-- [Field array](https://data-driven-forms.org/mappers/field-array?mapper=mui)
-- [Switch](https://data-driven-forms.org/mappers/switch?mapper=mui)
-- [Radio buttons](https://data-driven-forms.org/mappers/radio?mapper=mui)
-- [Date picker](https://data-driven-forms.org/mappers/date-picker?mapper=mui)
-- [Time picker](https://data-driven-forms.org/mappers/time-picker?mapper=mui)
-- [Tabs](https://data-driven-forms.org/mappers/tabs?mapper=mui)
-- [Slider](https://data-driven-forms.org/mappers/slider?mapper=mui)
-- [Sub-form](https://data-driven-forms.org/mappers/sub-form?mapper=mui)
-- [Plain text](https://data-driven-forms.org/mappers/plain-text?mapper=mui)
-- [Wizard](https://data-driven-forms.org/mappers/wizard?mapper=mui)
-
-Any other components can be added to mapper and renderer with the form renderer. Existing components can be also overriden.
-
-### Documentation
+# Documentation
 
 Please use our [documentation site](https://data-driven-forms.org/). In case of any problem, you can access documentation files directly in GitHub.
 
-### Useful links
+# Development setup
+
+Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
+
+---
+
+## Requirements
+
+- **○ NodeJS 14**
+
+- **○ Unix like OS (MacOS, Linux)**
+
+We do not support developing on Windows at this moment. However, we would welcome any PR to change this.
+
+---
+
+## Common commands
+
+### Install
+
+```bash
+yarn install
+```
+
+### Build
+
+```bash
+yarn build
+```
+
+All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package. A package has to be built first before it is used in other package.
+
+### Run a playground
+
+Each package has a small playground `package/demo`, where you can test your changes.
+
+```bash
+cd packages/pf3-component-mapper
+yarn start
+```
+
+### Run documentation
+
+The documentation is a server-side rendered React application based on [NextJS framework](https://nextjs.org/).
+
+```bash
+cd packages/react-renderer-demo
+yarn dev
+```
+
+### How to clean node_modules
+
+```bash
+yarn lerna clean
+rm -rf node_modules
+```
+### Cleaning built files
+
+To clean built files use following command: (This script is also ran automatically before each build.)
+
+```bash
+yarn clean-build
+```
+
+### Tests
+
+Tests can be ran from core folder or from specific package.
+
+```bash
+yarn test
+
+yarn test --watchAll packages/pf4-component-mapper
+
+# or
+
+cd packages/pf4-component-mapper
+yarn test
+```
+
+---
+
+## Checklist before you send a PR
+
+Please follow following checklist if you are going to open a PR. It will help you make the PR finished.
+
+### Build passes
+
+Run `yarn build` in root folder to build all packages. You can run this command only in package you changed. All packages are linked by default, you have to build them first.
+
+### Linter passes
+
+Run `yarn lint` in root folder to check if the code is correctly formatted. You can use `yarn lint --fix` to automatically correct issues.
+### Write tests
+
+All new code should be properly tested. Run `yarn test` in root folder to test all files. Check codecoverage report to see uncovered lines of code. We are using [Jest](https://jestjs.io/) and [Enzyme](https://enzymejs.github.io/enzyme/).
+
+### Documentation update
+
+If you introduce a new feature, you should document this change in our documentation. The documentation is located in `react-renderer-demo` package and it is a web application based on [NextJS](https://nextjs.org/). We do not write tests for the documentation.
+
+`yarn dev` starts a local version of the documentation.
+
+`yarn build` prepares files for deployment.
+
+`yarn serve` emulates the web application running in local emulator.
+
+### Correct commit message
+
+A correct commit message is important, because we are using [semantic release](https://github.com/semantic-release/commit-analyzer) to automatically releease new versions. These messages are also used in our release notes, so other users can see what is being changed.
+
+**My change introduces a new feature**
+
+Prefix your commit message with `feat` and specify the package that is being changed. An example: `feat(pf4): a new dual list integration`. If you change multiple packages, you can use `feat(common): ...` or `feat(all): ...`.
+
+**My change fixes a bug or technical debt**
+
+Prefix your commit message with `fix`. Otherwise, the same rules apply. An example: `fix(pf4): fixed missed proptype in select`.
+
+**My change does not change any released package**
+
+If your change does not change any of the released packages, you can simple just descibe the change, an example: `Fix button on documenation example page`. This also applies for any change in the documentation repo.
+
+**My change introduces a breaking change**
+
+We are trying to avoid breaking changes. Please, open an issue and discuss the issue with us, we will try to come up with alternative options.
+
+---
+
+# Useful links
 
 - [Data Driven Forms documentation](https://data-driven-forms.org/)
 - [PatternFly 4 Design documentation](https://www.patternfly.org/v4/)
@@ -240,81 +379,11 @@ Please use our [documentation site](https://data-driven-forms.org/). In case of 
   - [BlueprintJS Mapper](https://www.npmjs.com/package/@data-driven-forms/blueprint-component-mapper)
   - [Carbon Mapper](https://www.npmjs.com/package/@data-driven-forms/carbon-component-mapper)
 
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/pf4-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/pf4-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(pf4): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `4`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
-
-### Contribution
+# Contribution
 
 We welcome any community contribution. Don't be afraid to report bug or to create issues and pull-requests! :trophy:
 
-### LICENSE
+# LICENSE
 
 Apache License 2.0
 

--- a/packages/ant-component-mapper/README.md
+++ b/packages/ant-component-mapper/README.md
@@ -4,24 +4,25 @@
 
 [![Data Driven Form logo](images/logo.png)](https://data-driven-forms.org/)
 
-Material-UI component mapper for [Data Driven Forms](https://github.com/data-driven-forms/react-forms).
+Ant Design component mapper for [Data Driven Forms](https://github.com/data-driven-forms/react-forms).
 
 :book: For more information please visit the [documentation](https://data-driven-forms.org/). :book:
 
 **Table of Contents**
 
+- [More information](#more-information)
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
   - [ANT mapper](#ant-mapper)
 - [Usage](#usage)
 - [Basic provided components](#basic-provided-components)
 - [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
 - [Contribution](#contribution)
 - [LICENSE](#license)
+
+### More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
 ### Installation
 
@@ -104,78 +105,6 @@ Data Driven Forms supports all kinds of component, basic set is consisted of:
 - NPM
   - [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
   - [MaterialUI Mapper](https://www.npmjs.com/package/@data-driven-forms/ant-component-mapper)
-
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/ant-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-rm yarn.lock
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/ant-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(ant): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/blueprint-component-mapper/README.md
+++ b/packages/blueprint-component-mapper/README.md
@@ -10,18 +10,19 @@ Blueprint component mapper for [Data Driven Forms](https://github.com/data-drive
 
 **Table of Contents**
 
+- [More information](#more-information)
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
   - [Blueprint Mapper](#blueprint-mapper)
 - [Usage](#usage)
 - [Basic provided components](#basic-provided-components)
 - [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
 - [Contribution](#contribution)
 - [LICENSE](#license)
+
+### More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
 ### Installation
 
@@ -102,77 +103,6 @@ Data Driven Forms supports all kinds of component, basic set is consisted of:
 - NPM
   - [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
   - [Blueprint 4 Mapper](https://www.npmjs.com/package/@data-driven-forms/blueprint-component-mapper)
-
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/blueprint-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/blueprint-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(blueprint): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/carbon-component-mapper/README.md
+++ b/packages/carbon-component-mapper/README.md
@@ -10,18 +10,19 @@ Carbon component mapper for [Data Driven Forms](https://github.com/data-driven-f
 
 **Table of Contents**
 
+- [More information](#more-information)
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
   - [Carbon Mapper](#carbon-mapper)
 - [Usage](#usage)
 - [Basic provided components](#basic-provided-components)
 - [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
 - [Contribution](#contribution)
 - [LICENSE](#license)
+
+### More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
 ### Installation
 
@@ -102,76 +103,6 @@ Data Driven Forms supports all kinds of component, basic set is consisted of:
 - [Carbon Mapper NPM](https://www.npmjs.com/package/@data-driven-forms/carbon-component-mapper)
 - [Carbon Design System documentation](https://www.carbondesignsystem.com/)
 - [Carbon React Compononents storybook](https://react.carbondesignsystem.com/)
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/carbon-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/carbon-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(carbon): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `carbon`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/carbon-component-mapper/src/tests/time-picker.test.js
+++ b/packages/carbon-component-mapper/src/tests/time-picker.test.js
@@ -98,7 +98,7 @@ describe('TimePicker', () => {
     });
     wrapper.update();
 
-    expect(wrapper.find('input').props().value).toEqual('00:00');
+    expect(wrapper.find('input').props().value).toEqual('24:00');
     expect(onSubmit.mock.calls[0][0]['time-picker'].getHours()).toEqual(0);
     expect(onSubmit.mock.calls[0][0]['time-picker'].getMinutes()).toEqual(0);
   });

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -5,7 +5,7 @@
 This package exists to share code used by more than one data-driven-forms package, such as:
 
 - shared interfaces - propTypes
-- common mappers code 
+- common mappers code
   - wizard
   - select
   - multiplechoice list
@@ -15,12 +15,13 @@ This package exists to share code used by more than one data-driven-forms packag
 
 ...and some boring config files etc.
 
-￼
-This packages is not released but can be referenced in mapper packages. Demo packages does not have access to common package!
-
 ## Usage
 ￼
 ```
 import demoSchema from '../../../shared/demoschema';
 
 ```
+
+# More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).

--- a/packages/mui-component-mapper/README.md
+++ b/packages/mui-component-mapper/README.md
@@ -13,18 +13,19 @@ Material-UI component mapper for [Data Driven Forms](https://github.com/data-dri
 
 **Table of Contents**
 
+- [More information](#more-information)
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
   - [MUI mapper](#mui-mapper)
 - [Usage](#usage)
 - [Basic provided components](#basic-provided-components)
 - [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
 - [Contribution](#contribution)
 - [LICENSE](#license)
+
+### More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
 ### Installation
 
@@ -105,77 +106,6 @@ Data Driven Forms supports all kinds of component, basic set is consisted of:
 - NPM
   - [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
   - [MaterialUI Mapper](https://www.npmjs.com/package/@data-driven-forms/mui-component-mapper)
-
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/mui-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/mui-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(mui): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/parsers/README.md
+++ b/packages/parsers/README.md
@@ -12,17 +12,10 @@ Parsers for [Data Driven Forms](https://github.com/data-driven-forms/react-forms
 
 - [Installation](#installation)
 - [Usage](#usage)
-- [Parsers](#parsers)
-  - [ManageIQ parser](#manageiq-parser)
-  - [Mozilla JSON schema parser](#mozilla-json-schema-parser)
-- [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
-- [Contribution](#contribution)
+- [More information](#more-information)
 - [LICENSE](#license)
 
-### Installation
+# Installation
 
 ```console
 $ npm install @data-driven-forms/parsers -S
@@ -33,7 +26,9 @@ $ yarn add @data-driven-forms/parsers
 ```
 
 
-### Usage
+# Usage
+
+**THIS REPO IS NOT CURRENTLY MAINTAINED, IF YOU WANT TO USE IT, PLEASE LET US KNOW**
 
 For using Data Driven Forms in your component you need the renderer and a component mapper, which provides formFields components and layoutFields components.
 
@@ -66,85 +61,10 @@ const Form = () => (
 )
 ```
 
-### Parsers
+# More information
 
-#### ManageIQ parser
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
-#### Mozilla JSON schema parser
-
-### Useful links
-
-- [Data Driven Forms documentation](https://data-driven-forms.org/)
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Test a package
-
-You can test parsers using tests. Tests can be ran from core folder or from specific package.
-
-```console
-yarn test --watchAll packages/pf4-component-mapper
-
-# or
-
-cd packages/pf4-component-mapper
-yarn test
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(pf4): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
-
-### Contribution
-
-We welcome any community contribution. Don't be afraid to report bug or to create issues and pull-requests! :trophy:
-
-### LICENSE
+# LICENSE
 
 Apache License 2.0

--- a/packages/pf4-component-mapper/README.md
+++ b/packages/pf4-component-mapper/README.md
@@ -10,23 +10,24 @@ Patternfly 4 component mapper for [Data Driven Forms](https://github.com/data-dr
 
 **Table of Contents**
 
+- [More information](#more-information)
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
   - [PatternFly 4 Mapper](#patternfly-4-mapper)
 - [Usage](#usage)
 - [Basic provided components](#basic-provided-components)
+- [ValidateOnMount](#validateonmount)
 - [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
 - [Contribution](#contribution)
 - [LICENSE](#license)
+
+### More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
 ### Installation
 
 You need to add React Form Renderer
-
 
 #### [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
 
@@ -120,77 +121,6 @@ This field will show the error immediately.
 - NPM
   - [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
   - [PatternFly 4 Mapper](https://www.npmjs.com/package/@data-driven-forms/pf4-component-mapper)
-
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/pf4-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/pf3-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(pf4): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 

--- a/packages/react-renderer-demo/README.md
+++ b/packages/react-renderer-demo/README.md
@@ -29,16 +29,16 @@ yarn build
 ### Generate component examples from mappers
 ```bash
 cd packages/react-renderer-demo
-yarn generate:examples 
+yarn generate:examples
 ```
 ### Run bundle analyzer
 ```bash
 cd packages/react-renderer-demo
-yarn analyze 
+yarn analyze
 ```
 
 ### Emulate firebase server locally
 ```bash
 cd packages/react-renderer-demo
-yarn build && yarn serve 
+yarn build && yarn serve
 ```

--- a/packages/react-renderer-demo/package.json
+++ b/packages/react-renderer-demo/package.json
@@ -11,7 +11,7 @@
         "directory": "packages/react-renderer-demo"
     },
     "engines": {
-        "node": "10"
+        "node": "14"
     },
     "private": true,
     "scripts": {

--- a/packages/react-renderer-demo/src/pages/development-setup.md
+++ b/packages/react-renderer-demo/src/pages/development-setup.md
@@ -6,42 +6,35 @@ import DocPage from '@docs/doc-page';
 
 Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
 
-## Checklist before you send a PR
+---
 
-Please follow following checklist if you are going to open a PR. It will help you make the PR finished.
+## Requirements
 
-- [ ] `Yarn build` passes
-- [ ] `Yarn lint` passes
-- [ ] `Yarn test` passes
-- [ ] Test coverage for new code *(if applicable)*
-- [ ] Documentation update *(if applicable)*
-- [ ] **Correct commit message**
-   - format `fix|feat({scope}): {description}`
-   - i.e. `fix(pf3): wizard correctly handles next button`
-   - fix will release a new \_.\_.X version
-   - feat will release a new \_.X.\_ version (use when you introduce new features)
-     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
-   - scope: package
-   - **if you update the documentation or tests, do not use this format**
-     - i.e. `Fix button on documenation example page`
+- **○ NodeJS 14**
 
-## Install
+- **○ Unix like OS (MacOS, Linux)**
+
+We do not support developing on Windows at this moment. However, we would welcome any PR to change this.
+
+---
+
+## Common commands
+
+### Install
 
 ```bash
 yarn install
 ```
 
-## Build
+### Build
 
 ```bash
 yarn build
 ```
 
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
+All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package. A package has to be built first before it is used in other package.
 
-Don't forget to build all packages, which are linked together!
-
-## Run a package
+### Run a playground
 
 Each package has a small playground `package/demo`, where you can test your changes.
 
@@ -50,7 +43,7 @@ cd packages/pf3-component-mapper
 yarn start
 ```
 
-## Run documentation
+### Run documentation
 
 The documentation is a server-side rendered React application based on [NextJS framework](https://nextjs.org/).
 
@@ -59,29 +52,25 @@ cd packages/react-renderer-demo
 yarn dev
 ```
 
-## How to clean?
+### How to clean node_modules
 
 ```bash
-yarn lerna clean # will delete all node_modules
+yarn lerna clean
+rm -rf node_modules
 ```
-
-This command **does not remove** the root `node_module` folder.
-
 ### Cleaning built files
 
-To clean built files use:
+To clean built files use following command: (This script is also ran automatically before each build.)
 
 ```bash
 yarn clean-build
 ```
 
-This script is also ran automatically before each build.
+### Tests
 
-## Tests
+Tests can be ran from core folder or from specific package.
 
-You can test parsers using tests. Tests can be ran from core folder or from specific package.
-
-```console
+```bash
 yarn test
 
 yarn test --watchAll packages/pf4-component-mapper
@@ -92,73 +81,113 @@ cd packages/pf4-component-mapper
 yarn test
 ```
 
-## Commits
+---
 
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
+## Checklist before you send a PR
 
-Format:
+Please follow following checklist if you are going to open a PR. It will help you make the PR finished.
 
-```
-[type]([package]): message
+### Build passes
 
-fix(pf4): title accepts node
-```
+Run `yarn build` in root folder to build all packages. You can run this command only in package you changed. All packages are linked by default, you have to build them first.
 
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
+### Linter passes
 
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
+Run `yarn lint` in root folder to check if the code is correctly formatted. You can use `yarn lint --fix` to automatically correct issues.
+### Write tests
 
-Please, do not use Semantic Release, if you update only the demo.
+All new code should be properly tested. Run `yarn test` in root folder to test all files. Check codecoverage report to see uncovered lines of code. We are using [Jest](https://jestjs.io/) and [Enzyme](https://enzymejs.github.io/enzyme/).
 
-All packages are releasing together and they share the version number.
+### Documentation update
 
-## Changes to documentation
+If you introduce a new feature, you should document this change in our documentation. The documentation is located in `react-renderer-demo` package and it is a web application based on [NextJS](https://nextjs.org/). We do not write tests for the documentation.
 
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
+`yarn dev` starts a local version of the documentation.
+
+`yarn build` prepares files for deployment.
+
+`yarn serve` emulates the web application running in local emulator.
+
+### Correct commit message
+
+A correct commit message is important, because we are using [semantic release](https://github.com/semantic-release/commit-analyzer) to automatically releease new versions. These messages are also used in our release notes, so other users can see what is being changed.
+
+**My change introduces a new feature**
+
+Prefix your commit message with `feat` and specify the package that is being changed. An example: `feat(pf4): a new dual list integration`. If you change multiple packages, you can use `feat(common): ...` or `feat(all): ...`.
+
+**My change fixes a bug or technical debt**
+
+Prefix your commit message with `fix`. Otherwise, the same rules apply. An example: `fix(pf4): fixed missed proptype in select`.
+
+**My change does not change any released package**
+
+If your change does not change any of the released packages, you can simple just descibe the change, an example: `Fix button on documenation example page`. This also applies for any change in the documentation repo.
+
+**My change introduces a breaking change**
+
+We are trying to avoid breaking changes. Please, open an issue and discuss the issue with us, we will try to come up with alternative options.
+
+---
 
 ## Generating a mapper template
 
-To generate a mapper template, run:
+We provide a simple CLI tool for generating component mappers. It will create a based project structure and dummy components.
 
 ```bash
 yarn generate-template
 ```
 
-This command starts a CLI, that provides an interface for generating mappers. A mapper folder will be created and it will be populated with all neccesary files.
+---
+
 ## Adding form component example
 
 To add additional examples of [custom form components](/examples/sample-example), please follow these steps.
 
-1. Create a new markdown file in this directory: https://github.com/data-driven-forms/react-forms/tree/master/packages/react-renderer-demo/src/pages/examples.
-2. Wrap the whole content into `DocPage` component:
+(1) Create a new markdown file in this directory: https://github.com/data-driven-forms/react-forms/tree/master/packages/react-renderer-demo/src/pages/examples.
+
+<br />
+
+(2) Wrap the whole content into `DocPage` component:
+
 ```md
 import DocPage from '@docs/doc-page';
 
 <DocPage>
   Your content
 </DocPage>
-
 ```
-3. Add this information to the file:
-    1.  Description of the component
-    2. A problem it may help to solve
-    3. Example of the component implementation and usage in a form
-4. To create an example follow these steps:
-    1. Create a new JS file in this directory: https://github.com/data-driven-forms/react-forms/tree/master/packages/react-renderer-demo/src/examples/components/examples
-    2. Import the code example using this path `components/examples/<file name without extenstion>`
+
+<br />
+
+(3) Add this information to the file:
+
+&nbsp;&nbsp;&nbsp;&nbsp;(a) Description of the component
+
+&nbsp;&nbsp;&nbsp;&nbsp;(b) A problem it may help to solve
+
+&nbsp;&nbsp;&nbsp;&nbsp;(c) Example of the component implementation and usage in a form
+
+<br />
+
+(4) To create an example follow these steps:
+
+&nbsp;&nbsp;&nbsp;&nbsp;(a) Create a new JS file in this directory: https://github.com/data-driven-forms/react-forms/tree/master/packages/react-renderer-demo/src/examples/components/examples
+
+&nbsp;&nbsp;&nbsp;&nbsp;(b) Import the code example using this path `components/examples/<file name without extenstion>`
 
 ```md
-
 import CodeExample from '@docs/code-example';
 
 <CodeExample source="components/examples/sample-example" mode="preview" />
-
 ```
-5. Add the component to the navigation. Add a new object to this file: https://github.com/data-driven-forms/react-forms/blob/master/packages/react-renderer-demo/src/components/navigation/schemas/custom-examples.schema.js
-    1. Title: text of the link
-    2. Component: exact filename of the **markdown file**
+
+<br />
+
+(5) Add the component to the navigation. Add a new object to this file: https://github.com/data-driven-forms/react-forms/blob/master/packages/react-renderer-demo/src/components/navigation/schemas/custom-examples.schema.js
+
+&nbsp;&nbsp;&nbsp;&nbsp;(a) Title: text of the link
+
+&nbsp;&nbsp;&nbsp;&nbsp;(b) Component: exact filename of the **markdown file**
 
 </DocPage>

--- a/packages/suir-component-mapper/README.md
+++ b/packages/suir-component-mapper/README.md
@@ -10,18 +10,19 @@ Semantic ui react component mapper for [Data Driven Forms](https://github.com/da
 
 **Table of Contents**
 
+- [More information](#more-information)
 - [Installation](#installation)
   - [React Form Renderer](#react-form-renderer)
   - [SUIR mapper](#suir-mapper)
 - [Usage](#usage)
 - [Basic provided components](#basic-provided-components)
 - [Useful links](#useful-links)
-- [Development setup](#development-setup)
-  - [Tests](#tests)
-  - [Commits](#commits)
-  - [Changes to documentation](#changes-to-documentation)
 - [Contribution](#contribution)
 - [LICENSE](#license)
+
+### More information
+
+For more information please check the root [repository](https://github.com/data-driven-forms/react-forms) or our [documentation page](https://data-driven-forms.org/).
 
 ### Installation
 
@@ -102,77 +103,6 @@ Data Driven Forms supports all kinds of component, basic set is consisted of:
 - NPM
   - [React Form Renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
   - [Semantic UI React react Mapper](https://www.npmjs.com/package/@data-driven-forms/suir-component-mapper)
-
-
-### Development setup
-
-Data Driven Forms is a monorepo that uses [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), so you can use all its commands as well.
-
-1. Install
-
-```console
-yarn install
-```
-
-2. Build
-
-```console
-yarn build
-```
-
-3. Run a package
-
-Each package has a small playground `package/demo`, where you can test your changes.
-
-```console
-cd packages/suir-component-mapper
-yarn start
-```
-
-4. How to clean?
-
-```console
-yarn lerna clean # will delete all node_modules
-```
-
-All packages are linked together by default, so if you run a `yarn build` in a package, all other packages are updated to the latest version of that package.
-
-#### Tests
-
-Tests can be ran from the core folder or from specific packages.
-
-```console
-yarn test
-
-yarn test packages/suir-component-mapper
-```
-
-#### Commits
-
-Data Driven Forms uses [Semantic Release](https://github.com/semantic-release/commit-analyzer)
-
-Format:
-
-```
-[type]([package]): message
-
-fix(suir): title accepts node
-```
-
-Types:
-- `feat`: a new feature, will trigger new `_.X._` release
-- `fix`: a fix, will trigger new `_._.X` release
-
-Packages:
-- Please describe which package is being changed `pf3`, `renderer`, ...
-
-Please, do not use Semantic Release, if you update only the demo.
-
-All packages are releasing together and they share the version number.
-
-#### Changes to documentation
-
-If your changes influence API or add new features, you should describe these new options in the `react-renderer-demo` repository. Thanks!
 
 ### Contribution
 


### PR DESCRIPTION
Fixes #929

**Description**

Firebase now supports node14.

- updated development setup page
   - better formatting
   - requirements info
- reorganized and updated root readme
- updated packages readme (removed development setup from there)