### PR TITLE
Remove demo/dist folder on clean-build

### DIFF
--- a/scripts/clean-build.js
+++ b/scripts/clean-build.js
@@ -12,6 +12,10 @@ try {
   fse.rmSync(path.resolve(root, './packages/dist'), { recursive: true })
 } catch {}
 
+try {
+  fse.rmSync(path.resolve(root, './packages/react-renderer-demo/dist'), { recursive: true })
+} catch {}
+
 const x = glob.sync(path.resolve(root, './packages/*'));
 
 function cleanPackage(p) {


### PR DESCRIPTION
**Description**

When demo is built, a dist folder with empty package.json is created. Let's remove this folder to prevent mismatch error:

<img width="879" alt="Snímek obrazovky 2022-12-23 v 11 16 10" src="https://user-images.githubusercontent.com/32869456/209319020-39282614-9985-4b69-a21a-2dc65107e4a0.png">
