### PR TITLE
fix(types): update types for currentStep in Wizard

### DIFF
--- a/packages/react-form-renderer/src/wizard-context/wizard-context.d.ts
+++ b/packages/react-form-renderer/src/wizard-context/wizard-context.d.ts
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Field } from '../common-types';
 import { FormOptions } from '../renderer-context';
 
 export interface WizardContextValue {
   formOptions: FormOptions;
   crossroads: string[];
-  currentStep: string;
+  currentStep: { fields: Field[]; name: string; title: string; nextStep?: string };
   handlePrev: Function;
   onKeyDown: Function;
   jumpToStep: Function;


### PR DESCRIPTION
**Description**

Updates the types for `currentStep` in Wizard Context. 

Resolves the following typescript errors:
```
Property 'fields' does not exist on type 'string'.ts(2339)
Property 'nextStep' does not exist on type 'string'.ts(2339)
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
