### PR TITLE
fix(mui): added initialValue to the list of excluded props

### DIFF
--- a/packages/mui-component-mapper/src/multiple-choice-list/multiple-choice-list.js
+++ b/packages/mui-component-mapper/src/multiple-choice-list/multiple-choice-list.js
@@ -12,7 +12,7 @@ const FinalCheckbox = ({ label, isDisabled: _isDisabled, ...rest }) => {
   const {
     FormControlLabelProps,
     CheckboxProps,
-    props: { isRequired, isReadOnly, helperText, validate, isDisabled, component, ...props },
+    props: { initialValue, isRequired, isReadOnly, helperText, validate, isDisabled, component, ...props },
   } = useContext(CheckboxContext);
   return (
     <FormControlLabel


### PR DESCRIPTION
**Description**

On `multiselect` `initialValue` was passed to the span element resulting in console errors.

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [✅] `Yarn build` passes
- [✅] `Yarn lint` passes
- [✅] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [✅] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
