### PR TITLE
fix(TS): no-index type to exclude [otherProp: string]: any;

### DIFF
--- a/packages/react-form-renderer/src/common-types/index.d.ts
+++ b/packages/react-form-renderer/src/common-types/index.d.ts
@@ -1,4 +1,5 @@
 export * from './any-object';
+export * from './no-index';
 export { default as ComponentMapper } from './component-mapper';
 export * from './component-mapper';
 export { default as Field } from './field';
@@ -7,4 +8,4 @@ export * from './form-template-render-props';
 export { default as SchemaValidatorMapper } from './schema-validator-mapper';
 export * from './schema-validator-mapper';
 export { default as Schema } from './schema';
-export { FieldInputProps as Input } from 'react-final-form'
+export { FieldInputProps as Input } from 'react-final-form';

--- a/packages/react-form-renderer/src/common-types/no-index.d.ts
+++ b/packages/react-form-renderer/src/common-types/no-index.d.ts
@@ -1,0 +1,3 @@
+export type NoIndex<T> = {
+  [K in keyof T as {} extends Record<K, 1> ? never : K]: T[K];
+};

--- a/packages/react-form-renderer/src/form-renderer/form-renderer.d.ts
+++ b/packages/react-form-renderer/src/form-renderer/form-renderer.d.ts
@@ -6,13 +6,13 @@ import { ValidatorMapper } from '../validator-mapper';
 import { ActionMapper } from './action-mapper';
 import SchemaValidatorMapper from '../common-types/schema-validator-mapper';
 import { FormTemplateRenderProps } from '../common-types/form-template-render-props';
-import { AnyObject } from '../common-types/any-object';
+import { NoIndex } from '../common-types/no-index';
 
 export interface FormRendererProps<
   FormValues = Record<string, any>,
   InitialFormValues = Partial<FormValues>,
   FormTemplateProps extends FormTemplateRenderProps = FormTemplateRenderProps
-> extends Omit<FormProps<FormValues, InitialFormValues>, 'onSubmit'> {
+> extends Omit<NoIndex<FormProps<FormValues, InitialFormValues>>, 'onSubmit' | 'children'> {
   initialValues?: InitialFormValues;
   onCancel?: (values: FormValues, ...args: any[]) => void;
   onReset?: () => void;


### PR DESCRIPTION
**Description**

Final-form-api is using FormProps with `[otherProp: string]: any;`. If you then use Omit it will resolve in `[otherProp: string]: any;` and all other types will not be visible anymore.

[Typescript playground](https://www.typescriptlang.org/play?ts=5.0.2#code/JYWwDg9gTgLgBAbwGLRABShMBnAvnAM0xDgCIoBTAQwGMYBaA4AOyoBtHVSAobmATzAU4AOQgBJZgBMKADwA8AFQB8cALyJucOAG0A0nBZwA1hX4QCcRXCrZE+OTArS7AJQo1oU+XoA0cAEZVAH44ZgoANwooOAAuOD0AXXjFfUTuXF4BITgAeRBgGAB1QoALCABXGDFJGQVtFCgQADV2Coo7DXdPKG9sGCgWAHN-KmZ+ZV9JQuB2Rpa2jvU4NCpYWbZ5eda2duxlVQ18wq3UDCxsU6advf9pmA3txf3-UghmAGUKgCMCmFJlNwAPRA7TaAB6wV4fEEwmOxTKNWkcnkDVQNyWXQ8Xnk-UGzBGNnGk3uj3Rz2Wq3W7CuC12HQOy3h8iRdVp5xwtIx2DuzBmc3J9P2kzI7y+v0KAOBoLBkO4QA)

By using `NoIndex` we can exclude `[otherProp: string]: any;` and have all the types that we normally have in FormProps.


**Related**

- https://github.com/microsoft/TypeScript/issues/50638
- https://github.com/microsoft/TypeScript/issues/31153#issuecomment-1074283505

Both of them are closed with some examples on how to fix it but it seems that the TypeScript team will not fix the Omit. 👎🏼 


**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [x] Test coverage for new code *(if applicable)*
- [x] Documentation update *(if applicable)*
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
