### PR TITLE
fix(renderer): pass field property to when in sequence and not

### DIFF
--- a/packages/react-form-renderer/src/parse-condition/parse-condition.js
+++ b/packages/react-form-renderer/src/parse-condition/parse-condition.js
@@ -71,7 +71,7 @@ export const parseCondition = (condition, values, field) => {
   if (condition.sequence) {
     return condition.sequence.reduce(
       (acc, curr) => {
-        const result = parseCondition(curr, values);
+        const result = parseCondition(curr, values, field);
 
         return {
           sets: [...acc.sets, ...(result.set ? [result.set] : [])],
@@ -90,7 +90,7 @@ export const parseCondition = (condition, values, field) => {
   }
 
   if (condition.not) {
-    return !parseCondition(condition.not, values).result ? positiveResult : negativeResult;
+    return !parseCondition(condition.not, values, field).result ? positiveResult : negativeResult;
   }
 
   const finalWhen = typeof condition.when === 'function' ? condition.when(field) : condition.when;

--- a/packages/react-form-renderer/src/tests/form-renderer/parse-condition.test.js
+++ b/packages/react-form-renderer/src/tests/form-renderer/parse-condition.test.js
@@ -542,6 +542,46 @@ describe('parseCondition', () => {
       expect(whenSpyX).toHaveBeenCalledWith(field);
       expect(whenSpyY).toHaveBeenCalledWith(field);
     });
+
+    it('when is function in sequence', () => {
+      const whenSpy = jest.fn().mockImplementation(() => 'x');
+
+      condition = {
+        sequence: [
+          {
+            when: whenSpy,
+            is: 'yes',
+          },
+        ],
+      };
+
+      values = {
+        x: 'yes',
+      };
+
+      expect(parseCondition(condition, values, field)).toEqual({ ...positiveResult, sets: [] });
+      expect(whenSpy).toHaveBeenCalledWith(field);
+    });
+
+    it('when is function in not', () => {
+      const whenSpy = jest.fn().mockImplementation(() => 'x');
+
+      condition = {
+        not: [
+          {
+            when: whenSpy,
+            is: 'yes',
+          },
+        ],
+      };
+
+      values = {
+        x: 'yes',
+      };
+
+      expect(parseCondition(condition, values, field)).toEqual(negativeResult);
+      expect(whenSpy).toHaveBeenCalledWith(field);
+    });
   });
 
   it('simple condition - custom function', () => {


### PR DESCRIPTION
Fixes #1422

**Description**

`field` is not passed to inner sequence and not conditions