### PR TITLE
fix(carbon): do not use absolute import paths

### DIFF
--- a/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.js
@@ -4,15 +4,20 @@ import DualListSelectCommon from '@data-driven-forms/common/dual-list-select';
 import clsx from 'clsx';
 import { createUseStyles } from 'react-jss';
 
-import { Grid, Row, Column, Button, FormGroup, Search, TooltipIcon } from 'carbon-components-react';
-import { CheckmarkFilled16, ChevronRight32, ChevronLeft32, CaretSortDown32, CaretSortUp32 } from '@carbon/icons-react';
-
 import {
+  Grid,
+  Row,
+  Column,
+  Button,
+  FormGroup,
+  Search,
   StructuredListWrapper,
   StructuredListRow,
   StructuredListBody,
   StructuredListCell,
-} from 'carbon-components-react/lib/components/StructuredList/StructuredList';
+  TooltipIcon,
+} from 'carbon-components-react';
+import { CheckmarkFilled16, ChevronRight32, ChevronLeft32, CaretSortDown32, CaretSortUp32 } from '@carbon/icons-react';
 
 import { buildLabel } from '../prepare-props';
 

--- a/packages/common/babel.config.js
+++ b/packages/common/babel.config.js
@@ -164,101 +164,6 @@ const createAntTransform = (env) => [
   `ant-${env}`
 ];
 
-const carbonMapper = (importName) =>
-  ({
-    StructuredListWrapper: 'StructuredList',
-    StructuredListBody: 'StructuredList',
-    StructuredListRow: 'StructuredList',
-    StructuredListCell: 'StructuredList',
-    ProgressStep: 'ProgressIndicator'
-  }[importName] || importName);
-
-const createCarbonCJSTransform = (env) => [
-  'transform-imports',
-  {
-    'carbon-components-react': {
-      transform: (importName) => {
-        let res;
-        const files = glob.sync(
-          path.resolve(__dirname, `../{..,carbon-component-mapper}/node_modules/carbon-components-react/${env === 'cjs' ? 'lib' : 'es'}/**/${carbonMapper(importName)}.js`)
-        ).filter(path => !path.includes('/next/'));
-        if (files.length > 0) {
-          res = files[0];
-        } else {
-          throw new Error(`File with importName ${importName} does not exist`);
-        }
-
-        res = res.replace(/^.*node_modules\//, '');
-        res = res.replace(/^\//, '');
-        return res;
-      },
-      preventFullImport: false,
-      skipDefaultConversion: false
-    },
-    'carbon-components-react/lib/components/StructuredList/StructuredList': {
-      transform: (importName) => {
-        let res;
-        const files = glob.sync(
-          path.resolve(__dirname, `../{..,carbon-component-mapper}/node_modules/carbon-components-react/${env === 'cjs' ? 'lib' : 'es'}/**/${carbonMapper(importName)}.js`)
-        ).filter(path => !path.includes('/next/'));
-        if (files.length > 0) {
-          res = files[0];
-        } else {
-          throw new Error(`File with importName ${importName} does not exist`);
-        }
-
-        res = res.replace(/^.*node_modules\//, '');
-        res = res.replace(/^\//, '');
-        return res;
-      },
-      preventFullImport: false,
-      skipDefaultConversion: true
-    },
-    'carbon-components-react/lib/components/ProgressIndicator/ProgressIndicator': {
-      transform: (importName) => {
-        let res;
-        const files = glob.sync(
-          path.resolve(__dirname, `../{..,carbon-component-mapper}/node_modules/carbon-components-react/${env === 'cjs' ? 'lib' : 'es'}/**/${carbonMapper(importName)}.js`)
-        ).filter(path => !path.includes('/next/'));
-        if (files.length > 0) {
-          res = files[0];
-        } else {
-          throw new Error(`File with importName ${importName} does not exist`);
-        }
-
-        res = res.replace(/^.*node_modules\//, '');
-        res = res.replace(/^\//, '');
-        return res;
-      },
-      preventFullImport: false,
-      skipDefaultConversion: true
-    },
-    '@carbon/icons-react': {
-      transform: (importName) => {
-        let size = importName.match(/\d+/)[0];
-        let iconName = pascalToKebabCaseCarbonIcons(importName.replace(/\d+/, ''));
-
-        let res;
-        const files = glob.sync(
-          path.resolve(__dirname, `../{..,carbon-component-mapper}/node_modules/@carbon/icons-react/${env === 'cjs' ? 'lib' : 'es'}/${iconName}/${size}.js`)
-        );
-        if (files.length > 0) {
-          res = files[0];
-        } else {
-          throw new Error(`File with importName ${importName} does not exist`);
-        }
-
-        res = res.replace(/^.*node_modules\//, '');
-        res = res.replace(/^\//, '');
-        return res;
-      },
-      preventFullImport: false,
-      skipDefaultConversion: false
-    }
-  },
-  `carbon-components-react-${env}`
-];
-
 const createReactJSSTransform = (env) => [
   'transform-imports',
   {
@@ -298,7 +203,6 @@ module.exports = {
         createPfReactTransform('js'),
         createBluePrintTransform('cjs'),
         createAntTransform('cjs'),
-        createCarbonCJSTransform('cjs'),
         createReactJSSTransform('cjs')
       ]
     },
@@ -310,7 +214,6 @@ module.exports = {
         createPfReactTransform('esm'),
         createBluePrintTransform('esm'),
         createAntTransform('esm'),
-        createCarbonCJSTransform('esm'),
         createReactJSSTransform('esm')
       ]
     }

--- a/packages/mui-component-mapper/src/date-picker/date-picker.d.ts
+++ b/packages/mui-component-mapper/src/date-picker/date-picker.d.ts
@@ -6,6 +6,10 @@ type InternalDatePickerProps<TInputDate, TDate> = MuiDatePickerProps<TInputDate,
 }
 
 export type DatePickerProps<TInputDate, TDate> = InternalDatePickerProps<TInputDate, TDate> & UseFieldApiComponentConfig;
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 declare const DatePicker: React.ComponentType<DatePickerProps<any, any>>;
 
 export default DatePicker;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,9 +2945,9 @@
     react-is "^17.0.2"
 
 "@mui/utils@^5.4.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.9.1.tgz#2b2c9dadbf8ba6561e145b5688fb7df5ef15a934"
-  integrity sha512-8+4adOR3xusyJwvbnZxcjqcmbWvl7Og+260ZKIrSvwnFs0aLubL+8MhiceeDDGcmb0bTKxfUgRJ96j32Jb7P+A==
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.9.3.tgz#a11e0824f00b7ea40257b390060ce167fe861d02"
+  integrity sha512-l0N5bcrenE9hnwZ/jPecpIRqsDFHkPXoFUcmkgysaJwVZzJ3yQkGXB47eqmXX5yyGrSc6HksbbqXEaUya+siew==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@types/prop-types" "^15.7.5"
@@ -2956,9 +2956,9 @@
     react-is "^18.2.0"
 
 "@mui/x-date-pickers@^5.0.0-beta.0":
-  version "5.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.0-beta.1.tgz#d681249066c81d73f6ca88d500f77e922ae2e7c5"
-  integrity sha512-Vx/mxnCDTQ8a5tMcRpku49+YgDl91XS5FJ0ZjPWR7JQOW8EEurDmVreNESrrIugTzQhSUp4eJXdGmncwxzwI9A==
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.0-beta.3.tgz#e9fbd85fd787f80502de8bbc29398121aedcf627"
+  integrity sha512-SrcGhwbyXal039I00+/8xNh8qGp0Y/iqWhhRqWk7Dy2lBpxIchNDUAvWtG27QfesxSRmhspo51dotpoG04u41A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@date-io/core" "^2.14.0"


### PR DESCRIPTION
There are import path changes in minor releases. Using absolute imports
will cause backwads compatibility issues.

Fixes #1298


