### PR TITLE
feat(carbon): add string variant of timepicker

### DIFF
--- a/packages/carbon-component-mapper/src/tests/time-picker-string.test.js
+++ b/packages/carbon-component-mapper/src/tests/time-picker-string.test.js
@@ -1,0 +1,241 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { FormRenderer, componentTypes } from '@data-driven-forms/react-form-renderer';
+
+import FormTemplate from '../form-template';
+import { act } from 'react-dom/test-utils';
+import TimePicker from '../time-picker';
+
+describe('TimePicker<String>', () => {
+  let initialProps;
+  let onSubmit;
+  let wrapper;
+  let schema;
+
+  beforeEach(() => {
+    onSubmit = jest.fn();
+    initialProps = {
+      onSubmit: (values) => onSubmit(values),
+      componentMapper: {
+        [componentTypes.TIME_PICKER]: {
+          component: TimePicker,
+          useStringFormat: true,
+        },
+      },
+      FormTemplate,
+    };
+  });
+
+  it('change AM/PM', async () => {
+    schema = {
+      fields: [
+        {
+          component: componentTypes.TIME_PICKER,
+          name: 'time-picker',
+          twelveHoursFormat: true,
+        },
+      ],
+    };
+
+    wrapper = mount(<FormRenderer schema={schema} {...initialProps} />);
+
+    await act(async () => {
+      wrapper.find('input').simulate('change', { target: { value: '00:35' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('select#time-picker-12h').simulate('change', { target: { value: 'PM' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('00:35');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '00:35 PM' });
+
+    onSubmit.mockReset();
+
+    await act(async () => {
+      wrapper.find('select#time-picker-12h').simulate('change', { target: { value: 'AM' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('00:35');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '00:35 AM' });
+  });
+
+  it('does not handle invalid date', async () => {
+    schema = {
+      fields: [
+        {
+          component: componentTypes.TIME_PICKER,
+          name: 'time-picker',
+        },
+      ],
+    };
+
+    wrapper = mount(<FormRenderer schema={schema} {...initialProps} />);
+
+    await act(async () => {
+      wrapper.find('input').simulate('change', { target: { value: 'aa:BB' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('input').simulate('blur');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('aa:BB');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': 'aa:BB' });
+  });
+
+  it('handle change', async () => {
+    schema = {
+      fields: [
+        {
+          component: componentTypes.TIME_PICKER,
+          name: 'time-picker',
+        },
+      ],
+    };
+
+    wrapper = mount(<FormRenderer schema={schema} {...initialProps} />);
+
+    await act(async () => {
+      wrapper.find('input').simulate('change', { target: { value: '13:87' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('input').simulate('blur');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('13:87');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '13:87' });
+    onSubmit.mockReset();
+
+    await act(async () => {
+      wrapper.find('input').simulate('change', { target: { value: '25:16' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('input').simulate('blur');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('25:16');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '25:16' });
+  });
+
+  it('change timezone', async () => {
+    schema = {
+      fields: [
+        {
+          component: componentTypes.TIME_PICKER,
+          name: 'time-picker',
+          twelveHoursFormat: true,
+          timezones: [
+            { label: 'UTC', value: 'UTC' },
+            { label: 'EST', value: 'EAST' },
+          ],
+        },
+      ],
+    };
+
+    wrapper = mount(<FormRenderer schema={schema} {...initialProps} />);
+
+    await act(async () => {
+      wrapper.find('input').simulate('change', { target: { value: '00:35' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('select#time-picker-timezones').simulate('change', { target: { value: 'EST' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('00:35');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '00:35 AM EST' });
+
+    onSubmit.mockReset();
+
+    await act(async () => {
+      wrapper.find('select#time-picker-12h').simulate('change', { target: { value: 'UTC' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wrapper.find('input').props().value).toEqual('00:35');
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '00:35 UTC EST' });
+  });
+
+  it('handles initial value', async () => {
+    schema = {
+      fields: [
+        {
+          component: componentTypes.TIME_PICKER,
+          name: 'time-picker',
+          initialValue: '12:57 PM EAST',
+          twelveHoursFormat: true,
+          timezones: [
+            { label: 'UTC', value: 'UTC' },
+            { label: 'EST', value: 'EAST' },
+          ],
+        },
+      ],
+    };
+
+    wrapper = mount(<FormRenderer schema={schema} {...initialProps} />);
+
+    expect(wrapper.find('input').props().value).toEqual('12:57');
+
+    await act(async () => {
+      wrapper.find('input').simulate('change', { target: { value: '00:35' } });
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(onSubmit).toHaveBeenLastCalledWith({ 'time-picker': '00:35 PM EAST' });
+  });
+});

--- a/packages/carbon-component-mapper/src/time-picker-base/index.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker-base/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './time-picker-base';
+export * from './time-picker-base';

--- a/packages/carbon-component-mapper/src/time-picker-base/index.js
+++ b/packages/carbon-component-mapper/src/time-picker-base/index.js
@@ -1,0 +1,2 @@
+export { default } from './time-picker-base';
+export * from './time-picker-base';

--- a/packages/carbon-component-mapper/src/time-picker-base/time-picker-base.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker-base/time-picker-base.d.ts
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { AnyObject, Input } from "@data-driven-forms/react-form-renderer";
+
+import { FormGroupProps } from "../form-group";
+
+import { TimePickerProps as CarbonTimePickerProps, SelectItemProps } from 'carbon-components-react';
+
+export interface Timezone extends SelectItemProps {
+    value: string;
+    label?: string;
+}
+
+interface InternalTimePickerBaseProps extends CarbonTimePickerProps, AnyObject {
+    twelveHoursFormat?: boolean;
+    timezones?: Timezone[];
+    input: Input<any>;
+    enhnancedOnBlur?: () => void;
+    enhancedOnChange?: (value: string) => void;
+    finalValue: any;
+    warnText?: ReactNode;
+    selectFormat: (value: 'AM' | 'PM') => void;
+    selectTimezone: (value: string) => void;
+}
+
+export type TimePickerBaseProps = InternalTimePickerBaseProps & FormGroupProps;
+
+declare const TimePickerBase: React.ComponentType<TimePickerBaseProps>;
+
+export default TimePickerBase;

--- a/packages/carbon-component-mapper/src/time-picker-base/time-picker-base.js
+++ b/packages/carbon-component-mapper/src/time-picker-base/time-picker-base.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { TimePicker as CarbonTimePicker, TimePickerSelect, SelectItem } from 'carbon-components-react';
+
+import HelperTextBlock from '../helper-text-block/helper-text-block';
+
+const TimePickerBase = ({
+  WrapperProps,
+  input,
+  enhnancedOnBlur,
+  enhancedOnChange,
+  finalValue,
+  invalid,
+  twelveHoursFormat,
+  timezones,
+  helperText,
+  warnText,
+  selectFormat,
+  selectTimezone,
+  ...rest
+}) => (
+  <div {...WrapperProps}>
+    <CarbonTimePicker
+      {...input}
+      {...(enhnancedOnBlur && { onBlur: enhnancedOnBlur })}
+      {...(enhancedOnChange && { onChange: (e) => enhancedOnChange(e.target.value) })}
+      onBlur={enhnancedOnBlur}
+      value={finalValue}
+      key={input.name}
+      id={input.name}
+      invalid={Boolean(invalid)}
+      invalidText={invalid || ''}
+      {...rest}
+    >
+      {twelveHoursFormat && (
+        <TimePickerSelect labelText="Period" id={`${rest.id || input.name}-12h`} onChange={({ target: { value } }) => selectFormat(value)}>
+          <SelectItem value="AM" text="AM" />
+          <SelectItem value="PM" text="PM" />
+        </TimePickerSelect>
+      )}
+      {timezones && (
+        <TimePickerSelect labelText="Timezone" id={`${rest.id || input.name}-timezones`} onChange={({ target: { value } }) => selectTimezone(value)}>
+          {timezones.map(({ showAs, ...tz }) => (
+            <SelectItem key={tz.value} text={tz.label} {...tz} />
+          ))}
+        </TimePickerSelect>
+      )}
+    </CarbonTimePicker>
+    <HelperTextBlock helperText={!invalid && helperText} warnText={warnText} />
+  </div>
+);
+
+TimePickerBase.propTypes = {
+  isDisabled: PropTypes.bool,
+  isReadOnly: PropTypes.bool,
+  isRequired: PropTypes.bool,
+  label: PropTypes.node,
+  labelText: PropTypes.node,
+  description: PropTypes.node,
+  twelveHoursFormat: PropTypes.bool,
+  timezones: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+      showAs: PropTypes.string,
+    })
+  ),
+  WrapperProps: PropTypes.object,
+  input: PropTypes.shape({
+    name: PropTypes.string,
+  }).isRequired,
+  enhnancedOnBlur: PropTypes.func,
+  enhancedOnChange: PropTypes.func,
+  finalValue: PropTypes.any,
+  invalid: PropTypes.node,
+  helperText: PropTypes.node,
+  warnText: PropTypes.node,
+  selectFormat: PropTypes.func.isRequired,
+  selectTimezone: PropTypes.func.isRequired,
+};
+
+export default TimePickerBase;

--- a/packages/carbon-component-mapper/src/time-picker-date/index.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker-date/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './time-picker-date';
+export * from './time-picker-date';

--- a/packages/carbon-component-mapper/src/time-picker-date/index.js
+++ b/packages/carbon-component-mapper/src/time-picker-date/index.js
@@ -1,0 +1,2 @@
+export { default } from './time-picker-date';
+export * from './time-picker-date';

--- a/packages/carbon-component-mapper/src/time-picker-date/time-picker-date.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker-date/time-picker-date.d.ts
@@ -1,0 +1,21 @@
+import { UseFieldApiComponentConfig } from "@data-driven-forms/react-form-renderer";
+
+import { FormGroupProps } from "../form-group";
+
+import { TimePickerProps as CarbonTimePickerProps, SelectItemProps } from 'carbon-components-react';
+
+export interface Timezone extends SelectItemProps {
+    value: string;
+    label?: string;
+}
+
+interface InternalTimePickerProps extends CarbonTimePickerProps {
+    twelveHoursFormat?: boolean;
+    timezones?: Timezone[];
+}
+
+export type TimePickerDateProps = InternalTimePickerProps & FormGroupProps & UseFieldApiComponentConfig;
+
+declare const TimePickerDate: React.ComponentType<TimePickerDateProps>;
+
+export default TimePickerDate;

--- a/packages/carbon-component-mapper/src/time-picker-date/time-picker-date.js
+++ b/packages/carbon-component-mapper/src/time-picker-date/time-picker-date.js
@@ -1,0 +1,101 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useFieldApi } from '@data-driven-forms/react-form-renderer';
+
+import prepareProps from '../prepare-props';
+import TimePickerBase from '../time-picker-base';
+
+const TimePickerDate = (props) => {
+  const { input, meta, twelveHoursFormat, timezones, validateOnMount, helperText, WrapperProps, ...rest } = useFieldApi(prepareProps(props));
+
+  const [timezone, selectTimezone] = useState(timezones ? timezones[0]?.value : '');
+  const [format, selectFormat] = useState('AM');
+  const isMounted = useRef(false);
+
+  const invalid = (meta.touched || validateOnMount) && (meta.error || meta.submitError);
+  const warnText = (meta.touched || validateOnMount) && meta.warning;
+
+  let finalValue = input.value;
+  if (input.value instanceof Date) {
+    let [hours = '00', minutes = '00'] = input.value
+      .toLocaleTimeString('en-us', {
+        hour12: !!twelveHoursFormat,
+        timeZone: timezones?.find(({ value }) => value === timezone)?.showAs,
+      })
+      .split(':');
+
+    finalValue = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  }
+
+  const enhnancedOnBlur = () => {
+    let [hours = '00', minutes = '00'] = finalValue?.split(':') || [];
+
+    if (!hours || isNaN(hours)) {
+      hours = '00';
+    }
+
+    if (!minutes || isNaN(minutes)) {
+      minutes = '00';
+    }
+
+    if (twelveHoursFormat) {
+      hours = hours % 12;
+      if (format === 'PM') {
+        hours = hours + 12;
+      }
+    } else {
+      hours = hours % 24;
+    }
+
+    minutes = minutes % 59;
+    const enhancedValue = new Date(`Jan 1 2000 ${hours}:${minutes}:00 ${timezone}`);
+
+    input.onChange(enhancedValue);
+    input.onBlur();
+  };
+
+  useEffect(() => {
+    if (isMounted.current === true) {
+      enhnancedOnBlur();
+    } else {
+      isMounted.current = true;
+    }
+  }, [timezone, format]);
+
+  return (
+    <TimePickerBase
+      WrapperProps={WrapperProps}
+      input={input}
+      enhnancedOnBlur={enhnancedOnBlur}
+      finalValue={finalValue}
+      invalid={invalid}
+      twelveHoursFormat={twelveHoursFormat}
+      timezones={timezones}
+      helperText={helperText}
+      warnText={warnText}
+      selectFormat={selectFormat}
+      selectTimezone={selectTimezone}
+      {...rest}
+    />
+  );
+};
+
+TimePickerDate.propTypes = {
+  isDisabled: PropTypes.bool,
+  isReadOnly: PropTypes.bool,
+  isRequired: PropTypes.bool,
+  label: PropTypes.node,
+  labelText: PropTypes.node,
+  description: PropTypes.node,
+  twelveHoursFormat: PropTypes.bool,
+  timezones: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+      showAs: PropTypes.string,
+    })
+  ),
+  WrapperProps: PropTypes.object,
+};
+
+export default TimePickerDate;

--- a/packages/carbon-component-mapper/src/time-picker-string/index.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker-string/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './time-picker-string';
+export * from './time-picker-string';

--- a/packages/carbon-component-mapper/src/time-picker-string/index.js
+++ b/packages/carbon-component-mapper/src/time-picker-string/index.js
@@ -1,0 +1,2 @@
+export { default } from './time-picker-string';
+export * from './time-picker-string';

--- a/packages/carbon-component-mapper/src/time-picker-string/time-picker-string.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker-string/time-picker-string.d.ts
@@ -1,0 +1,21 @@
+import { UseFieldApiComponentConfig } from "@data-driven-forms/react-form-renderer";
+
+import { FormGroupProps } from "../form-group";
+
+import { TimePickerProps as CarbonTimePickerProps, SelectItemProps } from 'carbon-components-react';
+
+export interface Timezone extends SelectItemProps {
+    value: string;
+    label?: string;
+}
+
+interface InternalTimePickerProps extends CarbonTimePickerProps {
+    twelveHoursFormat?: boolean;
+    timezones?: Timezone[];
+}
+
+export type TimePickerStringProps = InternalTimePickerProps & FormGroupProps & UseFieldApiComponentConfig;
+
+declare const TimePickerString: React.ComponentType<TimePickerStringProps>;
+
+export default TimePickerString;

--- a/packages/carbon-component-mapper/src/time-picker-string/time-picker-string.js
+++ b/packages/carbon-component-mapper/src/time-picker-string/time-picker-string.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useFieldApi } from '@data-driven-forms/react-form-renderer';
+
+import prepareProps from '../prepare-props';
+import TimePickerBase from '../time-picker-base';
+
+const TimePickerString = (props) => {
+  const { input, meta, twelveHoursFormat, timezones, validateOnMount, helperText, WrapperProps, useStringFormat, ...rest } = useFieldApi(
+    prepareProps(props)
+  );
+
+  const [timezone, selectTimezone] = useState(() => (timezones ? input.value.match(/ \w+$/)?.[0].trim() || timezones[0]?.value : ''));
+  const [format, selectFormat] = useState(() => input.value.match(/ \w+ /)?.[0].trim() || 'AM');
+  const isMounted = useRef(false);
+
+  const invalid = (meta.touched || validateOnMount) && (meta.error || meta.submitError);
+  const warnText = (meta.touched || validateOnMount) && meta.warning;
+
+  const finalValue = input.value.replace(/ .*/, '');
+  const enhancedOnChange = (value) =>
+    input.onChange(`${value} ${twelveHoursFormat ? format : ''} ${timezones ? timezone : ''}`.replace(/ {2}/, ' ').trim());
+
+  useEffect(() => {
+    if (isMounted.current === true) {
+      enhancedOnChange(finalValue);
+    } else {
+      isMounted.current = true;
+    }
+  }, [timezone, format]);
+
+  return (
+    <TimePickerBase
+      WrapperProps={WrapperProps}
+      input={input}
+      enhancedOnChange={enhancedOnChange}
+      finalValue={finalValue}
+      invalid={invalid}
+      twelveHoursFormat={twelveHoursFormat}
+      timezones={timezones}
+      helperText={helperText}
+      warnText={warnText}
+      selectFormat={selectFormat}
+      selectTimezone={selectTimezone}
+      {...rest}
+    />
+  );
+};
+
+TimePickerString.propTypes = {
+  isDisabled: PropTypes.bool,
+  isReadOnly: PropTypes.bool,
+  isRequired: PropTypes.bool,
+  label: PropTypes.node,
+  labelText: PropTypes.node,
+  description: PropTypes.node,
+  twelveHoursFormat: PropTypes.bool,
+  timezones: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+      showAs: PropTypes.string,
+    })
+  ),
+  WrapperProps: PropTypes.object,
+  useStringFormat: PropTypes.bool,
+};
+
+export default TimePickerString;

--- a/packages/carbon-component-mapper/src/time-picker/time-picker.d.ts
+++ b/packages/carbon-component-mapper/src/time-picker/time-picker.d.ts
@@ -1,21 +1,13 @@
-import { ReactNode } from "react";
 import { UseFieldApiComponentConfig, AnyObject } from "@data-driven-forms/react-form-renderer";
 
-import { FormGroupProps } from "../form-group";
+import { TimePickerDateProps } from "../time-picker-date";
+import { TimePickerStringProps } from "../time-picker-string";
 
-import { TimePickerProps as CarbonTimePickerProps, SelectItemProps } from 'carbon-components-react';
-
-export interface Timezone extends SelectItemProps {
-    value: string;
-    label?: string;
+interface InternalTimePickerProps extends AnyObject{
+    useStringFormat?: boolean;
 }
 
-interface InternalTimePickerProps extends CarbonTimePickerProps {
-    twelveHoursFormat?: boolean;
-    timezones?: Timezone[];
-}
-
-export type TimePickerProps = InternalTimePickerProps & FormGroupProps & UseFieldApiComponentConfig;
+export type TimePickerProps = InternalTimePickerProps & TimePickerDateProps & TimePickerStringProps & UseFieldApiComponentConfig;
 
 declare const TimePicker: React.ComponentType<TimePickerProps>;
 

--- a/packages/carbon-component-mapper/src/time-picker/time-picker.js
+++ b/packages/carbon-component-mapper/src/time-picker/time-picker.js
@@ -1,120 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 
-import { TimePicker as CarbonTimePicker, TimePickerSelect, SelectItem } from 'carbon-components-react';
+import TimePickerString from '../time-picker-string/time-picker-string';
+import TimePickerDate from '../time-picker-date';
 
-import prepareProps from '../prepare-props';
-import HelperTextBlock from '../helper-text-block/helper-text-block';
-
-const TimePicker = (props) => {
-  const { input, meta, twelveHoursFormat, timezones, validateOnMount, helperText, WrapperProps, ...rest } = useFieldApi(prepareProps(props));
-
-  const [timezone, selectTimezone] = useState(timezones ? timezones[0]?.value : '');
-  const [format, selectFormat] = useState('AM');
-  const isMounted = useRef(false);
-
-  const invalid = (meta.touched || validateOnMount) && (meta.error || meta.submitError);
-  const warnText = (meta.touched || validateOnMount) && meta.warning;
-
-  let finalValue = input.value;
-  if (input.value instanceof Date) {
-    let [hours = '00', minutes = '00'] = input.value
-      .toLocaleTimeString('en-us', {
-        hour12: !!twelveHoursFormat,
-        timeZone: timezones?.find(({ value }) => value === timezone)?.showAs,
-      })
-      .split(':');
-
-    finalValue = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-  }
-
-  const enhnancedOnBlur = () => {
-    let [hours = '00', minutes = '00'] = finalValue?.split(':') || [];
-
-    if (!hours || isNaN(hours)) {
-      hours = '00';
-    }
-
-    if (!minutes || isNaN(minutes)) {
-      minutes = '00';
-    }
-
-    if (twelveHoursFormat) {
-      hours = hours % 12;
-      if (format === 'PM') {
-        hours = hours + 12;
-      }
-    } else {
-      hours = hours % 24;
-    }
-
-    minutes = minutes % 59;
-    const enhancedValue = new Date(`Jan 1 2000 ${hours}:${minutes}:00 ${timezone}`);
-
-    input.onChange(enhancedValue);
-    input.onBlur();
-  };
-
-  useEffect(() => {
-    if (isMounted.current === true) {
-      enhnancedOnBlur();
-    } else {
-      isMounted.current = true;
-    }
-  }, [timezone, format]);
-
-  return (
-    <div {...WrapperProps}>
-      <CarbonTimePicker
-        {...input}
-        value={finalValue}
-        onBlur={enhnancedOnBlur}
-        key={input.name}
-        id={input.name}
-        invalid={Boolean(invalid)}
-        invalidText={invalid || ''}
-        {...rest}
-      >
-        {twelveHoursFormat && (
-          <TimePickerSelect labelText="Period" id={`${rest.id || input.name}-12h`} onChange={({ target: { value } }) => selectFormat(value)}>
-            <SelectItem value="AM" text="AM" />
-            <SelectItem value="PM" text="PM" />
-          </TimePickerSelect>
-        )}
-        {timezones && (
-          <TimePickerSelect
-            labelText="Timezone"
-            id={`${rest.id || input.name}-timezones`}
-            onChange={({ target: { value } }) => selectTimezone(value)}
-          >
-            {timezones.map(({ showAs, ...tz }) => (
-              <SelectItem key={tz.value} text={tz.label} {...tz} />
-            ))}
-          </TimePickerSelect>
-        )}
-      </CarbonTimePicker>
-      <HelperTextBlock helperText={!invalid && helperText} warnText={warnText} />
-    </div>
-  );
-};
+const TimePicker = ({ useStringFormat, ...props }) => (useStringFormat ? <TimePickerString {...props} /> : <TimePickerDate {...props} />);
 
 TimePicker.propTypes = {
-  isDisabled: PropTypes.bool,
-  isReadOnly: PropTypes.bool,
-  isRequired: PropTypes.bool,
-  label: PropTypes.node,
-  labelText: PropTypes.node,
-  description: PropTypes.node,
-  twelveHoursFormat: PropTypes.bool,
-  timezones: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.node.isRequired,
-      showAs: PropTypes.string.isRequired,
-    })
-  ),
-  WrapperProps: PropTypes.object,
+  useStringFormat: PropTypes.bool,
 };
 
 export default TimePicker;

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/time-picker.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/time-picker.md
@@ -4,8 +4,25 @@ This component also accepts all other original props, please see [here](https://
 
 |Props|Description|default|
 |-----|-----------|-------|
+|useStringFormat|boolean - save value as string|false|
 |twelveHoursFormat|boolean - if true an AM/PM selector is shown|false|
 |timezones|array of timezones - if not empty, an timezone selector is shown|undefined|
+
+### useStringFormat
+
+If set to **true**, then the value is stored as a **string**. You need to parse it yourself. You should also provide a proper validation, currently the component does not check what users enter.
+
+Examples:
+
+`12:04`
+
+`12:04 PM`
+
+`12:04 PM EST` (timezone's value is being used)
+
+<br />
+
+If not set (or set to **false**), then the value is stored as a **Date**. You need to use `getHours` (see [more](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours)) and `getMinutes` (see [more](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes)) to obtain the values in your submit function.
 
 ### Timezone
 
@@ -15,11 +32,11 @@ Extends [SelectItem component](https://react.carbondesignsystem.com/?path=/story
 |-----|-----------|
 |label|A label of the timezone|
 |value|A value of the timezone used in `new Date('... ${value}')`|
-|showAs|Timezone that will be used to convert the value `value.toLocaleTimeString(..., { ..., timeZone: showsAs })`. Supported timezones can be found [here](https://cloud.google.com/dataprep/docs/html/Supported-Time-Zone-Values_66194188).|
+|showAs|Timezone that will be used to convert the value `value.toLocaleTimeString(..., { ..., timeZone: showsAs })`. Supported timezones can be found [here](https://cloud.google.com/dataprep/docs/html/Supported-Time-Zone-Values_66194188). **Not used when string format.**|
 
 #### value and showAs relationship
 
-To make this component work, please provide corresponding `showAs` for each timezone.
+To make this component work when not set to the string format, please provide corresponding `showAs` for each timezone.
 
 ```jsx
 {

--- a/packages/react-renderer-demo/src/pages/provided-mappers/time-picker.js
+++ b/packages/react-renderer-demo/src/pages/provided-mappers/time-picker.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ComponentText from '@docs/components/component-example-text';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import baseFieldProps from '../../helpers/base-field-props';
+import updateFieldSchema from '../../helpers/update-field-schema';
 
 const schema = {
   fields: [
@@ -12,8 +13,39 @@ const schema = {
     },
   ],
 };
+
+const basicVariant = { schema, label: 'Basic', value: 'basic' };
+const stringVariant = {
+  schema: updateFieldSchema(schema, {
+    useStringFormat: true,
+    twelveHoursFormat: true,
+    timezones: [
+      { value: 'CET', label: 'Central european time' },
+      { value: 'UTC', label: 'Universal Time Coordinated' },
+    ],
+  }),
+  label: 'String',
+  value: 'string',
+};
+
+const timezones = {
+  schema: updateFieldSchema(schema, {
+    twelveHoursFormat: true,
+    timezones: [
+      { label: 'UTC', value: 'UTC', showAs: 'UTC' },
+      { label: 'EST', value: 'EAST', showAs: 'Pacific/Easter' },
+    ],
+  }),
+  label: 'Timezones',
+  value: 'timezones',
+};
+
+const schemaVariants = {
+  carbon: [basicVariant, timezones, stringVariant],
+};
+
 const variants = [...baseFieldProps];
 
-const TimePicker = () => <ComponentText schema={schema} variants={variants} linkText="Time picker" />;
+const TimePicker = () => <ComponentText schema={schema} variants={variants} linkText="Time picker" schemaVariants={schemaVariants} />;
 
 export default TimePicker;


### PR DESCRIPTION
Fixes **see discord**

**Description**

### useStringFormat

If set to **true**, then the value is stored as a **string**. You need to parse it yourself. You should also provide a proper validation, currently the component does not check what users enter.

Examples:

`12:04`

`12:04 PM`

`12:04 PM EST` (timezone's value is being used)

<br />

If not set (or set to **false**), then the value is stored as a **Date**. You need to use `getHours` (see [more](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours)) and `getMinutes` (see [more](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes)) to obtain the values in your submit function.


**Schema** *(if applicable)*

```jsx
            schema={{
              fields: [
                {
                  component: 'time-picker',
                  name: 'time-picker',
                  twelveHoursFormat: true,
                  timezones: [
                    { label: 'EST', value: 'est' },
                    { label: 'PST', value: 'pst' },
                  ],
                  useStringFormat: true,
                },
              ],
            }}
```