### PR TITLE
fix(manager): when one field is dirty, whole form is dirty

### DIFF
--- a/packages/form-state-manager/src/manager-api/manager-api.ts
+++ b/packages/form-state-manager/src/manager-api/manager-api.ts
@@ -905,8 +905,8 @@ const createManagerApi: CreateManagerApi = ({
         value,
       }));
 
-      const setDirty = isFormDirty();
-      const setDirtySinceLastSubmit = isFormDirtySinceLastSubmit();
+      const setDirty = !pristine || isFormDirty();
+      const setDirtySinceLastSubmit = dirtySinceLastSubmit || isFormDirtySinceLastSubmit();
 
       modify('pristine', !setDirty);
       modify('dirty', setDirty);


### PR DESCRIPTION
**Description**

When one field is dirty, then the whole form is dirty too - so we do not have to check the other fields.