### PR TITLE
fix(pf4): fix bug in wizard navigation toolbar

### DIFF
--- a/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-nav.js
@@ -24,7 +24,7 @@ const WizardNavigationInternal = React.memo(
     <WizardNav>
       {navSchema
         .filter((field) => field.primary)
-        .map((step, ind) => {
+        .map((step) => {
           const substeps = step.substepOf && navSchema.filter((field) => field.substepOf === step.substepOf);
 
           const isValid = valid && !validating;
@@ -37,7 +37,7 @@ const WizardNavigationInternal = React.memo(
               isDisabled={isValid ? maxStepIndex < step.index : step.index > activeStepIndex}
               onClick={(e) => {
                 e.preventDefault();
-                jumpToStep(ind, isValid);
+                jumpToStep(step.index, isValid);
               }}
               step={step.index}
               type="button"


### PR DESCRIPTION
In Patternfly 4, the WizardNavItem component `step` prop is "the step passed into the onNavItemClick callback".

http://v4-archive.patternfly.org/v4/components/wizard#wizardnavitem

In Patternfly 5, onNavItemClick no longer exists. Instead, there is an onClick callback which expects the index of the step to be navigated to.

https://www.patternfly.org/components/wizard/#wizardnavitem

However, filtering the navSchema like so: `.filter((field) =>
field.primary)` results in substeps with field.primary===false being dropped. Practically, this means the 2nd substep and those following it. Therefore, the index provided by `.map((step, ind) => ...` is incorrect.

The correct index can still be found from `step.index`.

We first encountered a bug related to this while upgrading our app to PF5, see the PR here:
https://github.com/RedHatInsights/image-builder-frontend/pull/1365#issuecomment-1757841805