### PR TITLE
fix(renderer): prevent key from being spread via props

### DIFF
--- a/packages/react-form-renderer/src/form-renderer/render-form.tsx
+++ b/packages/react-form-renderer/src/form-renderer/render-form.tsx
@@ -127,7 +127,14 @@ const SingleField: React.FC<SingleFieldProps> = ({ component, ...rest }) => {
   );
 };
 
-const renderForm = (fields: FieldType[]): ReactNode[] =>
-  fields.map((field) => (Array.isArray(field) ? renderForm(field) : <SingleField key={field.name} {...field} />));
+const renderForm = (fields: FieldType[]): ReactNode[] => fields.map((field) => {
+  if (Array.isArray(field)) {
+    return renderForm(field);
+  }
+
+  const { key, ...otherFields } = field;
+  return <SingleField key={key || field.name} {...otherFields} />;
+});
+
 
 export default renderForm;


### PR DESCRIPTION
**Description**
When the schema contains a key field, it gets spread into the `SingleField` component, and triggers "key being spread" warning (React 18.3.0+ change: https://github.com/react/react/releases/tag/v18.3.0) - we rely on dynamic key values to force the component to re-render

Note: this only happens when Babel compiles JSX using the modern `_jsx` or `_jsxDEV` runtime (i.e., with `runtime: 'automatic'`), React emits the following runtime warning:
"Warning: A props object containing a 'key' prop is being spread into JSX."

**Before:**
<img width="3250" height="614" alt="image" src="https://github.com/user-attachments/assets/6e97dcf7-ac97-47a1-94f6-27b5c39dae27" />

**After:**
<img width="3174" height="456" alt="image" src="https://github.com/user-attachments/assets/7917175e-2c86-4760-b2b9-719eb55f1d2f" />



Please include a summary of the change.

**Schema** *(if applicable)*

```jsx
{
  fields: [
    {
      component: 'text-field',
      name: 'field1',
      label: 'Field 1 (no key)',
    },
    {
      component: 'text-field',
      name: 'field2',
      label: 'Field 2 (HAS KEY PROPERTY)',
      key: 'my-custom-key-123',
    },
  ],
};
```

**Checklist:** *(please see [documentation page](https://data-driven-forms.org/development-setup) for more information)*

- [ ] `Yarn build` passes
- [ ] `Yarn lint` passes
- [ ] `Yarn test` passes
- [ ] Test coverage for new code *(if applicable)*
- [ ] Documentation update *(if applicable)*
- [ ] Correct commit message
   - format `fix|feat({scope}): {description}`
   - i.e. `fix(pf3): wizard correctly handles next button`
   - fix will release a new \_.\_.X version
   - feat will release a new \_.X.\_ version (use when you introduce new features)
     - we want to avoid any breaking changes, please contact us, if there is no way how to avoid them
   - scope: package
   - if you update the documentation or tests, do not use this format
     - i.e. `Fix button on documenation example page`
