### PR TITLE
Fix data type validation message for numeric validator in case of custom message

### DIFF
--- a/packages/react-form-renderer/src/tests/validators/validators.test.js
+++ b/packages/react-form-renderer/src/tests/validators/validators.test.js
@@ -133,9 +133,9 @@ describe('New validators', () => {
     });
 
     it('should not pass the validation and return type error message', () => {
-      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, message: 'Foo' })("oo")).toEqual('Value is not a number');
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, message: 'Foo' })('oo')).toEqual('Value is not a number');
     });
-    
+
     it('should not pass the validation (with value as 0)', () => {
       expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 2 })(0)).toEqual('Value must be greater than or equal to 2.');
     });

--- a/packages/react-form-renderer/src/tests/validators/validators.test.js
+++ b/packages/react-form-renderer/src/tests/validators/validators.test.js
@@ -131,6 +131,10 @@ describe('New validators', () => {
     it('should not pass the validation and return custom message', () => {
       expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, message: 'Foo' })(1)).toEqual('Foo');
     });
+
+    it('should not pass the validation and return type error message', () => {
+      expect(validatorMapper[validatorTypes.MIN_NUMBER_VALUE]({ value: 99, message: 'Foo' })("oo")).toEqual('Value is not a number');
+    });
   });
 
   describe('max value validator', () => {

--- a/packages/react-form-renderer/src/validators/validator-functions.js
+++ b/packages/react-form-renderer/src/validators/validator-functions.js
@@ -95,7 +95,7 @@ export const numericality = memoize(
       }
 
       if (!isNumber(value)) {
-        return prepareMsg(message, 'notANumber').defaultMessage;
+        return prepareMsg(null, 'notANumber').defaultMessage;
       }
 
       if (equal !== null && +value !== equal) {


### PR DESCRIPTION
Currently if have a validation (ex: minimum) on a numeric field and the value is not a number then it shows the data type wrong message (Value must be an integer) and if the type is correct then it shows the correct message (Value must be greater or equal.....). But when we are passing a custom validation message, then the data type message is not displayed and in that case also the custom message is shown.