### PR TITLE
Fix docs examples display names.

### DIFF
--- a/packages/react-renderer-demo/src/components/code-example.js
+++ b/packages/react-renderer-demo/src/components/code-example.js
@@ -193,7 +193,7 @@ const CodeExample = ({ source, mode }) => {
     mode === 'preview'
       ? dynamic(
           import(`@docs/examples/${source}`).then((mod) => {
-            setName(mod.default.name);
+            setName(mod.default?.displayName || '');
             return mod;
           })
         )

--- a/packages/react-renderer-demo/src/examples/components/action-mapper.js
+++ b/packages/react-renderer-demo/src/examples/components/action-mapper.js
@@ -48,5 +48,6 @@ const actionMapper = {
 const ActionMapper = () => (
   <FormRenderer FormTemplate={FormTemplate} actionMapper={actionMapper} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
 );
+ActionMapper.displayName = 'Action mapper';
 
 export default ActionMapper;

--- a/packages/react-renderer-demo/src/examples/components/clear-on-unmount.js
+++ b/packages/react-renderer-demo/src/examples/components/clear-on-unmount.js
@@ -62,4 +62,6 @@ const ClearOnUnmount = () => {
   );
 };
 
+ClearOnUnmount.displayName = 'Clear on umnout';
+
 export default ClearOnUnmount;

--- a/packages/react-renderer-demo/src/examples/components/cleared-value.js
+++ b/packages/react-renderer-demo/src/examples/components/cleared-value.js
@@ -49,4 +49,6 @@ const ClearedValueExample = () => {
   );
 };
 
+ClearedValueExample.displayName = 'Cleard value example';
+
 export default ClearedValueExample;

--- a/packages/react-renderer-demo/src/examples/components/component-mapper/form-fields-mapper.js
+++ b/packages/react-renderer-demo/src/examples/components/component-mapper/form-fields-mapper.js
@@ -149,4 +149,6 @@ const ComponentMapper = () => {
   );
 };
 
+ComponentMapper.displayName = 'Component mapper';
+
 export default ComponentMapper;

--- a/packages/react-renderer-demo/src/examples/components/condition.js
+++ b/packages/react-renderer-demo/src/examples/components/condition.js
@@ -88,5 +88,6 @@ const componentMapper = {
 const FormTemplateWrapper = (props) => <FormTemplate {...props} showFormControls={false} />;
 
 const Condition = () => <FormRenderer FormTemplate={FormTemplateWrapper} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+Condition.displayName = 'Condition';
 
 export default Condition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/and.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/and.js
@@ -41,5 +41,6 @@ const componentMapper = {
 };
 
 const AndCondition = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+AndCondition.displayName = 'And condition';
 
 export default AndCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/comparators.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/comparators.js
@@ -46,5 +46,6 @@ const componentMapper = {
 };
 
 const IsCondition = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+IsCondition.displayName = 'Is condition';
 
 export default IsCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/is-empty.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/is-empty.js
@@ -31,5 +31,6 @@ const componentMapper = {
 };
 
 const IsEmpty = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+IsEmpty.displayName = 'Is empty';
 
 export default IsEmpty;

--- a/packages/react-renderer-demo/src/examples/components/conditions/is-function.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/is-function.js
@@ -44,5 +44,6 @@ const IsCondition = () => (
     <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
   </LocalizationProvider>
 );
+IsCondition.displayName = 'IsCondition';
 
 export default IsCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/is-not-empty.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/is-not-empty.js
@@ -30,5 +30,6 @@ const componentMapper = {
 };
 
 const IsNotEmpty = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+IsNotEmpty.displayName = 'Is not empty';
 
 export default IsNotEmpty;

--- a/packages/react-renderer-demo/src/examples/components/conditions/is.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/is.js
@@ -34,5 +34,6 @@ const IsCondition = () => (
     <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
   </div>
 );
+IsCondition.displayName = 'Is condition';
 
 export default IsCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/not-match.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/not-match.js
@@ -31,5 +31,6 @@ const componentMapper = {
 };
 
 const NotMatch = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+NotMatch.displayName = 'Not match';
 
 export default NotMatch;

--- a/packages/react-renderer-demo/src/examples/components/conditions/not.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/not.js
@@ -33,5 +33,6 @@ const componentMapper = {
 };
 
 const NotCondition = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+NotCondition.displayName = 'Not condition';
 
 export default NotCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/or.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/or.js
@@ -45,5 +45,6 @@ const OrCondition = () => (
     <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
   </div>
 );
+OrCondition.displayName = 'Or condition';
 
 export default OrCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/pattern.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/pattern.js
@@ -30,5 +30,6 @@ const componentMapper = {
 };
 
 const Pattern = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+Pattern.displayName = 'Pattern';
 
 export default Pattern;

--- a/packages/react-renderer-demo/src/examples/components/conditions/sequence.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/sequence.js
@@ -45,5 +45,6 @@ const SequenceCondition = () => (
     <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
   </div>
 );
+SequenceCondition.displayName = 'Sequence condition';
 
 export default SequenceCondition;

--- a/packages/react-renderer-demo/src/examples/components/conditions/set.js
+++ b/packages/react-renderer-demo/src/examples/components/conditions/set.js
@@ -46,5 +46,6 @@ const componentMapper = {
 };
 
 const SetAction = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+SetAction.displayName = 'Set action';
 
 export default SetAction;

--- a/packages/react-renderer-demo/src/examples/components/data-types-example.js
+++ b/packages/react-renderer-demo/src/examples/components/data-types-example.js
@@ -56,4 +56,6 @@ const DataTypesExample = () => {
   );
 };
 
+DataTypesExample.displayName = 'Data types example';
+
 export default DataTypesExample;

--- a/packages/react-renderer-demo/src/examples/components/examples/cascading-select.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/cascading-select.js
@@ -81,5 +81,6 @@ const componentMapper = {
 };
 
 const CascadingSelect = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+CascadingSelect.displayName = 'Cascading select';
 
 export default CascadingSelect;

--- a/packages/react-renderer-demo/src/examples/components/examples/custom-layout-component.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/custom-layout-component.js
@@ -60,5 +60,6 @@ const componentMapper = {
 const CustomLayoutComponent = () => (
   <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
 );
+CustomLayoutComponent.displayName = 'Custom layout component';
 
 export default CustomLayoutComponent;

--- a/packages/react-renderer-demo/src/examples/components/examples/custom-wizard.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/custom-wizard.js
@@ -120,4 +120,6 @@ const CustomWizard = () => {
   );
 };
 
+CustomWizard.displayName = 'Custom wizard';
+
 export default CustomWizard;

--- a/packages/react-renderer-demo/src/examples/components/examples/mui-one-row-layout.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/mui-one-row-layout.js
@@ -26,5 +26,6 @@ const componentMapper = {
 };
 
 const OneRowLayout = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+OneRowLayout.displayName = 'One row layout';
 
 export default OneRowLayout;

--- a/packages/react-renderer-demo/src/examples/components/examples/resolve-props-db.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/resolve-props-db.js
@@ -44,5 +44,6 @@ const ResolvePropsDb = () => (
     actionMapper={actionMapper}
   />
 );
+ResolvePropsDb.displayName = 'Resolve props DB';
 
 export default ResolvePropsDb;

--- a/packages/react-renderer-demo/src/examples/components/examples/resolve-props-formspy.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/resolve-props-formspy.js
@@ -32,5 +32,6 @@ const componentMapper = {
 const ResolvePropsFormSpy = () => (
   <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
 );
+ResolvePropsFormSpy.displayName = 'Resolve props form spy';
 
 export default ResolvePropsFormSpy;

--- a/packages/react-renderer-demo/src/examples/components/examples/resolve-props-subscription.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/resolve-props-subscription.js
@@ -35,5 +35,6 @@ const ResolvePropsSubscription = () => (
     subscription={{ values: true }}
   />
 );
+ResolvePropsSubscription.displayName = 'Resolve props subscription';
 
 export default ResolvePropsSubscription;

--- a/packages/react-renderer-demo/src/examples/components/examples/value-listener-b.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/value-listener-b.js
@@ -54,4 +54,6 @@ const ValueListener = () => (
   />
 );
 
+ValueListener.displayName = 'Value listener';
+
 export default ValueListener;

--- a/packages/react-renderer-demo/src/examples/components/examples/value-listener.js
+++ b/packages/react-renderer-demo/src/examples/components/examples/value-listener.js
@@ -56,4 +56,6 @@ const ValueListener = () => (
   />
 );
 
+ValueListener.displayName = 'Value listener';
+
 export default ValueListener;

--- a/packages/react-renderer-demo/src/examples/components/field-array/pf4-demo.js
+++ b/packages/react-renderer-demo/src/examples/components/field-array/pf4-demo.js
@@ -115,4 +115,6 @@ const MUIFieldArray = () => {
   );
 };
 
+MUIFieldArray.displayName = 'MUI Field array';
+
 export default MUIFieldArray;

--- a/packages/react-renderer-demo/src/examples/components/file-upload/file-input.js
+++ b/packages/react-renderer-demo/src/examples/components/file-upload/file-input.js
@@ -87,4 +87,6 @@ const FormWithFileUpload = () => {
   );
 };
 
+FormWithFileUpload.displayName = 'Form with file upload';
+
 export default FormWithFileUpload;

--- a/packages/react-renderer-demo/src/examples/components/form-template/custom-buttons.js
+++ b/packages/react-renderer-demo/src/examples/components/form-template/custom-buttons.js
@@ -75,4 +75,6 @@ const FormControls = () => (
   />
 );
 
+FormControls.displayName = 'Form controls';
+
 export default FormControls;

--- a/packages/react-renderer-demo/src/examples/components/form-template/form-level-validation.js
+++ b/packages/react-renderer-demo/src/examples/components/form-template/form-level-validation.js
@@ -135,4 +135,6 @@ const FormLevelErrors = () => (
   </Grid>
 );
 
+FormLevelErrors.displayName = 'Form level errors';
+
 export default FormLevelErrors;

--- a/packages/react-renderer-demo/src/examples/components/get-started/get-started.js
+++ b/packages/react-renderer-demo/src/examples/components/get-started/get-started.js
@@ -57,4 +57,6 @@ const GetStartedForm = () => (
   </Grid>
 );
 
+GetStartedForm.displayName = 'Get started form';
+
 export default GetStartedForm;

--- a/packages/react-renderer-demo/src/examples/components/global-component-props/add-global-prop-to-component.js
+++ b/packages/react-renderer-demo/src/examples/components/global-component-props/add-global-prop-to-component.js
@@ -46,4 +46,6 @@ const AddGlobalPropToComponent = () => {
   return <FormRenderer FormTemplate={FormTemplate} schema={schema} componentMapper={componentMapper} onSubmit={console.log} />;
 };
 
+AddGlobalPropToComponent.displayName = 'Add global prop to component';
+
 export default AddGlobalPropToComponent;

--- a/packages/react-renderer-demo/src/examples/components/global-component-props/props-priority.js
+++ b/packages/react-renderer-demo/src/examples/components/global-component-props/props-priority.js
@@ -34,4 +34,6 @@ const PropsPriority = () => {
   return <FormRenderer FormTemplate={FormTemplate} schema={schema} componentMapper={componentMapper} onSubmit={console.log} />;
 };
 
+PropsPriority.displayName = 'Props priority';
+
 export default PropsPriority;

--- a/packages/react-renderer-demo/src/examples/components/initialize-mount.js
+++ b/packages/react-renderer-demo/src/examples/components/initialize-mount.js
@@ -113,4 +113,6 @@ const InitializeOnMountWizardExample = () => {
   );
 };
 
+InitializeOnMountWizardExample.displayName = 'Initialize on mount wizard example';
+
 export default InitializeOnMountWizardExample;

--- a/packages/react-renderer-demo/src/examples/components/resolve-props.js
+++ b/packages/react-renderer-demo/src/examples/components/resolve-props.js
@@ -35,5 +35,6 @@ const componentMapper = {
 };
 
 const ResolveProps = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+ResolveProps.displayName = 'Resolve props';
 
 export default ResolveProps;

--- a/packages/react-renderer-demo/src/examples/components/schema-validator.js
+++ b/packages/react-renderer-demo/src/examples/components/schema-validator.js
@@ -43,5 +43,6 @@ const SchemaValidationExample = () => (
     schemaValidatorMapper={schemaValidatorMapper}
   />
 );
+SchemaValidationExample.displayName = 'Schema validation example';
 
 export default SchemaValidationExample;

--- a/packages/react-renderer-demo/src/examples/components/ts-example.js
+++ b/packages/react-renderer-demo/src/examples/components/ts-example.js
@@ -12,4 +12,6 @@ const TsExample = () => {
   );
 };
 
+TsExample.displayName = 'TsExample';
+
 export default TsExample;

--- a/packages/react-renderer-demo/src/examples/components/utilities/standalone-validation.js
+++ b/packages/react-renderer-demo/src/examples/components/utilities/standalone-validation.js
@@ -81,4 +81,6 @@ const StandaloneValidation = () => {
   );
 };
 
+StandaloneValidation.displayName = 'Standalone validation';
+
 export default StandaloneValidation;

--- a/packages/react-renderer-demo/src/examples/components/validator-mapper.js
+++ b/packages/react-renderer-demo/src/examples/components/validator-mapper.js
@@ -55,4 +55,6 @@ const ValidatorMapper = () => (
   />
 );
 
+ValidatorMapper.displayName = 'Validator mapper';
+
 export default ValidatorMapper;

--- a/packages/react-renderer-demo/src/examples/components/validators/async-validator.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/async-validator.js
@@ -42,5 +42,6 @@ const schema = {
 };
 
 const AsyncValidator = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+AsyncValidator.displayName = 'Async validator';
 
 export default AsyncValidator;

--- a/packages/react-renderer-demo/src/examples/components/validators/custom-function.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/custom-function.js
@@ -21,5 +21,6 @@ const schema = {
 };
 
 const CustomValidator = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+CustomValidator.displayName = 'Custom validator';
 
 export default CustomValidator;

--- a/packages/react-renderer-demo/src/examples/components/validators/custom-message.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/custom-message.js
@@ -20,5 +20,6 @@ const schema = {
 };
 
 const CustomMessage = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+CustomMessage.displayName = 'Custom message';
 
 export default CustomMessage;

--- a/packages/react-renderer-demo/src/examples/components/validators/global-message.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/global-message.js
@@ -47,5 +47,6 @@ const schema = {
 };
 
 const OverridingMessage = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+OverridingMessage.displayName = 'Overriding message';
 
 export default OverridingMessage;

--- a/packages/react-renderer-demo/src/examples/components/validators/length-validators.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/length-validators.js
@@ -45,4 +45,6 @@ const schema = {
 
 const LengthValidators = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
 
+LengthValidators.displayName = 'Length validators';
+
 export default LengthValidators;

--- a/packages/react-renderer-demo/src/examples/components/validators/number-validator.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/number-validator.js
@@ -36,5 +36,6 @@ const schema = {
 const NumberValueValidators = () => (
   <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
 );
+NumberValueValidators.displayName = 'Number value validators';
 
 export default NumberValueValidators;

--- a/packages/react-renderer-demo/src/examples/components/validators/pattern-validator.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/pattern-validator.js
@@ -40,5 +40,6 @@ const schema = {
 };
 
 const PatternValidators = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+PatternValidators.displayName = 'Pattern validators';
 
 export default PatternValidators;

--- a/packages/react-renderer-demo/src/examples/components/validators/record-level-validation.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/record-level-validation.js
@@ -35,5 +35,6 @@ const validate = (values) => {
 const RecordLevelValidator = () => (
   <FormRenderer validate={validate} FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />
 );
+RecordLevelValidator.displayName = 'Record level validator';
 
 export default RecordLevelValidator;

--- a/packages/react-renderer-demo/src/examples/components/validators/required-validator.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/required-validator.js
@@ -27,5 +27,6 @@ const schema = {
 };
 
 const RequiredValidator = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+RequiredValidator.displayName = 'Required validator';
 
 export default RequiredValidator;

--- a/packages/react-renderer-demo/src/examples/components/validators/url-validator.js
+++ b/packages/react-renderer-demo/src/examples/components/validators/url-validator.js
@@ -50,5 +50,6 @@ const schema = {
 };
 
 const UrlValidators = () => <FormRenderer FormTemplate={FormTemplate} componentMapper={componentMapper} schema={schema} onSubmit={console.log} />;
+UrlValidators.displayName = 'Url validators';
 
 export default UrlValidators;

--- a/packages/react-renderer-demo/src/next.config.js
+++ b/packages/react-renderer-demo/src/next.config.js
@@ -57,16 +57,16 @@ module.exports = withBundleAnalyzer(
           ...config.resolve.alias,
           ...(process.env.DEPLOY === 'true'
             ? {
-                "@emotion/react": path.resolve(__dirname, '../node_modules/@emotion/react'),
-                "@emotion/server": path.resolve(__dirname, '../node_modules/@emotion/server'),
-                "@emotion/styled": path.resolve(__dirname, '../node_modules/@emotion/styled'),
+                '@emotion/react': path.resolve(__dirname, '../node_modules/@emotion/react'),
+                '@emotion/server': path.resolve(__dirname, '../node_modules/@emotion/server'),
+                '@emotion/styled': path.resolve(__dirname, '../node_modules/@emotion/styled'),
               }
             : {
                 react: path.resolve(__dirname, '../../../node_modules/react'),
                 'react-dom': path.resolve(__dirname, '../../../node_modules/react-dom'),
-                "@emotion/react": path.resolve(__dirname, '../../../node_modules/@emotion/react'),
-                "@emotion/server": path.resolve(__dirname, '../../../node_modules/@emotion/server'),
-                "@emotion/styled": path.resolve(__dirname, '../../../node_modules/@emotion/styled'),
+                '@emotion/react': path.resolve(__dirname, '../../../node_modules/@emotion/react'),
+                '@emotion/server': path.resolve(__dirname, '../../../node_modules/@emotion/server'),
+                '@emotion/styled': path.resolve(__dirname, '../../../node_modules/@emotion/styled'),
               }),
 
           '@docs/doc-components': path.resolve(__dirname, './doc-components'),


### PR DESCRIPTION
Fixes #1333 *

The next.js minimizer mangles all the function names and cannot be configured to not mangle them. We can't use terser as it was causing issues during deployment. We will have to define the display names ourselves. 
