### PR TITLE
Float Issue fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,5 @@
       ]
     ]
   },
-  "dependencies": {
-    "yarn": "^1.22.19"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -189,5 +189,7 @@
       ]
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "yarn": "^1.22.19"
+  }
 }

--- a/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/data-types.test.js
@@ -92,6 +92,14 @@ describe('data types', () => {
       it('converts a negative integer', () => {
         expect(convertType(dataTypes.INTEGER, '-12132')).toEqual(-12132);
       });
+
+      it('converts a floating number with nothing preceding decimal', () => {
+        expect(convertType(dataTypes.FLOAT, '123.')).toEqual('123.');
+      });
+
+      it('converts a floating number', () => {
+        expect(convertType(dataTypes.FLOAT, '123.0')).toEqual(123.0);
+      });
     });
   });
 });

--- a/packages/react-form-renderer/src/use-field-api/convert-type.js
+++ b/packages/react-form-renderer/src/use-field-api/convert-type.js
@@ -23,7 +23,9 @@ const canBeConvertedToNumber = (value) => !isNaN(Number(value)) && value !== '';
  * @param {Any} value value to be checked
  */
 const canBeConvertedToFloat = (value) => {
-  if (typeof value == 'string' && value.endsWith('.')) return false;
+  if (typeof value == 'string' && value.endsWith('.')) {
+    return false;
+  }
   return canBeConvertedToNumber(value);
 };
 

--- a/packages/react-form-renderer/src/use-field-api/convert-type.js
+++ b/packages/react-form-renderer/src/use-field-api/convert-type.js
@@ -19,6 +19,15 @@ const castToBoolean = (value) => {
 const canBeConvertedToNumber = (value) => !isNaN(Number(value)) && value !== '';
 
 /**
+ * Check if the value can be converted to float
+ * @param {Any} value value to be checked
+ */
+const canBeConvertedToFloat = (value) => {
+  if (typeof value == 'string' && value.endsWith('.')) return false;
+  return canBeConvertedToNumber(value);
+};
+
+/**
  * Changes the value type
  * @param {FieldDataTypes} dataType type for value conversion
  * @param {Any} value value to be converted
@@ -28,7 +37,7 @@ const convertType = (dataType, value) => {
     case dataTypes.INTEGER:
       return canBeConvertedToNumber(value) ? parseInt(value) : value;
     case dataTypes.FLOAT:
-      return canBeConvertedToNumber(value) ? parseFloat(value) : value;
+      return canBeConvertedToFloat(value) ? parseFloat(value) : value;
     case dataTypes.NUMBER:
       return canBeConvertedToNumber(value) ? Number(value) : value;
     case dataTypes.BOOLEAN:

--- a/packages/react-form-renderer/src/use-field-api/convert-type.js
+++ b/packages/react-form-renderer/src/use-field-api/convert-type.js
@@ -26,6 +26,7 @@ const canBeConvertedToFloat = (value) => {
   if (typeof value == 'string' && value.endsWith('.')) {
     return false;
   }
+
   return canBeConvertedToNumber(value);
 };
 


### PR DESCRIPTION
When typing a "." in a field having dataType as "float", the input is ignored and due to which user is never able to type a decimal value even if the type is set to "float". 

Reason: The canBeConvertedToNumber functions returns true for values like "11.", but the parseFloat functions returns "11" only and thus removing the decimal.

Issue is replicated at https://stackblitz.com/edit/1dkk8s?file=schema.js