### PR TITLE
fix(renderer): fix undefined meta in condition

### DIFF
--- a/packages/react-form-renderer/src/condition/condition.js
+++ b/packages/react-form-renderer/src/condition/condition.js
@@ -51,10 +51,14 @@ const Condition = React.memo(
                * We have to get the meta in the timetout to wait for state initialization
                */
               const meta = formOptions.getFieldState(field.name);
+              const isFormModified = Object.values(formOptions.getState().modified).some(Boolean);
               /**
-               * Apply setter only on modfied fields or on fields with no initial value.
+               * Apply setter only
+               *    - field has no initial value
+               *    - form is modified
+               *    - when meta is false = field was unmounted before timeout, we finish the condition
                */
-              if (typeof meta.initial === 'undefined' || meta.modified) {
+              if (!meta || isFormModified || typeof meta.initial === 'undefined') {
                 formOptions.batch(() => {
                   Object.entries(setter).forEach(([name, value]) => {
                     formOptions.change(name, value);

--- a/packages/react-form-renderer/src/tests/form-renderer/condition.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/condition.test.js
@@ -468,7 +468,7 @@ describe('condition test', () => {
     expect(() => screen.getByLabelText('field-2')).toThrow();
   });
 
-  it('should handle nested complex coniditions', async () => {
+  it('should handle nested complex conditions', async () => {
     const schema = {
       fields: [
         {
@@ -519,6 +519,45 @@ describe('condition test', () => {
     userEvent.type(screen.getByLabelText('info.name.equipment'), 'Gun');
 
     await waitFor(() => expect(screen.getByLabelText('info.occupation')).toHaveValue('SPY'));
+  });
+
+  it('should change field with initial value only when form is modified', async () => {
+    const schema = {
+      fields: [
+        {
+          component: 'text-field',
+          name: 'field1',
+          initialValue: 'B',
+        },
+        {
+          component: 'text-field',
+          name: 'field2',
+          initialValue: 'schema initial value',
+          clearOnUnmount: true,
+          condition: {
+            when: 'field1',
+            is: 'B',
+            then: { set: { field2: 'set with then' } },
+            else: { set: { field2: 'set with else' } },
+          },
+        },
+      ],
+    };
+
+    render(<FormRenderer {...initialProps} schema={schema} />);
+
+    expect(screen.getByLabelText('field2')).toHaveValue('schema initial value');
+
+    userEvent.type(screen.getByLabelText('field2'), '+++');
+
+    expect(screen.getByLabelText('field2')).toHaveValue('schema initial value+++');
+
+    userEvent.clear(screen.getByLabelText('field1'));
+    userEvent.type(screen.getByLabelText('field1'), 'A');
+    userEvent.clear(screen.getByLabelText('field1'));
+    userEvent.type(screen.getByLabelText('field1'), 'B');
+
+    await waitFor(() => expect(screen.getByLabelText('field2')).toHaveValue('set with then'));
   });
 
   describe('reducer', () => {

--- a/packages/react-renderer-demo/src/pages/schema/condition-set.md
+++ b/packages/react-renderer-demo/src/pages/schema/condition-set.md
@@ -20,4 +20,6 @@ condition: {
 
 Set is a object consists of field names as keys and values as values. You can change any form field value from any conditional action.
 
+When the field containing a condition has some defined initial value, the setter is not triggered until the setter is retriggered with a different value.
+
 </DocPage>


### PR DESCRIPTION
Fixes #1233 

**Description**

- When a field is being unmounted (`meta == false`), we should finish the execution of condition setter.
- instead of field.modified we should check the entire form.modified as we do not know what fields are triggering the condition (there is a memoized setter result + fieldListeners, so that ensures that the setter is not triggered when anything else changes after the first render, but it only listens to the correct changes)

**Schema** *(if applicable)*

```jsx
    const schema = {
      fields: [
        {
          component: 'text-field',
          name: 'field1',
          initialValue: 'B',
        },
        {
          component: 'text-field',
          name: 'field2',
          initialValue: 'schema initial value',
          clearOnUnmount: true,
          condition: {
            when: 'field1',
            is: 'B',
            then: { set: { field2: 'set with then' } },
            else: { set: { field2: 'set with else' } },
          },
        },
      ],
    };
```

