### PR TITLE
Update types generator to use correct variable/function names.

### DIFF
--- a/packages/ant-component-mapper/src/validation-error/validation-error.d.ts
+++ b/packages/ant-component-mapper/src/validation-error/validation-error.d.ts
@@ -1,5 +1,5 @@
 import { Meta } from "@data-driven-forms/react-form-renderer";
 
-export type validationError = (meta: Meta<any>, validateOnMount?: boolean) => boolean | any | undefined
+export function validationError(meta: Meta<any>, validateOnMount?: boolean): boolean | any | undefined
 
 export default validationError;

--- a/packages/mui-component-mapper/src/validation-error/validation-error.d.ts
+++ b/packages/mui-component-mapper/src/validation-error/validation-error.d.ts
@@ -1,5 +1,5 @@
 import { Meta } from "@data-driven-forms/react-form-renderer";
 
-export type validationError = (meta: Meta<any>, validateOnMount?: boolean) => boolean | any | undefined;
+export function validationError(meta: Meta<any>, validateOnMount?: boolean): boolean | any | undefined;
 
 export default validationError;

--- a/packages/react-form-renderer/src/component-types/component-types.d.ts
+++ b/packages/react-form-renderer/src/component-types/component-types.d.ts
@@ -1,6 +1,6 @@
 export type ComponentType = 'text-field'|'field-array'|'checkbox'|'sub-form'|'radio'|'tabs'|'tab-item'|'date-picker'|'time-picker'|'wizard'|'switch'|'textarea'|'select'|'plain-text'|'button'|'input-addon-group'|'input-addon-button-group'|'dual-list-select'|'slider';
 
-interface componentTypes {
+interface IcomponentTypes {
   TEXT_FIELD: 'text-field';
   FIELD_ARRAY: 'field-array';
   CHECKBOX: 'checkbox';
@@ -22,6 +22,6 @@ interface componentTypes {
   SLIDER: 'slider';
 }
 
-declare const componentTypes: componentTypes;
+declare const componentTypes: IcomponentTypes;
 
 export default componentTypes;

--- a/packages/react-form-renderer/src/data-types/data-types.d.ts
+++ b/packages/react-form-renderer/src/data-types/data-types.d.ts
@@ -1,6 +1,6 @@
 export type DataType = 'integer'|'float'|'number'|'boolean'|'string';
 
-interface dataTypes {
+interface IdataTypes {
   INTEGER: 'integer';
   FLOAT: 'float';
   NUMBER: 'number';
@@ -8,6 +8,6 @@ interface dataTypes {
   STRING: 'string';
 }
 
-declare const dataTypes: dataTypes;
+declare const dataTypes: IdataTypes;
 
 export default dataTypes;

--- a/packages/react-form-renderer/src/validator-types/validator-types.d.ts
+++ b/packages/react-form-renderer/src/validator-types/validator-types.d.ts
@@ -1,4 +1,4 @@
-interface validatorTypes {
+interface IvalidatorTypes {
   REQUIRED: 'required';
   MIN_LENGTH: 'min-length';
   MAX_LENGTH: 'max-length';
@@ -10,6 +10,6 @@ interface validatorTypes {
   URL: 'url';
 }
 
-declare const validatorTypes: validatorTypes;
+declare const validatorTypes: IvalidatorTypes;
 
 export default validatorTypes;

--- a/scripts/generate-typings.js
+++ b/scripts/generate-typings.js
@@ -44,16 +44,18 @@ async function generateIndexTypes(from, to) {
         exportName = kebabToCamel(file.split('/').shift());
       }
 
-      let name = fileSource.match(/export default *[a-zA-Z\d;]+\n/gm);
-      if (name !== null) {
-        name = name.pop().replace('export default', '').replace(/\n/, '').replace(';', '').trim();
-      } else {
-        name = kebabToCamel(file.split('/').shift());
-      }
+      if (fileSource) {
+        let name = fileSource.match(/export default *[a-zA-Z\d;]+\n/gm);
+        if (name !== null) {
+          name = name.pop().replace('export default', '').replace(/\n/, '').replace(';', '').trim();
+        } else {
+          name = kebabToCamel(file.split('/').shift());
+        }
 
-      exportName = name;
-      if (!name) {
-        throw new Error(`module name missing!: ${file}\n`);
+        exportName = name;
+        if (!name) {
+          throw new Error(`module name missing!: ${file}\n`);
+        }
       }
     }
 

--- a/scripts/generate-typings.js
+++ b/scripts/generate-typings.js
@@ -19,17 +19,52 @@ async function generateIndexTypes(from, to) {
   const files = glob
     .sync(`${from}/*/`)
     .filter((name) => !name.includes('/tests/'))
-    .map((path) =>
-      path
-        .replace(/\/$/, '')
-        .split('/')
-        .pop()
-    );
-  const content = `${files.map(
-    (file) => `export { default as ${kebabToCamel(file.split('/').shift())} } from './${file.split('.').shift()}';
+    .map((path) => path.replace(/\/$/, '').split('/').pop());
+  const content = `${files.map((file) => {
+    let module;
+    let exportName;
+    const moduleSource = `${from}/${file.split('.').shift()}/${file}.js`.replace('//', '/');
+    try {
+      module = require(`${to}/${file.split('.').shift()}`);
+    } catch (error) {
+      console.log('Unable to find module: ', moduleSource);
+      module = {};
+      exportName = kebabToCamel(file.split('/').shift());
+    }
+
+    let fileSource;
+    /**
+     * Transform default module name to build index.d.ts export name
+     */
+    if (module.default) {
+      try {
+        fileSource = fse.readFileSync(moduleSource, { encoding: 'utf-8' });
+      } catch (error) {
+        console.error(`Unable to read file ${moduleSource}`);
+        exportName = kebabToCamel(file.split('/').shift());
+      }
+
+      let name = fileSource.match(/export default *[a-zA-Z\d;]+\n/gm);
+      if (name !== null) {
+        name = name.pop().replace('export default', '').replace(/\n/, '').replace(';', '').trim();
+      } else {
+        name = kebabToCamel(file.split('/').shift());
+      }
+
+      exportName = name;
+      if (!name) {
+        throw new Error(`module name missing!: ${file}\n`);
+      }
+    }
+
+    if (!exportName) {
+      exportName = kebabToCamel(file.split('/').shift());
+    }
+
+    return `export { default as ${exportName} } from './${file.split('.').shift()}';
 export * from './${file.split('.').shift()}';
-`
-  )}`.replace(/,/g, '');
+`;
+  })}`.replace(/,/g, '');
   return Promise.all([fse.writeFile(path.resolve(to, 'index.d.ts'), content)]);
 }
 


### PR DESCRIPTION
Fixes #1165

**Description**
Functions and constants had incorrect type name casing resulting in missing TS types when using named exports. For example:
```TS
// results in TS error that the module does not exist
import { useFieldApi } from '@data-driven-forms/react-form-renderer'
// the type was named but that function does not exist
import { UseFieldApi } from '@data-driven-forms/react-form-renderer'
```
### Changes
- the default re-export name is based on the actual variable/function name instead of automatically converting everything to CamelCase. If the script is unable to extract the correct name, it will fall back to CamelCase conversion.
- fixed some invalid type definitions

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`

cc @steverhoades