### PR TITLE
fix(common): Fix clear all right values dual list action type typo

### DIFF
--- a/packages/common/src/dual-list-select/dual-list-select.js
+++ b/packages/common/src/dual-list-select/dual-list-select.js
@@ -73,7 +73,7 @@ const DualListSelectCommon = (props) => {
   };
 
   const handleClearRightValues = () => {
-    dispatch({ type: 'clearRightValue' });
+    dispatch({ type: 'clearRightValues' });
     rest.input.onChange([...rest.input.value.filter((val) => !rightValues.find(({ value }) => val === value))]);
   };
 


### PR DESCRIPTION
Fixes hanging remove button is enabled even if no option is selected

**Description**

Fixed dual list select action dispatch typo

https://codesandbox.io/s/modal-multiselect-forked-7w9yl7?file=/src/index.js

How to produce:

1. select one option and add it to the right
2. click on the option in the right column but make no other action
3. Click on the Remove all button

The remove button stays enabled (as if the option was still selected)

The button should be disabled