### PR TITLE
fix(common): update common version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@khala/commit-analyzer-wildcard": "^2.5.2",
     "@khala/npm-release-monorepo": "^2.5.2",
     "@khala/wildcard-release-notes": "^2.5.2",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^9.0.1",
     "@semantic-release/github": "^7.2.3",
     "@semantic-release/npm": "^7.1.3",
@@ -177,6 +178,11 @@
             "packages/*/package.json"
           ],
           "message": "Release of new version: ${nextRelease.version} <no> [skip ci]"
+        }
+      ],
+      [
+        "@semantic-release/exec", {
+          "prepareCmd": "node ./scripts/update-common.js ${nextRelease.version}"
         }
       ]
     ]

--- a/packages/ant-component-mapper/package.json
+++ b/packages/ant-component-mapper/package.json
@@ -29,7 +29,7 @@
     "antd": "^4.2.0"
   },
   "peerDependencies": {
-    "@data-driven-forms/react-form-renderer": ">=3.2.1",
+    "@data-driven-forms/react-form-renderer": "*",
     "antd": "^4.2.0",
     "react": "^16.13.1 || ^17.0.2",
     "react-dom": "^16.13.1 || ^17.0.2"

--- a/packages/mui-component-mapper/package.json
+++ b/packages/mui-component-mapper/package.json
@@ -30,7 +30,7 @@
     "@mui/styles": "^5.0.2"
   },
   "peerDependencies": {
-    "@data-driven-forms/react-form-renderer": ">=3.2.1",
+    "@data-driven-forms/react-form-renderer": "*",
     "@mui/icons-material": "^5.0.5",
     "@mui/material": "^5.0.6",
     "@mui/styles": "^5.0.2",

--- a/packages/pf4-component-mapper/package.json
+++ b/packages/pf4-component-mapper/package.json
@@ -34,7 +34,7 @@
     "@patternfly/react-icons": "^4.11.7"
   },
   "peerDependencies": {
-    "@data-driven-forms/react-form-renderer": ">=3.2.1",
+    "@data-driven-forms/react-form-renderer": "*",
     "@patternfly/react-core": "^4.157.3",
     "@patternfly/react-icons": "^4.11.7",
     "react": "^16.13.1 || ^17.0.2",

--- a/packages/suir-component-mapper/package.json
+++ b/packages/suir-component-mapper/package.json
@@ -27,7 +27,7 @@
     "semantic-ui-react": "^2.0.3"
   },
   "peerDependencies": {
-    "@data-driven-forms/react-form-renderer": ">=3.2.1",
+    "@data-driven-forms/react-form-renderer": "*",
     "react": "^16.13.1 || ^17.0.2",
     "react-dom": "^16.13.1 || ^17.0.2",
     "semantic-ui-react": "^2.0.3"

--- a/scripts/update-common.js
+++ b/scripts/update-common.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+const replace = require('replace-in-file');
+const glob = require('glob');
+
+const nextVersion = process.argv[2];
+console.log('Updating common package version!\n');
+console.log('Next version is:', nextVersion, '\n');
+
+const root = process.cwd();
+const files = glob.sync(`${root}/packages/*/package.json`);
+
+console.log('Files to replace: ', files.join(',\n'), '\n');
+console.log('Replacing to: ', `"@data-driven-forms/common": "^${nextVersion}"`, '\n');
+
+const optionTypeScriptPath = {
+  files,
+  from: '"@data-driven-forms/common": "*"',
+  to: `"@data-driven-forms/common": "^${nextVersion}"`,
+};
+
+(async () => await replace(optionTypeScriptPath))();
+
+console.log('Common package version successfully updated!\n');

--- a/scripts/update-common.js
+++ b/scripts/update-common.js
@@ -12,12 +12,12 @@ const files = glob.sync(`${root}/packages/*/package.json`);
 console.log('Files to replace: ', files.join(',\n'), '\n');
 console.log('Replacing to: ', `"@data-driven-forms/common": "^${nextVersion}"`, '\n');
 
-const optionTypeScriptPath = {
+const replaceConfig = {
   files,
-  from: '"@data-driven-forms/common": "*"',
-  to: `"@data-driven-forms/common": "^${nextVersion}"`,
+  from: ['"@data-driven-forms/common": "*"', '"@data-driven-forms/react-form-renderer": "*"'],
+  to: [`"@data-driven-forms/common": "^${nextVersion}"`, `"@data-driven-forms/react-form-renderer": "^${nextVersion}"`],
 };
 
-(async () => await replace(optionTypeScriptPath))();
+(async () => await replace(replaceConfig))();
 
 console.log('Common package version successfully updated!\n');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,6 +3405,23 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
 
+"@semantic-release/error@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-3.0.0.tgz#30a3b97bbb5844d695eb22f9d3aa40f6a92770c2"
+  integrity sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==
+
+"@semantic-release/exec@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-6.0.3.tgz#d212fdf19633bdfb553de6cb6c7f8781933224db"
+  integrity sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==
+  dependencies:
+    "@semantic-release/error" "^3.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    execa "^5.0.0"
+    lodash "^4.17.4"
+    parse-json "^5.0.0"
+
 "@semantic-release/git@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-9.0.1.tgz#7b5486578460084d8914c1aa4c4fff5087afa32a"


### PR DESCRIPTION
We can replace common version in package.json using [`semantic-release/exec`](https://github.com/semantic-release/exec/tree/master/test) plugin. This will prevent issues with mismatched package versions as seen in Edge frontend.

This plugin takes the `nextVersion`, finds all `package.json`s in `packages/package/` folders and changes the `*` to the `nextVersion`.

I tested the script directly and it *worked*, but I wasn't able to test it in dry-run, I guess we have to just hope. @Hyperkid123 Please do not merge it when we are not online so if there is any issue, we can deprecate the wrong versions. 😄 

This step happens **after git commit** so the changes should not be committed to the repository.