### PR TITLE
fix(renderer): nested condition based on form initial values

### DIFF
--- a/packages/react-form-renderer/demo/form-fields-mapper.js
+++ b/packages/react-form-renderer/demo/form-fields-mapper.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
-import { componentTypes } from '../src';
+import { componentTypes, useFormApi } from '../src';
 import FieldProvider from '../src/field-provider';
 import useFieldApi from '../src/use-field-api';
 
@@ -71,13 +71,62 @@ const AsyncComponent = (props) => {
   );
 };
 
+const SubForm = ({ fields, title, ...props }) => {
+  const formOptions = useFormApi();
+  return (
+    <div>
+      <h2>{title}</h2>
+      <div>{formOptions.renderForm(fields)}</div>
+    </div>
+  );
+};
+
+const RadioOption = ({ name, option }) => {
+  const { input } = useFieldApi({
+    name,
+    type: 'radio',
+    value: option.value,
+  });
+  return (
+    <div>
+      <label htmlFor={option.label}>{option.label}</label>
+      <input
+        type="radio"
+        {...input}
+        id={option.label}
+        name={name}
+        onChange={(e) => {
+          input.onChange(option.value);
+        }}
+      />
+    </div>
+  );
+};
+
+const Radio = (props) => {
+  const { label, options } = useFieldApi({
+    ...props,
+    type: 'radio',
+  });
+  return (
+    <div>
+      <fieldset>
+        <legend>{label}</legend>
+        {options.map(({ value, label }) => {
+          return <RadioOption key={value} option={{ value, label }} name={props.name} />;
+        })}
+      </fieldset>
+    </div>
+  );
+};
+
 const mapper = {
   [componentTypes.TEXT_FIELD]: TextField,
   [componentTypes.TEXTAREA]: TextField,
   [componentTypes.SELECT]: SelectField,
   [componentTypes.CHECKBOX]: (props) => <div>checkbox</div>,
-  [componentTypes.SUB_FORM]: (props) => <div>sub form</div>,
-  [componentTypes.RADIO]: (props) => <div>radio</div>,
+  [componentTypes.SUB_FORM]: SubForm,
+  [componentTypes.RADIO]: Radio,
   [componentTypes.TABS]: (props) => <div>tabs</div>,
   [componentTypes.TAB_ITEM]: (props) => <div>tab item</div>,
   [componentTypes.DATE_PICKER]: (props) => <div>date picker</div>,
@@ -85,8 +134,8 @@ const mapper = {
   dataShower: AsyncComponent,
   'composite-mapper-field': {
     component: TextField,
-    className: 'composite-component-class'
-  }
+    className: 'composite-component-class',
+  },
 };
 
 export default mapper;

--- a/packages/react-form-renderer/demo/index.js
+++ b/packages/react-form-renderer/demo/index.js
@@ -7,35 +7,112 @@ import FormTemplate from './form-template';
 import mapper from './form-fields-mapper';
 
 const schema = {
-  title: 'Set action',
   fields: [
     {
-      component: 'text-field',
-      name: 'useDefaultNickName',
-      label: 'Do you want to use default nickname?',
-      description: 'set: {} is used to reset the setter',
+      name: 'formRadio',
+      label: 'SelectSubForm',
+      component: 'radio',
+      initializeOnMount: true,
+      clearOnUnmount: true,
+      options: [
+        { label: 'form1', value: 'form1' },
+        { label: 'form2', value: 'form2' },
+      ],
     },
     {
-      component: 'text-field',
-      name: 'nickname',
-      label: 'Nickname',
+      component: 'sub-form',
+      name: 'subform1',
       condition: {
-        when: 'useDefaultNickName',
-        is: 'a',
-        then: {
-          set: (formState, getFieldState) => {
-            return { nickname: formState.values.useDefaultNickName };
+        when: 'formRadio',
+        is: 'form1',
+      },
+      fields: [
+        {
+          name: 'txt1',
+          label: 'Enter text',
+          initializeOnMount: true,
+          clearOnUnmount: true,
+          component: 'text-field',
+        },
+        {
+          name: 'radioBtn',
+          label: 'Select',
+          component: 'radio',
+          initializeOnMount: true,
+          clearOnUnmount: true,
+          options: [
+            { label: 'abc', value: 'abc' },
+            { label: 'def', value: 'def' },
+          ],
+        },
+        {
+          name: 'txtField2',
+          label: 'Radio1',
+          initializeOnMount: true,
+          clearOnUnmount: true,
+          component: 'text-field',
+          condition: {
+            when: 'radioBtn',
+            is: 'def',
           },
         },
-        else: { visible: true, set: {} },
+      ],
+    },
+    {
+      component: 'sub-form',
+      title: 'Subform2',
+      description: 'This is a subform',
+      name: 'subform2',
+      condition: {
+        when: 'formRadio',
+        is: 'form2',
       },
+      fields: [
+        {
+          name: 'radioBtn2',
+          label: 'Select',
+          component: 'radio',
+          initializeOnMount: true,
+          clearOnUnmount: true,
+          options: [
+            { label: 'pqr', value: 'pqr' },
+            { label: 'stu', value: 'stu' },
+          ],
+        },
+        {
+          name: 'txtField3',
+          label: 'Radio1',
+          initializeOnMount: true,
+          clearOnUnmount: true,
+          component: 'text-field',
+          condition: {
+            and: [
+              {
+                when: 'radioBtn2',
+                is: 'stu',
+              },
+              {
+                when: 'formRadio',
+                is: 'form2',
+              },
+            ],
+          },
+        },
+      ],
     },
   ],
 };
+
+const initialValues = {
+  formRadio: 'form2',
+  radioBtn2: 'stu',
+  txtField3: 'data',
+};
+
 const App = () => {
   return (
     <div style={{ padding: 20 }}>
-      <FormRenderer componentMapper={mapper} onSubmit={console.log} FormTemplate={FormTemplate} schema={schema} />
+      <FormRenderer initialValues={initialValues} componentMapper={mapper} onSubmit={console.log} FormTemplate={FormTemplate} schema={schema} />
     </div>
   );
 };

--- a/packages/react-form-renderer/src/condition/condition.js
+++ b/packages/react-form-renderer/src/condition/condition.js
@@ -43,7 +43,10 @@ const Condition = React.memo(
       initial: true,
     });
 
-    const conditionResult = parseCondition(condition, values, field);
+    // It is required to get the context state values from in order to get the latest state.
+    // Using the trigger values can cause issues with the radio field as each input is registered separately to state and does not yield the actual field value.
+    const conditionResult = parseCondition(condition, formOptions.getState().values, field);
+
     const setters = conditionResult.set ? [conditionResult.set] : conditionResult.sets;
 
     useEffect(() => {

--- a/packages/react-form-renderer/src/tests/form-renderer/initial-values-condition-schema.json
+++ b/packages/react-form-renderer/src/tests/form-renderer/initial-values-condition-schema.json
@@ -1,0 +1,101 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "formRadio",
+        "label": "SelectSubForm",
+        "component": "radio",
+        "initializeOnMount": true,
+        "clearOnUnmount": true,
+        "options": [
+          { "label": "form1", "value": "form1" },
+          { "label": "form2", "value": "form2" }
+        ]
+      },
+      {
+        "component": "sub-form",
+        "name": "subform1",
+        "condition": {
+          "when": "formRadio",
+          "is": "form1"
+        },
+        "fields": [
+          {
+            "name": "txt1",
+            "label": "Enter text",
+            "initializeOnMount": true,
+            "clearOnUnmount": true,
+            "component": "text-field"
+          },
+          {
+            "name": "radioBtn",
+            "label": "Select",
+            "component": "radio",
+            "initializeOnMount": true,
+            "clearOnUnmount": true,
+            "options": [
+              { "label": "abc", "value": "abc" },
+              { "label": "def", "value": "def" }
+            ]
+          },
+          {
+            "name": "txtField2",
+            "label": "Radio1",
+            "initializeOnMount": true,
+            "clearOnUnmount": true,
+            "component": "text-field",
+            "condition": {
+              "when": "radioBtn",
+              "is": "def"
+            }
+          }
+        ]
+      },
+      {
+        "component": "sub-form",
+        "name": "subform2",
+        "condition": {
+          "when": "formRadio",
+          "is": "form2"
+        },
+        "fields": [
+          {
+            "name": "radioBtn2",
+            "label": "Select",
+            "component": "radio",
+            "initializeOnMount": true,
+            "clearOnUnmount": true,
+            "options": [
+              { "label": "pqr", "value": "pqr" },
+              { "label": "stu", "value": "stu" }
+            ]
+          },
+          {
+            "name": "txtField3",
+            "label": "Radio1",
+            "initializeOnMount": true,
+            "clearOnUnmount": true,
+            "component": "text-field",
+            "condition": {
+              "and": [
+                {
+                  "when": "radioBtn2",
+                  "is": "stu"
+                },
+                {
+                  "when": "formRadio",
+                  "is": "form2"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "initialValues": {
+    "formRadio": "form2",
+    "radioBtn2": "stu",
+    "txtField3": "data"
+  }
+}

--- a/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/render-form.test.js
@@ -13,12 +13,59 @@ import useFieldApi from '../../use-field-api';
 import FieldProvider from '../../field-provider';
 import Form from '../../form';
 
+import initialValuesConditionSchema from './initial-values-condition-schema.json';
+import useFormApi from '../../use-form-api/use-form-api';
+
 const TextField = (props) => {
   const { input, meta, ...rest } = useFieldApi(props);
   return (
     <div>
       <input {...input} {...rest} aria-label={input.name} />
       {meta.error && <div id="error">{meta.error}</div>}
+    </div>
+  );
+};
+
+const SubForm = ({ fields, title, ...props }) => {
+  const formOptions = useFormApi();
+  return <div>{formOptions.renderForm(fields)}</div>;
+};
+
+const RadioOption = ({ name, option }) => {
+  const { input } = useFieldApi({
+    name,
+    type: 'radio',
+    value: option.value,
+  });
+  return (
+    <div>
+      <label htmlFor={option.label}>{option.label}</label>
+      <input
+        type="radio"
+        {...input}
+        id={option.label}
+        name={name}
+        onChange={(e) => {
+          input.onChange(option.value);
+        }}
+      />
+    </div>
+  );
+};
+
+const Radio = (props) => {
+  const { label, options } = useFieldApi({
+    ...props,
+    type: 'radio',
+  });
+  return (
+    <div>
+      <fieldset>
+        <legend>{label}</legend>
+        {options.map(({ value, label }) => {
+          return <RadioOption key={value} option={{ value, label }} name={props.name} />;
+        })}
+      </fieldset>
     </div>
   );
 };
@@ -320,14 +367,18 @@ describe('renderForm function', () => {
           },
         },
       ];
+
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
       expect(() => screen.getByLabelText('foo')).toThrow();
 
@@ -354,13 +405,16 @@ describe('renderForm function', () => {
       ];
 
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       expect(screen.getByLabelText('foo')).toBeInTheDocument();
@@ -391,13 +445,16 @@ describe('renderForm function', () => {
       ];
 
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
       expect(() => screen.getByLabelText('foo')).toThrow();
 
@@ -421,15 +478,17 @@ describe('renderForm function', () => {
           },
         },
       ];
-
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       expect(screen.getByLabelText('foo')).toBeInTheDocument();
@@ -459,13 +518,16 @@ describe('renderForm function', () => {
         },
       ];
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
       expect(() => screen.getByLabelText('foo')).toThrow();
 
@@ -490,13 +552,16 @@ describe('renderForm function', () => {
         },
       ];
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       expect(() => screen.getByLabelText('foo')).toThrow();
@@ -523,13 +588,16 @@ describe('renderForm function', () => {
         },
       ];
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       expect(() => screen.getByLabelText('foo')).toThrow();
@@ -556,13 +624,16 @@ describe('renderForm function', () => {
         },
       ];
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       expect(screen.getByLabelText('foo')).toBeInTheDocument();
@@ -597,13 +668,16 @@ describe('renderForm function', () => {
         },
       ];
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       await userEvent.type(screen.getByLabelText('a'), 'x');
@@ -644,13 +718,16 @@ describe('renderForm function', () => {
         },
       ];
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       await userEvent.clear(screen.getByLabelText('a'));
@@ -689,13 +766,16 @@ describe('renderForm function', () => {
       ];
 
       render(
-        <ContextWrapper
+        <FormRenderer
           componentMapper={{
             'custom-component': CustomComponent,
           }}
+          schema={{
+            fields: formFields,
+          }}
         >
-          {renderForm(formFields)}
-        </ContextWrapper>
+          {({ formFields }) => formFields}
+        </FormRenderer>
       );
 
       expect(() => screen.getByLabelText('foo.bar')).toThrow();
@@ -750,6 +830,38 @@ describe('renderForm function', () => {
       await userEvent.type(screen.getByLabelText('b'), 'x');
 
       expect(screen.getByLabelText('foo')).toBeInTheDocument();
+    });
+
+    it('should correctly re-mount field after condition is met, when condition is based on initial values.', async () => {
+      render(
+        <FormRenderer
+          componentMapper={{
+            'text-field': CustomComponent,
+            radio: Radio,
+            'sub-form': SubForm,
+          }}
+          schema={{
+            fields: initialValuesConditionSchema.schema.fields,
+          }}
+          initialValues={initialValuesConditionSchema.initialValues}
+        >
+          {({ formFields }) => formFields}
+        </FormRenderer>
+      );
+
+      // field should be visible on initial mount as condition is met
+      expect(screen.getByLabelText('txtField3')).toBeInTheDocument();
+
+      // select form1 option to hide the `form2` and the `txtField3`
+      await userEvent.click(screen.getByText('form1'));
+
+      // field should not be visible after hiding its parent sub form
+      expect(() => screen.getByLabelText('txtField3')).toThrow();
+
+      // select form2 option to reveal the subform `form2`
+      await userEvent.click(screen.getByText('form2'));
+      // field should be visible on re-mount and if the condition is met
+      expect(screen.getByLabelText('txtField3')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Fixes #1383

**Description**

The input of type `radio` does not trigger the condition after `re-mount` if the condition is based on `initialValues` renderer prop.

Issue is with the `values` that are collected from all the triggers. Because the `radio` type is registered multiple times, per each option, the `useField` does not `yield` the actual state value immediately. Therefore we have to use the `getState().values` to retrieve the state values and pass it to the condition parser instead of the smaller, `values` collected from the triggers. 

To reproduce the issue, use the following schema with initial values. Select `form1` from the top radio component, and then `reselect` the `form2` option.

Without the fix the `Radio1` text field will not be visible, even though the values for the condition are correct.

**Schema** *(if applicable)*

```jsx
  const initialValues = {
    "formRadio": "form2",
    "radioBtn2": "stu",
    "txtField3": "data"
  }
  const scema =  {
    "fields": [
      {
        "name": "formRadio",
        "label": "SelectSubForm",
        "component": "radio",
        "initializeOnMount": true,
        "clearOnUnmount": true,
        "options": [
          { "label": "form1", "value": "form1" },
          { "label": "form2", "value": "form2" }
        ]
      },
      {
        "component": "sub-form",
        "name": "subform1",
        "condition": {
          "when": "formRadio",
          "is": "form1"
        },
        "fields": [
          {
            "name": "txt1",
            "label": "Enter text",
            "initializeOnMount": true,
            "clearOnUnmount": true,
            "component": "text-field"
          },
          {
            "name": "radioBtn",
            "label": "Select",
            "component": "radio",
            "initializeOnMount": true,
            "clearOnUnmount": true,
            "options": [
              { "label": "abc", "value": "abc" },
              { "label": "def", "value": "def" }
            ]
          },
          {
            "name": "txtField2",
            "label": "Radio1",
            "initializeOnMount": true,
            "clearOnUnmount": true,
            "component": "text-field",
            "condition": {
              "when": "radioBtn",
              "is": "def"
            }
          }
        ]
      },
      {
        "component": "sub-form",
        "name": "subform2",
        "condition": {
          "when": "formRadio",
          "is": "form2"
        },
        "fields": [
          {
            "name": "radioBtn2",
            "label": "Select",
            "component": "radio",
            "initializeOnMount": true,
            "clearOnUnmount": true,
            "options": [
              { "label": "pqr", "value": "pqr" },
              { "label": "stu", "value": "stu" }
            ]
          },
          {
            "name": "txtField3",
            "label": "Radio1",
            "initializeOnMount": true,
            "clearOnUnmount": true,
            "component": "text-field",
            "condition": {
              "and": [
                {
                  "when": "radioBtn2",
                  "is": "stu"
                },
                {
                  "when": "formRadio",
                  "is": "form2"
                }
              ]
            }
          }
        ]
      }
    ]
  }
```

