### PR TITLE
Remove isRequired from conditionalSubmitFlag

### DIFF
--- a/packages/pf4-component-mapper/src/wizard/wizard-components/step-buttons.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/step-buttons.js
@@ -27,7 +27,7 @@ NextButton.propTypes = {
   handleNext: PropTypes.func.isRequired,
   nextLabel: PropTypes.node.isRequired,
   getState: PropTypes.func.isRequired,
-  conditionalSubmitFlag: PropTypes.string.isRequired,
+  conditionalSubmitFlag: PropTypes.string,
 };
 
 const WizardStepButtons = ({
@@ -84,7 +84,7 @@ const WizardStepButtons = ({
 
 WizardStepButtons.propTypes = {
   disableBack: PropTypes.bool,
-  conditionalSubmitFlag: PropTypes.string.isRequired,
+  conditionalSubmitFlag: PropTypes.string,
   handlePrev: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,
   nextStep: PropTypes.oneOfType([

--- a/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-step.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-step.js
@@ -95,7 +95,7 @@ WizardStep.propTypes = {
   name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hasNoBodyPadding: PropTypes.bool,
   StepTemplate: PropTypes.elementType,
-  conditionalSubmitFlag: PropTypes.string.isRequired,
+  conditionalSubmitFlag: PropTypes.string,
 };
 
 WizardStep.defaultProps = {

--- a/packages/pf4-component-mapper/src/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard.js
@@ -178,7 +178,7 @@ WizardInternal.propTypes = {
   container: PropTypes.instanceOf(Element),
   StepTemplate: PropTypes.elementType,
   className: PropTypes.string,
-  conditionalSubmitFlag: PropTypes.string.isRequired,
+  conditionalSubmitFlag: PropTypes.string,
 };
 
 const defaultLabels = {


### PR DESCRIPTION
**Description**

Removed isRequired from conditionalSubmitFlag because it caused unnecessary  warnings.

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [x] Test coverage for new code *(if applicable)*
- [x] Documentation update *(if applicable)*
- [x] Correct commit message
@Hyperkid123 
