### PR TITLE
fix(pf4): Use PF5 name for WizardBody no padding

### DIFF
--- a/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-step.js
+++ b/packages/pf4-component-mapper/src/wizard/wizard-components/wizard-step.js
@@ -61,7 +61,7 @@ const WizardStep = ({
 
   return (
     <Fragment>
-      <WizardBody hasNoBodyPadding={hasNoBodyPadding}>
+      <WizardBody hasNoPadding={hasNoBodyPadding}>
         <StepTemplate
           formFields={fields.map((item) => formOptions.renderForm([item], formOptions))}
           name={name}


### PR DESCRIPTION
**Description**

In the new PF5 wizard, the prop to disable body padding is called `hasNoPadding` rather than `hasNoBodyPadding`.

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [x] `Yarn build` passes
- [x] `Yarn lint` passes
- [x] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [x] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
