### PR TITLE
Add labelIcon ptoperty to TextField

### DIFF
--- a/packages/pf4-component-mapper/src/text-field/text-field.js
+++ b/packages/pf4-component-mapper/src/text-field/text-field.js
@@ -6,11 +6,26 @@ import { useFieldApi } from '@data-driven-forms/react-form-renderer';
 import showError from '../show-error/show-error';
 
 const TextField = (props) => {
-  const { label, isRequired, helperText, meta, validateOnMount, description, hideLabel, input, isReadOnly, isDisabled, id, FormGroupProps, ...rest } =
-    useFieldApi(props);
+  const {
+    label,
+    labelIcon,
+    isRequired,
+    helperText,
+    meta,
+    validateOnMount,
+    description,
+    hideLabel,
+    input,
+    isReadOnly,
+    isDisabled,
+    id,
+    FormGroupProps,
+    ...rest
+  } = useFieldApi(props);
   return (
     <FormGroup
       label={label}
+      labelIcon={labelIcon}
       isRequired={isRequired}
       helperText={helperText}
       meta={meta}
@@ -35,6 +50,7 @@ const TextField = (props) => {
 
 TextField.propTypes = {
   label: PropTypes.node,
+  labelIcon: PropTypes.element,
   validateOnMount: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   isRequired: PropTypes.bool,


### PR DESCRIPTION
**Description**

Added support of `labelIcon` property to PF4 text field

**Schema** 

```
{
              component: componentTypes.TEXT_FIELD,
              label: 'First name',
              labelIcon: labelIcon,
              name: 'first-name',
            },
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [ ] `Yarn build` passes
- [x] `Yarn lint` passes
- [ ] `Yarn test` passes
- [x] Test coverage for new code 
- [x] Documentation update 
- [x] Correct commit message