### PR TITLE
fix(ci): switch release checkout from SSH key to PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.BOT_SSH_KEY }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Replace `ssh-key: ${{ secrets.BOT_SSH_KEY }}` with `token: ${{ secrets.RELEASE_TOKEN }}` in the release workflow checkout step
- The SSH deploy key was revoked, causing the release job to fail with `Permission denied (publickey)`
- The `RELEASE_TOKEN` PAT is already configured and used later in the workflow for `GITHUB_TOKEN`, so no new secrets are needed

## Context
- Failed run: https://github.com/data-driven-forms/react-forms/actions/runs/28578161904/job/84731628182
- This approach matches how other projects (e.g. RedHatInsights/frontend-components) handle release authentication

## Test plan
- [ ] Verify `RELEASE_TOKEN` secret has `contents: write` permission on this repo
- [ ] Merge and confirm the release workflow succeeds on next push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)