### PR TITLE
fix(pf): bug in wizard navbar

### DIFF
--- a/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-nav.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-nav.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 
-import { WizardNavItem, WizardNav } from '@patternfly/react-core';
+import { WizardNav, WizardNavItem } from '@patternfly/react-core';
 
 import isEqual from 'lodash/isEqual';
 import get from 'lodash/get';
@@ -21,7 +21,7 @@ const memoValues = (initialValue) => {
 
 const WizardNavigationInternal = React.memo(
   ({ navSchema, activeStepIndex, maxStepIndex, jumpToStep, valid, validating }) => (
-    <WizardNav>
+    <Fragment>
       {navSchema
         .filter((field) => field.primary)
         .map((step) => {
@@ -63,7 +63,7 @@ const WizardNavigationInternal = React.memo(
             </WizardNavItem>
           );
         })}
-    </WizardNav>
+    </Fragment>
   ),
   isEqual
 );


### PR DESCRIPTION
In the Image Builder wizard we are no longer seeing step numbers with the pf5 upgrade.

The wizard navigation should only contain one WizardNav component. Wrapping the WizardNavItems in two WizardNav components is causing all steps to be treated as substeps and therefore don't have step numbers. The fix is to remove one of the WizardNav wrappers.

The other WizardNav component is here: https://github.com/data-driven-forms/react-forms/blob/baaf60020a972b51d01ef7722cb91ab66297dc98/packages/pf4-component-mapper/src/wizard/wizard.js#L129

And here is a screenshot of the issue.

<img width="379" alt="Screenshot 2023-10-23 at 16 17 43" src="https://github.com/data-driven-forms/react-forms/assets/11712857/bdfc2864-f1fb-4b54-88f5-5956fce1ce44">
