### PR TITLE
Just add a link to custom component mapper to examples

### DIFF
--- a/packages/react-renderer-demo/src/components/navigation/schemas/custom-examples.schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/custom-examples.schema.js
@@ -1,5 +1,9 @@
 const customExamplesSchema = [
   {
+    component: 'custom-component-mapper',
+    linkText: 'Custom component mapper',
+  },
+  {
     component: 'mui-one-row-layout',
     linkText: 'MUI one row layout',
   },

--- a/packages/react-renderer-demo/src/pages/examples/custom-component-mapper.md
+++ b/packages/react-renderer-demo/src/pages/examples/custom-component-mapper.md
@@ -1,0 +1,18 @@
+import DocPage from '@docs/doc-page';
+import CodeExample from '@docs/code-example';
+
+<DocPage>
+
+
+# Custom component mapper
+
+This example shows how to implement a custom component mapper. Read more [here](/mappers/custom-mapper).
+
+## Example
+
+<CodeExample
+  source="components/component-mapper/form-fields-mapper"
+  mode="preview"
+/>
+
+</DocPage>


### PR DESCRIPTION
**Description**

Adds a custom mapper example to examples section so people can easily find it.
