### PR TITLE
Prevent isFetching bug in useSelect

### DIFF
--- a/packages/common/src/use-select/reducer.js
+++ b/packages/common/src/use-select/reducer.js
@@ -32,7 +32,10 @@ const reducer = (state, { type, payload, options = [], optionsTransformer }) => 
         ...state,
         isInitialLoaded: true,
       };
-    case 'setPromises':
+    case 'setPromises': {
+      const compareValues = payload.compareValues;
+      delete payload.compareValues;
+
       return {
         ...state,
         promises: {
@@ -42,16 +45,15 @@ const reducer = (state, { type, payload, options = [], optionsTransformer }) => 
         options: optionsTransformer
           ? optionsTransformer([
               ...state.options,
-              ...options.filter(({ value }) => !state.options.find((option) => payload.compareValues(option.value, value))),
+              ...options.filter(({ value }) => !state.options.find((option) => compareValues(option.value, value))),
             ])
-          : [...state.options, ...options.filter(({ value }) => !state.options.find((option) => payload.compareValues(option.value, value)))],
+          : [...state.options, ...options.filter(({ value }) => !state.options.find((option) => compareValues(option.value, value)))],
         ...(optionsTransformer && {
-          originalOptions: [
-            ...state.options,
-            ...options.filter(({ value }) => !state.options.find((option) => payload.compareValues(option.value, value))),
-          ],
+          originalOptions: [...state.options, ...options.filter(({ value }) => !state.options.find((option) => compareValues(option.value, value)))],
         }),
       };
+    }
+
     default:
       return state;
   }


### PR DESCRIPTION
Related to #1448


**Description**

When using searchable select with loadoOptions, the spinner persists after the promises have resolved. 

The cause was [this line](https://github.com/data-driven-forms/react-forms/blob/271e46673cdbec5cdcb6e0b449bb7381e1aa5a30/packages/common/src/use-select/use-select.js#L158) returning true because there was an extra `compareValues` function in the reducer payloads.

I saved that function to another variable and removed it from the payload.

**Schema** *(if applicable)*

```jsx
     {
              component: 'select',
              label: 'Select',
              name: 'select',
              options: [],
              isSearchable: true,
              loadOptions: () =>
                new Promise((res) =>
                  setTimeout(
                    () =>
                      res([
                        { value: 'first-option', label: 'First async option' },
                        { value: 'second-option', label: 'Second async option' },
                      ]),
                    2500
                  )
                ),
            },
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [ x] `Yarn build` passes
- [ x] `Yarn lint` passes
- [ x] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [ ] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
