### PR TITLE
fix(mui): apply SwitchProps to Switch component

### DIFF
--- a/packages/mui-component-mapper/src/switch/switch.js
+++ b/packages/mui-component-mapper/src/switch/switch.js
@@ -47,6 +47,7 @@ export const Switch = (props) => {
                 readOnly={isReadOnly}
                 disabled={isDisabled || isReadOnly}
                 onChange={({ target: { checked } }) => input.onChange(checked)}
+                {...SwitchProps}
               />
             }
             label={<FormLabel {...FormLabelProps}>{input.checked ? onText || label : offText || label}</FormLabel>}


### PR DESCRIPTION
**Description**

In the current code, the SwitchProps are not being applied to the Switch component. We should apply these SwitchProps so that users can customize the behavior of the component as this was the original intent.

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
