### PR TITLE
Add compareValues prop to useSelect's reducer

### DIFF
--- a/packages/common/src/select/deep-equal.d.ts
+++ b/packages/common/src/select/deep-equal.d.ts
@@ -1,0 +1,3 @@
+declare const deepEqual: (valueA: any, valueB: any) => boolean;
+
+export default deepEqual;

--- a/packages/common/src/select/deep-equal.js
+++ b/packages/common/src/select/deep-equal.js
@@ -1,0 +1,35 @@
+const deepEqual = (a, b, depth = 0) => {
+  if (depth > 4) {
+    console.error('Recursion limit of 5 has been exceeded.');
+    return false;
+  }
+
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b) && a.length === b.length) {
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    for (const key of keysA) {
+      if (!keysB.includes(key) || !deepEqual(a[key], b[key], depth + 1)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+};
+
+export default deepEqual;

--- a/packages/common/src/select/select.d.ts
+++ b/packages/common/src/select/select.d.ts
@@ -29,6 +29,7 @@ export interface SelectProps {
   SelectComponent?: React.ComponentType;
   noValueUpdates?: boolean;
   optionsTransformer?: (options: AnyObject[]) => option[];
+  compareValues?: (valueA: any, valueB: any) => boolean;
 }
 
 declare const Select: React.ComponentType<SelectProps>;

--- a/packages/common/src/select/select.js
+++ b/packages/common/src/select/select.js
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import useSelect from '../use-select/use-select';
+import deepEqual from './deep-equal';
 
 const Select = ({
   invalid,
@@ -24,6 +25,7 @@ const Select = ({
   SelectComponent,
   noValueUpdates,
   optionsTransformer,
+  compareValues = deepEqual,
   ...props
 }) => {
   const {
@@ -44,6 +46,7 @@ const Select = ({
     pluckSingleValue,
     isMulti,
     simpleValue,
+    compareValues,
   });
 
   const renderNoOptionsMessage = () => (Object.values(state.promises).some((value) => value) ? () => updatingMessage : () => noOptionsMessage);
@@ -119,6 +122,7 @@ Select.propTypes = {
   SelectComponent: PropTypes.elementType.isRequired,
   noValueUpdates: PropTypes.bool,
   optionsTransformer: PropTypes.func,
+  compareValues: PropTypes.func,
 };
 
 Select.defaultProps = {
@@ -129,6 +133,7 @@ Select.defaultProps = {
   placeholder: 'Choose...',
   isSearchable: false,
   isClearable: false,
+  compareValues: deepEqual,
 };
 
 export default Select;

--- a/packages/common/src/tests/select/deep-equal.test.js
+++ b/packages/common/src/tests/select/deep-equal.test.js
@@ -1,0 +1,78 @@
+import cloneDeep from 'lodash/cloneDeep';
+import deepEqual from '../../select/deep-equal';
+
+describe('deepEqual', () => {
+  describe('primitives', () => {
+    const tuplesBase = [1, 'a', false, undefined, null];
+    const positiveCases = tuplesBase.map((value) => ({
+      input: [value, value],
+      output: true,
+    }));
+    const negativeCases = tuplesBase.map((value) => ({
+      input: [value, value + 1],
+      output: false,
+    }));
+    positiveCases.forEach(({ input, output }) => {
+      it(`should return ${output} for a ${input} input`, () => {
+        expect(deepEqual(...input)).toEqual(output);
+      });
+    });
+
+    negativeCases.forEach(({ input, output }) => {
+      it(`should return ${output} for a ${input} input`, () => {
+        expect(deepEqual(...input)).toEqual(output);
+      });
+    });
+  });
+
+  describe('objects', () => {
+    it('should return true for equal object structure', () => {
+      const valueA = {
+        value: {
+          foo: 'bar',
+          baz: [1, 2, { quaz: { 2: 3 } }],
+        },
+      };
+
+      expect(deepEqual(valueA, cloneDeep(valueA))).toEqual(true);
+    });
+
+    it('should return false for non equal object structure', () => {
+      const valueA = {
+        value: {
+          foo: 'bar',
+          baz: [1, 2, { quaz: { 2: 3 } }],
+        },
+      };
+
+      const valueB = {
+        ...valueA,
+        value: {
+          ...valueA.value,
+          baz: [1, 2, { quaz: {} }],
+        },
+      };
+
+      expect(deepEqual(valueA, valueB)).toEqual(false);
+    });
+
+    it('should log an error if an object is too deeply nested', () => {
+      const errorSpy = jest.spyOn(console, 'error');
+      const valueA = {
+        value: {
+          value: {
+            value: {
+              value: {
+                value: {},
+              },
+            },
+          },
+        },
+      };
+
+      expect(deepEqual(valueA, cloneDeep(valueA))).toEqual(false);
+      expect(errorSpy).toHaveBeenCalledWith('Recursion limit of 5 has been exceeded.');
+      errorSpy.mockReset();
+    });
+  });
+});

--- a/packages/common/src/use-select/reducer.js
+++ b/packages/common/src/use-select/reducer.js
@@ -40,10 +40,16 @@ const reducer = (state, { type, payload, options = [], optionsTransformer }) => 
           ...payload,
         },
         options: optionsTransformer
-          ? optionsTransformer([...state.options, ...options.filter(({ value }) => !state.options.find((option) => option.value === value))])
-          : [...state.options, ...options.filter(({ value }) => !state.options.find((option) => option.value === value))],
+          ? optionsTransformer([
+              ...state.options,
+              ...options.filter(({ value }) => !state.options.find((option) => payload.compareValues(option.value, value))),
+            ])
+          : [...state.options, ...options.filter(({ value }) => !state.options.find((option) => payload.compareValues(option.value, value)))],
         ...(optionsTransformer && {
-          originalOptions: [...state.options, ...options.filter(({ value }) => !state.options.find((option) => option.value === value))],
+          originalOptions: [
+            ...state.options,
+            ...options.filter(({ value }) => !state.options.find((option) => payload.compareValues(option.value, value))),
+          ],
         }),
       };
     default:

--- a/packages/common/src/use-select/use-select.d.ts
+++ b/packages/common/src/use-select/use-select.d.ts
@@ -13,6 +13,7 @@ interface UseSelectProps {
     pluckSingleValue?: boolean;
     isMulti?: boolean;
     simpleValue?: boolean;
+    compareValues?: (value1: any, value2: any) => any;
 }
 
 interface SelectState {

--- a/packages/common/src/use-select/use-select.js
+++ b/packages/common/src/use-select/use-select.js
@@ -67,6 +67,7 @@ const useSelect = ({
   pluckSingleValue,
   isMulti,
   simpleValue,
+  compareValues,
 }) => {
   const [state, originalDispatch] = useReducer(reducer, { optionsTransformer, propsOptions }, init);
   const dispatch = (action) => originalDispatch({ ...action, optionsTransformer });
@@ -81,10 +82,12 @@ const useSelect = ({
         if (!noValueUpdates) {
           if (value && Array.isArray(value)) {
             const selectValue = value.filter((value) =>
-              typeof value === 'object' ? data.find((option) => value.value === option.value) : data.find((option) => value === option.value)
+              typeof value === 'object'
+                ? data.find((option) => compareValues(value.value, option.value))
+                : data.find((option) => compareValues(value, option.value))
             );
             onChange(selectValue.length === 0 ? undefined : selectValue);
-          } else if (value && !data.find(({ value: internalValue }) => internalValue === value)) {
+          } else if (value && !data.find(({ value: internalValue }) => compareValues(internalValue, value))) {
             onChange(undefined);
           }
         }
@@ -122,14 +125,14 @@ const useSelect = ({
 
   const onInputChange = (inputValue) => {
     if (inputValue && loadOptions && state.promises[inputValue] === undefined && isSearchable) {
-      dispatch({ type: 'setPromises', payload: { [inputValue]: true } });
+      dispatch({ type: 'setPromises', payload: { [inputValue]: true, compareValues } });
 
       loadOptions(inputValue)
         .then((options) => {
           if (isMounted.current) {
             dispatch({
               type: 'setPromises',
-              payload: { [inputValue]: false },
+              payload: { [inputValue]: false, compareValues },
               options,
             });
           }

--- a/packages/pf4-component-mapper/demo/demo-schemas/select-schema.js
+++ b/packages/pf4-component-mapper/demo/demo-schemas/select-schema.js
@@ -4,24 +4,24 @@ import componentTypes from '@data-driven-forms/react-form-renderer/component-typ
 const options = [
   {
     label: 'Morton',
-    value: 'Jenifer'
+    value: 'Jenifer',
   },
   {
     label: 'Vega',
-    value: 'Cervantes'
+    value: 'Cervantes',
   },
   {
     label: 'Gilbert',
-    value: 'Wallace'
+    value: 'Wallace',
   },
   {
     label: 'Jami',
-    value: 'Cecilia'
+    value: 'Cecilia',
   },
   {
     label: 'Ebony',
-    value: 'Kay'
-  }
+    value: 'Kay',
+  },
 ];
 
 const loadOptions = (inputValue = '') => {
@@ -37,7 +37,7 @@ const loadOptions = (inputValue = '') => {
 };
 
 const loadOptionsLong = (inputValue = '') => {
-  const options = [...Array(99)].map((_v, index) => ({ label: `${index}`, value: `${index}` }));
+  const options = [...Array(99)].map((_v, index) => ({ label: `${index}`, value: { index } }));
   return new Promise((res) =>
     setTimeout(() => {
       if (inputValue.length === 0) {
@@ -56,8 +56,12 @@ const selectSchema = {
       name: 'long-searchable-async-select',
       label: 'Long searchable async select',
       loadOptions: loadOptionsLong,
+      compareValues: (a, b) => {
+        console.log('Custom compare is beeing used.');
+        return a.value === b.value;
+      },
       isSearchable: true,
-      menuIsPortal: true
+      menuIsPortal: true,
     },
     {
       component: componentTypes.SELECT,
@@ -65,41 +69,41 @@ const selectSchema = {
       label: 'Simple portal select',
       options,
       isSearchable: true,
-      menuIsPortal: true
+      menuIsPortal: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'simple-async-select',
       label: 'Simple async select',
-      loadOptions
+      loadOptions,
     },
     {
       component: componentTypes.SELECT,
       name: 'simple-searchable-async-select',
       label: 'Simple searchable async select',
       loadOptions,
-      isSearchable: true
+      isSearchable: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'multi-async-select',
       label: 'multi async select',
       loadOptions,
-      isMulti: true
+      isMulti: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'searchable-multi-async-select',
       label: 'Multi searchable async select',
       loadOptions,
-      isSearchable: true
+      isSearchable: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'multi-simple-select',
       label: 'Simple multi select',
       options,
-      isMulti: true
+      isMulti: true,
     },
     {
       component: componentTypes.SELECT,
@@ -107,7 +111,7 @@ const selectSchema = {
       label: 'Searchable multi select',
       options,
       isMulti: true,
-      isSearchable: true
+      isSearchable: true,
     },
     {
       component: componentTypes.SELECT,
@@ -116,40 +120,40 @@ const selectSchema = {
       options,
       isMulti: true,
       isSearchable: true,
-      isClearable: true
+      isClearable: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'simple-select',
       label: 'Simple-select',
-      options
+      options,
     },
     {
       component: componentTypes.SELECT,
       name: 'disabled-select',
       label: 'Disabled-select',
       options,
-      isDisabled: true
+      isDisabled: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'clearable-select',
       label: 'Clearable-select',
       options,
-      isClearable: true
+      isClearable: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'searchable-select',
       label: 'Clearable-select',
       options,
-      isSearchable: true
+      isSearchable: true,
     },
     {
       component: componentTypes.SELECT,
       name: 'dosbaled-option-select',
       label: 'Disabled-option-select',
-      options: [...options, { label: 'Disabled option', value: 'disabled', isDisabled: true }]
+      options: [...options, { label: 'Disabled option', value: 'disabled', isDisabled: true }],
     },
     {
       component: componentTypes.SELECT,
@@ -158,13 +162,13 @@ const selectSchema = {
       options: [
         {
           label: <span>None</span>,
-          key: 'none'
+          key: 'none',
         },
         {
           label: <span>Jack</span>,
-          value: 'jack'
-        }
-      ]
+          value: 'jack',
+        },
+      ],
     },
     {
       component: componentTypes.SELECT,
@@ -174,18 +178,18 @@ const selectSchema = {
       options: [
         {
           label: <span>Jack</span>,
-          value: 'jack'
+          value: 'jack',
         },
         {
           label: <span>Mary</span>,
-          value: 'Mary'
-        }
-      ]
-    }
-  ]
+          value: 'Mary',
+        },
+      ],
+    },
+  ],
 };
 
 export default {
   ...selectSchema,
-  fields: [selectSchema.fields[0]]
+  fields: [selectSchema.fields[0]],
 };

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/select.md
@@ -4,6 +4,14 @@ import Chip from '@mui/material/Chip';
 
 This mapper component is using the common select component to provide additional features.
 
+## compareValues
+
+*(optionValueA, optionValueB) => boolean*
+
+If the option values are not primitive types, this option can be used to compare the option values to properly identify selected option(s).
+
+> **__NOTE:__** By default, the select will run a `deepEqual` compare function. This function is expensive and will only compare 5 levels of the value. To improve performance or overcome this limit define custom `compareValues` prop.
+
 ## loadOptions
 
 *(currentSearchValue: string) => Promise< Options >*

--- a/packages/react-renderer-demo/src/pages/provided-mappers/component-api.md
+++ b/packages/react-renderer-demo/src/pages/provided-mappers/component-api.md
@@ -67,6 +67,7 @@ Basic components that can change the form state (inputs) share common props. The
 |----|:--:|----------:|
 |placeholder|node/string|A placeholder|
 |options|array|Options in format of `{ label: 'Label', value: value }`|
+|compareValues|`func`|A custom function to compare select options `(valueA, valueB) => boolean`|
 |loadOptions|function|A function for loading a options asynchronously|
 |loadingMessage|node/string|A message which will shown as a placeholder during the loading|
 |simpleValue|boolean|Simple value (no isMulti)|


### PR DESCRIPTION
Fixes #1401

**Description**


**Schema** *(if applicable)*

```jsx
const loadOptions = (searchValue = '') => {
  return getGroups({ name: searchValue }).then((data) => {
    return data.results.map(({ name, id }) => ({
      label: name,
      value: { id, name },
    }));
  });
};

const exampleSchema = (hosts) => ({
  fields: [
    {
      component: 'select',
      name: 'group',
      label: 'Select a group',
      simpleValue: true,
      isSearchable: true, // enables typeahead
      isRequired: true,
      isClearable: true,
      placeholder: 'Type or click to select a group',
      loadOptions,
      options: [],
      validate: [{ type: validatorTypes.REQUIRED }],
    }
  ],
});
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [x] Test coverage for new code *(if applicable)*
- [x] Documentation update *(if applicable)*
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
