### PR TITLE
fix(carbon): fix time picker minute range

### DIFF
--- a/packages/carbon-component-mapper/src/tests/time-picker.test.js
+++ b/packages/carbon-component-mapper/src/tests/time-picker.test.js
@@ -130,9 +130,9 @@ describe('TimePicker', () => {
     });
     wrapper.update();
 
-    expect(wrapper.find('input').props().value).toEqual('13:28');
+    expect(wrapper.find('input').props().value).toEqual('13:27');
     expect(onSubmit.mock.calls[0][0]['time-picker'].getHours()).toEqual(13);
-    expect(onSubmit.mock.calls[0][0]['time-picker'].getMinutes()).toEqual(28);
+    expect(onSubmit.mock.calls[0][0]['time-picker'].getMinutes()).toEqual(27);
     onSubmit.mockReset();
 
     await act(async () => {

--- a/packages/carbon-component-mapper/src/time-picker-date/time-picker-date.js
+++ b/packages/carbon-component-mapper/src/time-picker-date/time-picker-date.js
@@ -47,7 +47,7 @@ const TimePickerDate = (props) => {
       hours = hours % 24;
     }
 
-    minutes = minutes % 59;
+    minutes = minutes % 60;
     const enhancedValue = new Date(`Jan 1 2000 ${hours}:${minutes}:00 ${timezone}`);
 
     input.onChange(enhancedValue);


### PR DESCRIPTION
**Description**

Changed minute overflow calculation to occur at 60 minutes instead of 59.
