### PR TITLE
Fix numeric validator

### DIFF
--- a/packages/react-form-renderer/src/tests/validators/validators.test.js
+++ b/packages/react-form-renderer/src/tests/validators/validators.test.js
@@ -131,6 +131,10 @@ describe('New validators', () => {
     it('should not pass the validation and return custom message', () => {
       expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, message: 'Foo' })(1)).toEqual('Foo');
     });
+
+    it('should not pass the validation (with value as 0)', () => {
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 2 })(0)).toEqual('Value must be greater than or equal to 2.');
+    });
   });
 
   describe('max value validator', () => {

--- a/packages/react-form-renderer/src/validators/validator-functions.js
+++ b/packages/react-form-renderer/src/validators/validator-functions.js
@@ -90,7 +90,7 @@ export const numericality = memoize(
     lessOrEqual = selectNum(lessOrEqual, lessThanOrEqualTo);
 
     return prepare((value) => {
-      if (!value) {
+      if (value == null) {
         return;
       }
 

--- a/packages/react-form-renderer/src/validators/validator-functions.js
+++ b/packages/react-form-renderer/src/validators/validator-functions.js
@@ -90,7 +90,7 @@ export const numericality = memoize(
     lessOrEqual = selectNum(lessOrEqual, lessThanOrEqualTo);
 
     return prepare((value) => {
-      if (value == null) {
+      if (value === null || value === undefined) {
         return;
       }
 


### PR DESCRIPTION
Currently the numeric validators (min or max) doesn't shows any validation error if the value in the field is zero.

Scenario:
If a field is added with min validation with threshold as 3, the validator will show error for values like 1,2,-1 etc but nothing for 0.