### PR TITLE
Remove live-editor link and redirect old page to new page

### DIFF
--- a/packages/react-renderer-demo/src/components/navigation/schemas/schema.js
+++ b/packages/react-renderer-demo/src/components/navigation/schemas/schema.js
@@ -67,10 +67,6 @@ const schema = [
     chip: 'Preview',
   },
   {
-    linkText: 'Form builder',
-    link: 'live-editor',
-  },
-  {
     linkText: 'Testing',
     link: 'testing',
   },

--- a/packages/react-renderer-demo/src/pages/404.js
+++ b/packages/react-renderer-demo/src/pages/404.js
@@ -21,6 +21,7 @@ const rerouting = {
   '/renderer/condition': '/schema/introduction#condition',
   '/renderer/validators': '/schema/introduction#validate',
   '/mappers/component-api': '/provided-mappers/component-api',
+  '/live-editor': '/editor/live-editor',
 };
 
 const validatorHashMapper = {


### PR DESCRIPTION
Fixes https://github.com/data-driven-forms/react-forms/discussions/1337

**Description**

Redirects the old live-editor to the new version of it.

