### PR TITLE
fix(pf4): Field-Array no longer shows delete all when minItems has a …

### DIFF
--- a/packages/pf4-component-mapper/src/field-array/field-array.js
+++ b/packages/pf4-component-mapper/src/field-array/field-array.js
@@ -95,13 +95,15 @@ const DynamicArray = ({ ...props }) => {
               titleDescription={description}
               actions={
                 <React.Fragment>
-                  <Button
-                    variant="link"
-                    isDisabled={value.length === 0}
-                    {...(value.length !== 0 && { onClick: () => removeBatch(value.map((_, index) => index)) })}
-                  >
-                    {combinedButtonLabels.removeAll}
-                  </Button>
+                  {minItems === 0 && (
+                    <Button
+                      variant="link"
+                      isDisabled={value.length === 0}
+                      {...(value.length !== 0 && { onClick: () => removeBatch(value.map((_, index) => index)) })}
+                    >
+                      {combinedButtonLabels.removeAll}
+                    </Button>
+                  )}
                   <Button
                     variant="secondary"
                     isDisabled={value.length >= maxItems}

--- a/packages/pf4-component-mapper/src/tests/field-array.test.js
+++ b/packages/pf4-component-mapper/src/tests/field-array.test.js
@@ -306,7 +306,7 @@ describe('<FieldArray/>', () => {
     });
 
     await act(async () => {
-      wrapper.find('button').at(1).simulate('click');
+      wrapper.find('button').at(0).simulate('click');
     });
     wrapper.update();
 
@@ -321,7 +321,7 @@ describe('<FieldArray/>', () => {
     onSubmit.mockClear();
 
     await act(async () => {
-      wrapper.find('button').at(1).simulate('click');
+      wrapper.find('button').at(0).simulate('click');
     });
     wrapper.update();
 
@@ -336,7 +336,7 @@ describe('<FieldArray/>', () => {
     onSubmit.mockClear();
 
     await act(async () => {
-      wrapper.find('button').at(1).simulate('click');
+      wrapper.find('button').at(0).simulate('click');
     });
     wrapper.update();
 


### PR DESCRIPTION
Fixes #(issue) *(if applicable)*
I did not create an issue for this but it is in relation to the discussions for PR #1146 

**Description**
When `maxItems` has a value greater than 0 we should not show the `deleteAll` button.

Please include a summary of the change.
When `maxItems` is greater than 0 it will no longer show the `Delete all` button. This prevents the component from incidentally wiping the contents of the field-array when `maxItems` is set.

**Schema** *(if applicable)*

```jsx
const schema = {
    fields: [
        {
          "component": "field-array",
          "label": "Field Array",
          "name": "FieldArray",
          "minItems": 1,
          "fields": [
            {
              "component": "text-field",
              "label": "Add Input",
              "name": "InputName",
            }
          ]
        }
    ]
};

```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [(pf4):  ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [x] Correct commit message
