### PR TITLE
feat(mui5):introducing isFilterCaseInSensitive prop for dual-list-select filterOption

### DIFF
--- a/packages/blueprint-component-mapper/src/dual-list-select/dual-list-select.d.ts
+++ b/packages/blueprint-component-mapper/src/dual-list-select/dual-list-select.d.ts
@@ -26,6 +26,7 @@ interface InternalDualListSelectProps {
   filterOptionsText?: ReactNode;
   leftValues?: DualListSelectValue[];
   rightValues?: DualListSelectValue[];
+  isFilterCaseInSensitive?: boolean;
   WrapperProps?: React.HTMLProps<HTMLDivElement>;
   LeftWrapperProps?: React.HTMLProps<HTMLDivElement>;
   RightWrapperProps?: React.HTMLProps<HTMLDivElement>;

--- a/packages/blueprint-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/blueprint-component-mapper/src/dual-list-select/dual-list-select.js
@@ -263,6 +263,7 @@ DualListInternal.propTypes = {
   filterValues: PropTypes.func,
   rightValues: PropTypes.array,
   handleValuesClick: PropTypes.func,
+  isFilterCaseInSensitive: PropTypes.bool,
   WrapperProps: PropTypes.object,
   LeftWrapperProps: PropTypes.object,
   RightWrapperProps: PropTypes.object,

--- a/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.d.ts
+++ b/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.d.ts
@@ -44,6 +44,7 @@ interface InternalDualListSelectProps {
   sortValuesTitle?: string;
   filterOptionsText?: ReactNode;
   filterValueText?: ReactNode;
+  isFilterCaseInSensitive?: boolean;
   FormGroupProps?: CarbonFormGroups;
   GridProps?: GridDefaultProps;
   RowProps?: RowDefaultProps;

--- a/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/carbon-component-mapper/src/dual-list-select/dual-list-select.js
@@ -304,6 +304,7 @@ DualListSelectInner.propTypes = {
   sortValuesTitle: PropTypes.string,
   filterOptionsText: PropTypes.node,
   filterValueText: PropTypes.node,
+  isFilterCaseInSensitive: PropTypes.bool,
   FormGroupProps: PropTypes.object,
   GridProps: PropTypes.object,
   RowProps: PropTypes.object,

--- a/packages/common/src/dual-list-select/dual-list-select.js
+++ b/packages/common/src/dual-list-select/dual-list-select.js
@@ -39,10 +39,20 @@ const DualListSelectCommon = (props) => {
   });
 
   const leftValues = rest.options
-    .filter((option) => !rest.input.value.includes(option.value) && option.label.includes(state.filterOptions))
+    .filter((option) => {
+      if(!props.isFilterCaseInSensitive)
+        return !rest.input.value.includes(option.value) && option.label.includes(state.filterOptions);
+      else
+        return !rest.input.value.includes(option.value) && option.label.toLowerCase().includes(state.filterOptions.toLowerCase());
+    })
     .sort((a, b) => (state.sortLeftDesc ? a.label.localeCompare(b.label) : b.label.localeCompare(a.label)));
   const rightValues = rest.options
-    .filter((option) => rest.input.value.includes(option.value) && option.label.includes(state.filterValue))
+    .filter((option) => {
+      if(!props.isFilterCaseInSensitive)
+        return rest.input.value.includes(option.value) && option.label.includes(state.filterValue);
+      else
+        return rest.input.value.includes(option.value) && option.label.toLowerCase().includes(state.filterValue.toLowerCase());
+    })
     .sort((a, b) => (state.sortRightDesc ? a.label.localeCompare(b.label) : b.label.localeCompare(a.label)));
 
   const handleOptionsClick = (event, value) => handleOptionClick(event, value, leftValues, true, dispatch, state);

--- a/packages/common/src/dual-list-select/dual-list-select.js
+++ b/packages/common/src/dual-list-select/dual-list-select.js
@@ -40,20 +40,18 @@ const DualListSelectCommon = (props) => {
 
   const leftValues = rest.options
     .filter((option) => {
-      if (!props.isFilterCaseInSensitive){
+      if (!props.isFilterCaseInSensitive) {
         return !rest.input.value.includes(option.value) && option.label.includes(state.filterOptions);
-      }
-      else{
+      } else {
         return !rest.input.value.includes(option.value) && option.label.toLowerCase().includes(state.filterOptions.toLowerCase());
       }
     })
     .sort((a, b) => (state.sortLeftDesc ? a.label.localeCompare(b.label) : b.label.localeCompare(a.label)));
   const rightValues = rest.options
     .filter((option) => {
-      if (!props.isFilterCaseInSensitive){
+      if (!props.isFilterCaseInSensitive) {
         return rest.input.value.includes(option.value) && option.label.includes(state.filterValue);
-      }
-      else{
+      } else {
         return rest.input.value.includes(option.value) && option.label.toLowerCase().includes(state.filterValue.toLowerCase());
       }
     })

--- a/packages/common/src/dual-list-select/dual-list-select.js
+++ b/packages/common/src/dual-list-select/dual-list-select.js
@@ -40,18 +40,22 @@ const DualListSelectCommon = (props) => {
 
   const leftValues = rest.options
     .filter((option) => {
-      if(!props.isFilterCaseInSensitive)
+      if (!props.isFilterCaseInSensitive){
         return !rest.input.value.includes(option.value) && option.label.includes(state.filterOptions);
-      else
+      }
+      else{
         return !rest.input.value.includes(option.value) && option.label.toLowerCase().includes(state.filterOptions.toLowerCase());
+      }
     })
     .sort((a, b) => (state.sortLeftDesc ? a.label.localeCompare(b.label) : b.label.localeCompare(a.label)));
   const rightValues = rest.options
     .filter((option) => {
-      if(!props.isFilterCaseInSensitive)
+      if (!props.isFilterCaseInSensitive){
         return rest.input.value.includes(option.value) && option.label.includes(state.filterValue);
-      else
+      }
+      else{
         return rest.input.value.includes(option.value) && option.label.toLowerCase().includes(state.filterValue.toLowerCase());
+      }
     })
     .sort((a, b) => (state.sortRightDesc ? a.label.localeCompare(b.label) : b.label.localeCompare(a.label)));
 

--- a/packages/mui-component-mapper/src/dual-list-select/dual-list-select.d.ts
+++ b/packages/mui-component-mapper/src/dual-list-select/dual-list-select.d.ts
@@ -48,6 +48,7 @@ interface InternalDualListSelectProps {
   id?: string;
   leftValues?: DualListOption[];
   rightValues?: DualListOption[];
+  isFilterCaseInSensitive?: boolean;
   FormFieldGridProps?: GridProps;
   InternalGridProps?: GridProps;
   ListGridProps?: GridProps;

--- a/packages/mui-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/mui-component-mapper/src/dual-list-select/dual-list-select.js
@@ -555,6 +555,7 @@ DualListSelect.propTypes = {
   rightValues: PropTypes.array,
   handleValuesClick: PropTypes.func,
   isFilterable: PropTypes.bool,
+  isFilterCaseInSensitive: PropTypes.bool,
   // props
   FormFieldGridProps: PropTypes.object,
   InternalGridProps: PropTypes.object,

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/blueprint/dual-list-select.md
@@ -23,6 +23,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |filterOptionsText|String|'Remove your filter to see all options'|Placeholder for options when there is no filtered option|
 |leftSortTitle|String|'Sort options'|Accessible title for left sort button.|
 |rightSortTitle|String|'Sort value'|Accessible title for right sort button.|
+|isFilterCaseInSensitive|bool|true|Toolbar filter is case insensitive|
 
 ### Options
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/carbon/dual-list-select.md
@@ -19,6 +19,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |filterValueTitle|String|'Filter selected value'|Placeholder for value filter input|
 |filterValueText|String|'Remove your filter to see all selected'|Placeholder for value when there is no filtered value|
 |filterOptionsText|String|'Remove your filter to see all options'|Placeholder for options when there is no filtered option|
+|isFilterCaseInSensitive|bool|true|Toolbar filter is case insensitive|
 
 ### Options
 

--- a/packages/react-renderer-demo/src/doc-components/examples-texts/mui/dual-list-select.md
+++ b/packages/react-renderer-demo/src/doc-components/examples-texts/mui/dual-list-select.md
@@ -23,6 +23,7 @@ Dual list select is wrapped in a form group, so it accepts all [form group props
 |filterOptionsText|String|'Remove your filter to see all options'|Placeholder for options when there is no filtered option|
 |checkboxVariant|bool|false|Change list item to checkboxes|
 |isFilterable|bool|true|Shows toolbar for both lists|
+|isFilterCaseInSensitive|bool|true|Toolbar filter is case insensitive|
 
 ### Options
 

--- a/packages/suir-component-mapper/src/dual-list-select/dual-list-select.d.ts
+++ b/packages/suir-component-mapper/src/dual-list-select/dual-list-select.d.ts
@@ -29,6 +29,7 @@ interface InternalDualListSelectProps {
   filterOptionsText?: ReactNode;
   leftValues?: DualListSelectOption[];
   rightValues?: DualListSelectOption[];
+  isFilterCaseInSensitive?: boolean;
   /** Sub components customization API */
   OptionsListProps?: SegmentProps;
   OptionProps?: DualListSelectOptionProps;

--- a/packages/suir-component-mapper/src/dual-list-select/dual-list-select.js
+++ b/packages/suir-component-mapper/src/dual-list-select/dual-list-select.js
@@ -362,6 +362,7 @@ DualList.propTypes = {
   validateOnMount: PropTypes.bool,
   leftSortTitle: PropTypes.node,
   rightSortTitle: PropTypes.node,
+  isFilterCaseInSensitive: PropTypes.bool,
   /** Sub components customization API */
   OptionsListProps: PropTypes.object,
   OptionProps: PropTypes.object,


### PR DESCRIPTION
**Description**

Please include a summary of the change.
introducing isFilterCaseInSensitive prop for dual-list-select filterOption.
isFilterCaseInSensitive : false  -> Filtering would be Case sensitive, CaTs would not match with cats.
isFilterCaseInSensitive : true -> Filtering would not be Case sensitive, CaTs would match with cats.
**Schema** *(if applicable)*
export default {
    "fields": [
      {
        "component": "customDualList",
        "name": "MUI",
        "isFilterCaseInSensitive":true,
        "options": [
          {
            "value": "cats",
            "label": "cats"
          },
          {
            "value": "cats_1",
            "label": "cats_1"
          },
          {
            "value": "cats_2",
            "label": "cats_2"
          },
          {
            "value": "zebras",
            "label": "zebras"
          },
          {
            "value": "pigeons",
            "label": "pigeons"
          }
        ]
      }
    ]
  };
```jsx
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [x] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
