### PR TITLE
Checkbox validation fix

### DIFF
--- a/packages/react-form-renderer/src/tests/validators/validators.test.js
+++ b/packages/react-form-renderer/src/tests/validators/validators.test.js
@@ -10,6 +10,14 @@ describe('New validators', () => {
       expect(validatorMapper[validatorTypes.REQUIRED]()('Foo')).toBeUndefined();
     });
 
+    it('should pass required validator with false value', () => {
+      expect(validatorMapper[validatorTypes.REQUIRED]()(false)).toBeUndefined();
+    });
+
+    it('should fail required validator for null value', () => {
+      expect(validatorMapper[validatorTypes.REQUIRED]()(null)).toBe('Required');
+    });
+
     it('should fail required validator', () => {
       expect(validatorMapper[validatorTypes.REQUIRED]()()).toBe('Required');
     });

--- a/packages/react-form-renderer/src/validators/validator-functions.js
+++ b/packages/react-form-renderer/src/validators/validator-functions.js
@@ -2,7 +2,7 @@ import { memoize, prepare, prepareMsg, selectNum, isNumber, trunc } from '../com
 
 export const required = memoize(({ message } = {}) => {
   return prepare((value) => {
-    const cond = typeof value === 'string' ? !value.trim() : value && !isNaN(value.length) ? !value.length : !value;
+    const cond = typeof value === 'string' ? !value.trim() : value && !isNaN(value.length) ? !value.length : value == null;
     if (cond) {
       return prepareMsg(message, 'required').defaultMessage;
     }


### PR DESCRIPTION
Issue:

For checkbox component, if a "required" validation is passed then in that case a validation error is thrown if the user deselects the value. This shouldn't be the case because "false" is a valid value for boolean data.