### PR TITLE
Fix problem with ESC button on wizard in modal

### DIFF
--- a/packages/pf4-component-mapper/src/wizard/wizard.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard.js
@@ -90,12 +90,12 @@ const WizardInternal = ({
   return (
     <Modal inModal={inModal} container={state.container} aria-labelledby={rest.name}>
       <div
+        tabIndex={inModal ? 0 : null}
         className={`pf-c-wizard ${inModal ? '' : 'no-shadow'} ddorg__pf4-component-mapper__wizard ${className ? className : ''}`}
         role="dialog"
         aria-modal={inModal ? 'true' : undefined}
         onKeyDown={(e) => {
           onKeyDown(e);
-
           if (e.key === 'Escape' && inModal) {
             formOptions.onCancel();
           }


### PR DESCRIPTION
**Description**

Fix the problem with Escape button on wizard in the modal. Now Escape normally works after clicking outside the modal window/text area and clicking back on modal.


**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [x] Test coverage for new code *(if applicable)*
- [x] Documentation update *(if applicable)*
- [x] Correct commit message

@Hyperkid123 
