### PR TITLE
fix(ant): use htmlFor and id instead of Form.item name

### DIFF
--- a/packages/ant-component-mapper/src/date-picker/date-picker.js
+++ b/packages/ant-component-mapper/src/date-picker/date-picker.js
@@ -30,6 +30,7 @@ const DatePicker = (props) => {
         readOnly={isReadOnly}
         {...input}
         value={input.value || null}
+        id={input.name}
         {...rest}
       />
     </FormGroup>

--- a/packages/ant-component-mapper/src/form-group/form-group.js
+++ b/packages/ant-component-mapper/src/form-group/form-group.js
@@ -16,7 +16,7 @@ const FormGroup = ({ label, children, isRequired, FormItemProps, meta, validateO
       help={help}
       label={!hideLabel && label}
       required={isRequired}
-      name={input?.name}
+      htmlFor={input?.name}
       {...FormItemProps}
     >
       {children}

--- a/packages/ant-component-mapper/src/select/select.js
+++ b/packages/ant-component-mapper/src/select/select.js
@@ -54,6 +54,7 @@ const Select = (props) => {
         disabled={isDisabled || isReadOnly}
         onChange={(value, option) => input.onChange(isMulti ? selectValue(option) : option ? option.value : undefined)}
         input={input}
+        id={input.name}
         {...rest}
       >
         {options

--- a/packages/ant-component-mapper/src/slider/slider.js
+++ b/packages/ant-component-mapper/src/slider/slider.js
@@ -43,6 +43,7 @@ const Slider = (props) => {
         range={range}
         min={min}
         max={max}
+        id={input.name}
         {...rest}
       />
     </FormGroup>

--- a/packages/ant-component-mapper/src/switch/switch.js
+++ b/packages/ant-component-mapper/src/switch/switch.js
@@ -37,6 +37,7 @@ export const Switch = (props) => {
       input={input}
     >
       <AntSwitch
+        id={input.name}
         {...rest}
         defaultValue={input.checked ? input.checked : undefined}
         onChange={onChange}

--- a/packages/ant-component-mapper/src/text-field/text-field.js
+++ b/packages/ant-component-mapper/src/text-field/text-field.js
@@ -26,6 +26,7 @@ const TextField = (props) => {
         disabled={isDisabled}
         readOnly={isReadOnly}
         placeholder={placeholder}
+        id={input.name}
         {...rest}
       />
     </FormGroup>

--- a/packages/ant-component-mapper/src/textarea/textarea.js
+++ b/packages/ant-component-mapper/src/textarea/textarea.js
@@ -28,6 +28,7 @@ const Textarea = (props) => {
         disabled={isDisabled}
         readOnly={isReadOnly}
         placeholder={placeholder}
+        id={input.name}
         {...rest}
       />
     </FormGroup>

--- a/packages/ant-component-mapper/src/time-picker/time-picker.js
+++ b/packages/ant-component-mapper/src/time-picker/time-picker.js
@@ -32,6 +32,7 @@ const TimePicker = (props) => {
         defaultValue={input.value ? input.value : undefined}
         {...input}
         value={input.value || null}
+        id={input.name}
         {...rest}
       />
     </FormGroup>


### PR DESCRIPTION
Fixes #1356 

**Description**

- form.item name includes Ant form functionality we do not want to initialize
