### PR TITLE
Fix mui date picker and time picker examples

### DIFF
--- a/packages/react-renderer-demo/src/stackblitz-templates/mui-templates.js
+++ b/packages/react-renderer-demo/src/stackblitz-templates/mui-templates.js
@@ -73,7 +73,7 @@ export const dependencies = {
   '@data-driven-forms/mui-component-mapper': 'latest',
   '@data-driven-forms/common': 'latest',
   '@mui/icons-material': 'latest',
-  '@mui/x-date-pickers': 'latest',
+  '@mui/x-date-pickers': '^5.0.20',
   '@mui/material': 'latest',
   'prop-types': 'latest',
 };


### PR DESCRIPTION
**Description**

specify stackblitz dependency on `@mui/x-date-pickers` for latest release of major version 5 instead of using `latest` which used incompatible version 6

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [x] Documentation update *(if applicable)*
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
